### PR TITLE
add  option to not load 3d smoke/hrrpuv files when values are below a specified cutoff value

### DIFF
--- a/Source/smokeview/IOsmoke.c
+++ b/Source/smokeview/IOsmoke.c
@@ -647,11 +647,15 @@ void readsmoke3d(int ifile,int flag, int *errorcode){
     if(smoke3di->type == FIRE&&smoke3di->maxval<=load_hrrpuv_cutoff){
       readsmoke3d(ifile,UNLOAD,&error);
       *errorcode=0;
+      PRINTF("*** HRRPUV file: %s skipped\n",smoke3di->file);
+      PRINTF("    maximum HRRPUV %f<=%f in mesh %s\n", smoke3di->maxval,load_hrrpuv_cutoff,meshi->label);
       return;
     }
     if(smoke3di->type == SOOT&&smoke3di->maxval<=load_3dsmoke_cutoff){
       readsmoke3d(ifile,UNLOAD,&error);
       *errorcode=0;
+      PRINTF("*** Soot file: %s skipped\n",smoke3di->file);
+      PRINTF("    maximum soot opacity %f<=%f in  mesh %s\n", smoke3di->maxval,load_3dsmoke_cutoff, meshi->label);
       return;
     }
   }

--- a/Source/smokeview/IOsmoke.c
+++ b/Source/smokeview/IOsmoke.c
@@ -644,12 +644,12 @@ void readsmoke3d(int ifile,int flag, int *errorcode){
     return;
   }
   if(smoke3di->maxval>=0.0){
-    if(load_hrrpuv_cutoff<=smoke3di->maxval&&smoke3di->type==FIRE){
+    if(smoke3di->type == FIRE&&smoke3di->maxval<=load_hrrpuv_cutoff){
       readsmoke3d(ifile,UNLOAD,&error);
       *errorcode=0;
       return;
     }
-    if(load_3dsmoke_cutoff<=smoke3di->maxval&&smoke3di->type==SOOT){
+    if(smoke3di->type == SOOT&&smoke3di->maxval<=load_3dsmoke_cutoff){
       readsmoke3d(ifile,UNLOAD,&error);
       *errorcode=0;
       return;

--- a/Source/smokeview/flowfiles.h
+++ b/Source/smokeview/flowfiles.h
@@ -1291,6 +1291,7 @@ typedef struct _smoke3ddata {
 
   int ncomp_smoke_total;
   int *nchars_compressed_smoke, *nchars_compressed_smoke_full;
+  float maxval;
   unsigned char *smokeframe_in, *lightframe_in, *smokeframe_out, **smokeframe_comp_list;
   unsigned char *smokeview_tmp;
   unsigned char *smoke_comp_all;

--- a/Source/smokeview/glui_3dsmoke.cpp
+++ b/Source/smokeview/glui_3dsmoke.cpp
@@ -120,6 +120,8 @@ GLUI_Spinner *SPINNER_smoke3d_smoke_blue = NULL;
 GLUI_Spinner *SPINNER_extinct = NULL;
 GLUI_Spinner *SPINNER_smokedens=NULL;
 GLUI_Spinner *SPINNER_pathlength=NULL;
+GLUI_Spinner *SPINNER_load_3dsmoke = NULL;
+GLUI_Spinner *SPINNER_load_hrrpuv = NULL;
 
 GLUI_Checkbox *CHECKBOX_combine_meshes=NULL;
 #ifdef pp_CULL
@@ -144,6 +146,7 @@ GLUI_Panel *PANEL_absorption=NULL,*PANEL_smokesensor=NULL;
 GLUI_Panel *PANEL_testsmoke=NULL;
 GLUI_Panel *PANEL_color = NULL;
 GLUI_Panel *PANEL_smoke = NULL;
+GLUI_Panel *PANEL_loadcutoff = NULL;
 
 GLUI_Rollout *ROLLOUT_colormap3 = NULL;
 GLUI_Rollout *ROLLOUT_colormap4 = NULL;
@@ -439,6 +442,13 @@ extern "C" void glui_3dsmoke_setup(int main_window){
   Smoke3d_CB(TEMP_MIN);
   Smoke3d_CB(TEMP_CUTOFF);
   Smoke3d_CB(TEMP_MAX);
+
+  PANEL_loadcutoff = glui_3dsmoke->add_panel_to_panel(PANEL_overall, _d("Load 3D smoke/HRRPUV when..."));
+  SPINNER_load_3dsmoke = glui_3dsmoke->add_spinner_to_panel(PANEL_loadcutoff,_d("soot alpha>"),GLUI_SPINNER_FLOAT,&load_3dsmoke_cutoff);
+  SPINNER_load_3dsmoke->set_float_limits(0.0, 255.0);
+  SPINNER_load_hrrpuv = glui_3dsmoke->add_spinner_to_panel(PANEL_loadcutoff,_d("HRRPUV>"),GLUI_SPINNER_FLOAT,&load_hrrpuv_cutoff);
+  SPINNER_load_hrrpuv->set_float_limits(0.0, HRRPUV_CUTOFF_MAX);
+
 
   if(nsmoke3dinfo>0){
     PANEL_meshvis = glui_3dsmoke->add_rollout_to_panel(PANEL_overall,"Mesh Visibility",false);

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -5064,6 +5064,7 @@ int ReadSMV(char *file, char *file2){
         smoke3di->use_smokeframe=NULL;
         smoke3di->nchars_compressed_smoke=NULL;
         smoke3di->nchars_compressed_smoke_full=NULL;
+        smoke3di->maxval = -1.0;
         smoke3di->frame_all_zeros=NULL;
 
         smoke3di->display=0;
@@ -9720,6 +9721,11 @@ int ReadINI2(char *inifile, int localfile){
       slicezipskip = slicezipstep - 1;
       continue;
     }
+    if(Match(buffer, "SMOKE3DCUTOFFS") == 1){
+      fgets(buffer, 255, stream);
+      sscanf(buffer, "%f %f", &load_3dsmoke_cutoff, &load_hrrpuv_cutoff);
+      continue;
+    }
     if(Match(buffer, "ISOZIPSTEP") == 1){
       fgets(buffer, 255, stream);
       sscanf(buffer, "%i", &isozipstep);
@@ -12178,6 +12184,8 @@ void WriteINI(int flag,char *filename){
   fprintf(fileout, " %i %f %i\n", slice_average_flag, slice_average_interval, vis_slice_average);
   fprintf(fileout, "SLICEDATAOUT\n");
   fprintf(fileout, " %i \n", output_slicedata);
+  fprintf(fileout, "SMOKE3DCUTOFFS\n");
+  fprintf(fileout, " %f %f\n", load_3dsmoke_cutoff, load_hrrpuv_cutoff);
   fprintf(fileout, "SLICEZIPSTEP\n");
   fprintf(fileout, " %i\n", slicezipstep);
   fprintf(fileout, "SMOKE3DZIPSTEP\n");

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -823,12 +823,6 @@ EXTERNCPP void readvslice(int ivslice, int flag, int *errorcode);
 EXTERNCPP void freesmoke3d(smoke3ddata *smoke3di);
 EXTERNCPP void readsmoke(int ifile,int flag, int *errorcode);
 EXTERNCPP void readsmoke3d(int ifile,int flag, int *errorcode);
-EXTERNCPP int getsmoke3d_sizes(int skip, char *smokefile, int version,
-                      float **timelist, int **use_smokeframe,
-                      int *nchars_uncompressed,
-                      int **nchars_compressed,
-                      int **nchars_compressed_full,
-                      int *nframes, int *nframes_full,int *have_light);
 EXTERNCPP void readfed(int ifile, int flag, int file_type, int *errorcode);
 EXTERNCPP void readslice(char *file, int ifile, int flag, int set_slicecolor, int *errorcode);
 EXTERNCPP void readiso(const char *file, int ifile, int flag, int *geom_frame_index, int *errorcode);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -20,6 +20,7 @@
 #include "smokeheaders.h"
 #include "threader.h"
 
+SVEXTERN float SVDECL(load_3dsmoke_cutoff, 0.0), SVDECL(load_hrrpuv_cutoff,0.0);
 SVEXTERN int SVDECL(visCompartments, 1);
 SVEXTERN int render_mode, render_times;
 SVEXTERN int SVDECL(render_from_menu, 0);


### PR DESCRIPTION
cut off values default to 0.0. Other values can be specified using the 3d smoke dialog box  .
This option is implemented for both 3d smoke and HRRPUV files.  For 3d smoke the cut off values are specified in terms of a smokeview alpha (related to opacity) alpha=0 is completely transparent, alpha=255 completely opaque.  This pull request has passed smokebot.  

