### PR TITLE
smokeview source: correction to code that reads 3d smoke/hrrpuv size files (handling max values in a 3d smoke  data frame)

### DIFF
--- a/Source/smokeview/IOsmoke.c
+++ b/Source/smokeview/IOsmoke.c
@@ -481,7 +481,7 @@ int getsmoke3d_sizes(int fortran_skip, char *smokefile, int version, float **tim
   ntimes_full2 = 0;
   time_max = -1000000.0;
   iii = 0;
-  *maxval = 0.0;
+  *maxval = -1.0;
   while(!feof(SMOKE_SIZE)){
     float maxvali;
 


### PR DESCRIPTION
this pull request make the recent changes to 3d smoke/hrrpuv sizing code compatible with previous versions of FDS