### PR TITLE
corrections to smokeview scripts that generate figures for geom_notes

### DIFF
--- a/Verification/Immersed_Boundary_Method/geom_arch.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_arch.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 RENDERONCE

--- a/Verification/Immersed_Boundary_Method/geom_azim.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_azim.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 XSCENECLIP
  0 -1.002000 0 1.002000
 YSCENECLIP

--- a/Verification/Immersed_Boundary_Method/geom_elev.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_elev.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETTIMEVAL

--- a/Verification/Immersed_Boundary_Method/geom_obst.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_obst.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 RENDERONCE

--- a/Verification/Immersed_Boundary_Method/geom_scale.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_scale.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 XSCENECLIP
  0 -1.002000 0 1.002000
 YSCENECLIP

--- a/Verification/Immersed_Boundary_Method/geom_simple.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_simple.ssf
@@ -1,4 +1,4 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 RENDERONCE
  geom_simple

--- a/Verification/Immersed_Boundary_Method/geom_slice.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_slice.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 XSCENECLIP
  0 -0.001600 0 1.601600
 YSCENECLIP

--- a/Verification/Immersed_Boundary_Method/geom_sphere1a.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere1a.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere1b.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere1b.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere1c.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere1c.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere1d.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere1d.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere1e.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere1e.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere1f.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere1f.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere2.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere2.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 RENDERCLIP
  1 10 10 450 410
 SETTIMEVAL

--- a/Verification/Immersed_Boundary_Method/geom_sphere2_fire.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere2_fire.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 XSCENECLIP
  0 -2.004000 0 2.004000
 YSCENECLIP

--- a/Verification/Immersed_Boundary_Method/geom_sphere3a.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere3a.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere3b.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere3b.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere3c.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere3c.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere3d.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere3d.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere3e.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere3e.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere3f.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere3f.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETVIEWPOINT
  view 1
 SETVIEWPOINT

--- a/Verification/Immersed_Boundary_Method/geom_sphere_fire.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_sphere_fire.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 LOADFILE
  geom_sphere_fire_01.s3d
 LOADFILE

--- a/Verification/Immersed_Boundary_Method/geom_terrain.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_terrain.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 XSCENECLIP
  0 -1.002000 0 1.002000
 YSCENECLIP

--- a/Verification/Immersed_Boundary_Method/geom_texture.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_texture.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 XSCENECLIP
  0 -0.001000 0 1.001000
 YSCENECLIP

--- a/Verification/Immersed_Boundary_Method/geom_texture2.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_texture2.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 XSCENECLIP
  0 -0.001000 0 1.001000
 YSCENECLIP

--- a/Verification/Immersed_Boundary_Method/geom_texture3.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_texture3.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  0.000000
 RENDERCLIP

--- a/Verification/Immersed_Boundary_Method/geom_texture3a.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_texture3a.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  0.000000
 RENDERCLIP

--- a/Verification/Immersed_Boundary_Method/geom_texture3b.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_texture3b.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  0.000000
 RENDERCLIP

--- a/Verification/Immersed_Boundary_Method/geom_texture4a.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_texture4a.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  0.000000
 RENDERCLIP

--- a/Verification/Immersed_Boundary_Method/geom_texture4b.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_texture4b.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  0.000000
 RENDERCLIP

--- a/Verification/Immersed_Boundary_Method/geom_time.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_time.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  50.000000
 RENDERONCE

--- a/Verification/Immersed_Boundary_Method/geom_time2.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_time2.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  50.000000
 RENDERONCE

--- a/Verification/Immersed_Boundary_Method/geom_time3.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_time3.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  50.000000
 RENDERONCE

--- a/Verification/Immersed_Boundary_Method/geom_time4.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_time4.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  50.000000
 RENDERONCE

--- a/Verification/Immersed_Boundary_Method/geom_time5.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_time5.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SETTIMEVAL
  50.000000
 RENDERONCE

--- a/Verification/Immersed_Boundary_Method/geom_volume.ssf
+++ b/Verification/Immersed_Boundary_Method/geom_volume.ssf
@@ -1,5 +1,5 @@
 RENDERDIR
- ..\..\Manuals\FDS_User_Guide\SCRIPT_FIGURES
+ ..\..\..\fds\Manuals\FDS_User_Guide\SCRIPT_FIGURES
 SCENECLIP
  1 114 43 45 66
 SETTIMEVAL


### PR DESCRIPTION
smokeview scripts (.ssf files) used to generate figures for geom_notes was never updated after we reorganized the repos.  this pull request corrects these scripts