### PR TITLE
smokeview source: use PRINTF instead of fprintf(stderr when outputtin…

### DIFF
--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -343,7 +343,7 @@ int setup_case(int argc, char **argv){
   // intialise info header
   initialiseInfoHeader(&titleinfo, release_title, smv_githash, fds_githash,
                        chidfilebase);
-  fprintf(stderr, "initialised titlea: %s\n", titleinfo.titleline);
+  PRINTF("initialised titlea: %s\n", titleinfo.titleline);
   return 0;
 }
 


### PR DESCRIPTION
…g infoheader info