### PR TITLE
fixes problem with smokeview script keyword SETTIMEVAL

### DIFF
--- a/Source/smokeview/IOscript.c
+++ b/Source/smokeview/IOscript.c
@@ -1803,7 +1803,7 @@ void script_settimeval(scriptdata *scripti){
     if(timeval>global_times[nglobal_times-1]-0.0001){
       float dt;
 
-      dt = timeval-global_times[nglobal_times-1]-0.0001;
+      dt = timeval-(global_times[nglobal_times-1]-0.0001);
       if(nglobal_times>1&&dt>global_times[1]-global_times[0]){
         fprintf(stderr,"*** Error: data not available at time requested\n");
         fprintf(stderr,"           time: %f s, min time: %f, max time: %f s\n",
@@ -1815,7 +1815,7 @@ void script_settimeval(scriptdata *scripti){
     }
     valmin=ABS(global_times[0]-timeval);
     imin=0;
-    for(i=1;i<nglobal_times-1;i++){
+    for(i=1;i<nglobal_times;i++){
       float val;
 
       val = ABS(global_times[i]-timeval);

--- a/Source/smokeview/glui_bounds.cpp
+++ b/Source/smokeview/glui_bounds.cpp
@@ -2813,7 +2813,7 @@ extern "C" void Slice_CB(int var){
           Part_CB(SETVALMAX);
           Part_CB(FILERELOAD);
         }
-        
+
         // plot3d files
 
         if(nplot3dloaded>0){

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -4,7 +4,7 @@
 
 #define pp_release
 
-//*** uncomment the following two lines to force all versions to be beta
+//*** uncomment the following two lines to force all versions to be beta 
 //#undef pp_BETA
 //#define pp_BETA
 


### PR DESCRIPTION
this pull request fixes problem reported in issue 4385.  smokeview was searching all frames except the last one when determining which frame matched a given time

