### PR TITLE
clean up header files

### DIFF
--- a/Build/smokediff/Makefile
+++ b/Build/smokediff/Makefile
@@ -72,7 +72,7 @@ LINUXFORTLIBS_64=$(FORTLIBDIR)/intel64/libifcore.a
 # ------------- 32 bit Linux gnu ----------------
 
 gnu_linux_32 : FFLAGS    = -O0 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_32 : CFLAGS    = -O0 -Wall -D pp_GCC -D pp_LINUX -D pp_append $(GITINFO)
+gnu_linux_32 : CFLAGS    = -O0 -Wall -D pp_GCC -D pp_LINUX $(GITINFO)
 gnu_linux_32 : LFLAGS    = 
 gnu_linux_32 : CC        = gcc
 gnu_linux_32 : CPP       = g++
@@ -85,7 +85,7 @@ gnu_linux_32 : $(obj)
 # ------------- 64 bit Linux gnu ----------------
 
 gnu_linux_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_append $(GITINFO)
+gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX $(GITINFO)
 gnu_linux_64 : LFLAGS    = -m64
 gnu_linux_64 : CC        = gcc
 gnu_linux_64 : CPP       = g++
@@ -99,7 +99,7 @@ gnu_linux_64 : $(obj)
 #  gnu osx
 
 gnu_osx_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D  pp_OSX -D pp_append $(GITINFO)
+gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D  pp_OSX $(GITINFO)
 gnu_osx_64 : LFLAGS    = -m64
 gnu_osx_64 : CC        = gcc
 gnu_osx_64 : CPP       = g++
@@ -113,7 +113,7 @@ gnu_osx_64 : $(obj)
 #  64 bit linux
 
 intel_linux_64 : FFLAGS    = -O2 -m64 -fpp -D pp_LINUX
-intel_linux_64 : CFLAGS    = -O2 -m64 -D pp_LINUX -D pp_INTEL -D pp_append $(GITINFO)
+intel_linux_64 : CFLAGS    = -O2 -m64 -D pp_LINUX -D pp_INTEL $(GITINFO)
 intel_linux_64 : CC        = icc
 intel_linux_64 : CPP       = icc
 intel_linux_64 : FC        = ifort
@@ -123,7 +123,7 @@ intel_linux_64 : $(obj)
 	$(CPP) -o $(bin)/$(exe) -static-intel $(obj) $(LINUXFORTLIBS_64)
 
 intel_linux_64_db : FFLAGS    = -O0 -m64 -fpp -D pp_LINUX
-intel_linux_64_db : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_INTEL -D pp_append -g -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
+intel_linux_64_db : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_INTEL -g -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
 intel_linux_64_db : CC        = icc
 intel_linux_64_db : CPP       = icc
 intel_linux_64_db : FC        = ifort
@@ -139,7 +139,7 @@ MACFORTLIBS=$(FORTLIBDIR)/libifcoremt.a $(FORTLIBDIR)/libimf.a $(FORTLIBDIR)/lib
 #  64 bit OSX
 
 intel_osx_64 : FFLAGS    = -O2 -m64 -fpp -D pp_OSX
-intel_osx_64 : CFLAGS    = -O2 -m64 -D pp_INTEL -D pp_OSX -D pp_append $(GITINFO)
+intel_osx_64 : CFLAGS    = -O2 -m64 -D pp_INTEL -D pp_OSX $(GITINFO)
 intel_osx_64 : CC        = icc
 intel_osx_64 : CPP       = icc
 intel_osx_64 : FC        = ifort

--- a/Build/smokediff/Makefile
+++ b/Build/smokediff/Makefile
@@ -72,7 +72,7 @@ LINUXFORTLIBS_64=$(FORTLIBDIR)/intel64/libifcore.a
 # ------------- 32 bit Linux gnu ----------------
 
 gnu_linux_32 : FFLAGS    = -O0 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_32 : CFLAGS    = -O0 -Wall -D pp_GCC -D pp_LINUX $(GITINFO)
+gnu_linux_32 : CFLAGS    = -O0 -Wall -D pp_GCC -D pp_LINUX -D pp_append $(GITINFO)
 gnu_linux_32 : LFLAGS    = 
 gnu_linux_32 : CC        = gcc
 gnu_linux_32 : CPP       = g++
@@ -85,7 +85,7 @@ gnu_linux_32 : $(obj)
 # ------------- 64 bit Linux gnu ----------------
 
 gnu_linux_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX $(GITINFO)
+gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_append $(GITINFO)
 gnu_linux_64 : LFLAGS    = -m64
 gnu_linux_64 : CC        = gcc
 gnu_linux_64 : CPP       = g++
@@ -99,7 +99,7 @@ gnu_linux_64 : $(obj)
 #  gnu osx
 
 gnu_osx_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D  pp_OSX $(GITINFO)
+gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D  pp_OSX -D pp_append $(GITINFO)
 gnu_osx_64 : LFLAGS    = -m64
 gnu_osx_64 : CC        = gcc
 gnu_osx_64 : CPP       = g++
@@ -113,7 +113,7 @@ gnu_osx_64 : $(obj)
 #  64 bit linux
 
 intel_linux_64 : FFLAGS    = -O2 -m64 -fpp -D pp_LINUX
-intel_linux_64 : CFLAGS    = -O2 -m64 -D pp_LINUX -D pp_INTEL $(GITINFO)
+intel_linux_64 : CFLAGS    = -O2 -m64 -D pp_LINUX -D pp_INTEL -D pp_append $(GITINFO)
 intel_linux_64 : CC        = icc
 intel_linux_64 : CPP       = icc
 intel_linux_64 : FC        = ifort
@@ -123,7 +123,7 @@ intel_linux_64 : $(obj)
 	$(CPP) -o $(bin)/$(exe) -static-intel $(obj) $(LINUXFORTLIBS_64)
 
 intel_linux_64_db : FFLAGS    = -O0 -m64 -fpp -D pp_LINUX
-intel_linux_64_db : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_INTEL -g -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
+intel_linux_64_db : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_INTEL -D pp_append -g -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
 intel_linux_64_db : CC        = icc
 intel_linux_64_db : CPP       = icc
 intel_linux_64_db : FC        = ifort
@@ -139,7 +139,7 @@ MACFORTLIBS=$(FORTLIBDIR)/libifcoremt.a $(FORTLIBDIR)/libimf.a $(FORTLIBDIR)/lib
 #  64 bit OSX
 
 intel_osx_64 : FFLAGS    = -O2 -m64 -fpp -D pp_OSX
-intel_osx_64 : CFLAGS    = -O2 -m64 -D pp_INTEL -D pp_OSX $(GITINFO)
+intel_osx_64 : CFLAGS    = -O2 -m64 -D pp_INTEL -D pp_OSX -D pp_append $(GITINFO)
 intel_osx_64 : CC        = icc
 intel_osx_64 : CPP       = icc
 intel_osx_64 : FC        = ifort

--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -191,7 +191,7 @@ intel_win_64 : $(objwin)
 intel_linux_64 : LIB_DIR_PLAT = $(LIB_DIR)/intel_linux_64
 intel_linux_64 : LIBS_PLAT =
 intel_linux_64 : FFLAGS    = -O0 -traceback -m64 -static-intel -fpp $(SMV_PROFILEFLAG)
-intel_linux_64 : CFLAGS    = -O0 -traceback -m64 -static-intel -D pp_LINUX -D pp_INTEL $(SMV_TESTFLAG) $(SMV_PROFILEFLAG) $(GITINFO)
+intel_linux_64 : CFLAGS    = -O0 -traceback -m64 -static-intel -D pp_LINUX -D pp_INTEL -D pp_append $(SMV_TESTFLAG) $(SMV_PROFILEFLAG) $(GITINFO)
 intel_linux_64 : LIBLUA    =
 ifeq ($(LUA_SCRIPTING),true)
 intel_linux_64 : CFLAGS    += -D pp_LUA
@@ -213,7 +213,7 @@ intel_linux_64 : $(obj)  $(if $(LUA_SCRIPTING),smvluacore)
 # ------------- intel_linux_64_db ----------------
 
 intel_linux_64_db : FFLAGS    = -O0 -m64 -static-intel -traceback -g -fpe0 -fltconsistency -WB -fpp -stand:f08 $(SMV_PROFILEFLAG)
-intel_linux_64_db : CFLAGS    = -O0 -g -m64 -static-intel $(SMV_TESTFLAG) -D _DEBUG -D pp_LINUX -D pp_INTEL $(SMV_PROFILEFLAG) -traceback -Wall -Wextra -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
+intel_linux_64_db : CFLAGS    = -O0 -g -m64 -static-intel $(SMV_TESTFLAG) -D _DEBUG -D pp_LINUX -D pp_INTEL -D pp_append $(SMV_PROFILEFLAG) -traceback -Wall -Wextra -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
 intel_linux_64_db : LFLAGS    = -m64 -static-intel -traceback $(SMV_PROFILEFLAG)
 intel_linux_64_db : CC        = icc
 intel_linux_64_db : CPP       = icpc
@@ -226,7 +226,7 @@ intel_linux_64_db : $(obj)
 # ------------- gnu_linux_64_db ----------------
 
 gnu_linux_64_db : FFLAGS    = -O0 -m64 -ggdb -Wall -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4 -fcheck=all -fbacktrace
-gnu_linux_64_db : CFLAGS    = -O0 -m64 -ggdb -Wall -Wno-write-strings -D _DEBUG -D pp_LINUX -D pp_GCC
+gnu_linux_64_db : CFLAGS    = -O0 -m64 -ggdb -Wall -Wno-write-strings -D _DEBUG -D pp_LINUX -D pp_append -D pp_GCC
 gnu_linux_64_db : LFLAGS    = -m64
 gnu_linux_64_db : CC        = gcc
 gnu_linux_64_db : CPP       = g++
@@ -241,7 +241,7 @@ gnu_linux_64_db : $(obj)
 gnu_linux_64 : LIB_DIR_PLAT = $(LIB_DIR)/gnu_linux_64
 gnu_linux_64 : LIBS_PLAT =
 gnu_linux_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_GCC -Wno-write-strings
+gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_GCC -D pp_append -Wno-write-strings
 ifeq ($(LUA_SCRIPTING),true)
 gnu_linux_64 : CFLAGS    += -D pp_LUA
 gnu_linux_64 : LIBS_PLAT += $(LIB_DIR_PLAT)/lua53.a
@@ -263,7 +263,7 @@ gnu_linux_64 : $(obj) $(if $(LUA_SCRIPTING),smvluacore)
 gnu_linux_32 : LIB_DIR_PLAT = $(LIB_DIR)/gnu_linux_32
 gnu_linux_32 : LIBS_PLAT =
 gnu_linux_32 : FFLAGS    = -O0 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_32 : CFLAGS    = -O0 -D pp_LINUX -D pp_GCC -Wno-write-strings
+gnu_linux_32 : CFLAGS    = -O0 -D pp_LINUX -D pp_GCC -D pp_append -Wno-write-strings
 gnu_linux_32 : LFLAGS    =
 gnu_linux_32 : CC        = gcc
 gnu_linux_32 : CPP       = g++
@@ -277,7 +277,7 @@ gnu_linux_32 : $(obj)
 # ------------- gnu_linux_32_db ----------------
 
 gnu_linux_32_db : FFLAGS    = -O0 -ggdb -Wall -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4 -fcheck=all -fbacktrace
-gnu_linux_32_db : CFLAGS    = -O0 -ggdb -Wall -Wno-write-strings -Wno-comment -Wno-unused-function -D _DEBUG -D pp_LINUX -D pp_GCC
+gnu_linux_32_db : CFLAGS    = -O0 -ggdb -Wall -Wno-write-strings -Wno-comment -Wno-unused-function -D _DEBUG -D pp_LINUX -D pp_GCC -D pp_append 
 gnu_linux_32_db : LFLAGS    =
 gnu_linux_32_db : CC        = gcc
 gnu_linux_32_db : CPP       = g++
@@ -297,7 +297,7 @@ mingw_win_64 : LIBS_PLAT = $(LIB_DIR_PLAT)/libglui.a \
 mingw_win_64 : INC += -I $(SOURCE_DIR)/GLINC-mingw -I $(SOURCE_DIR)/pthreads
 mingw_win_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC \
 						       -ffree-form -frecord-marker=4 -fno-underscoring
-mingw_win_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D GLEW_STATIC -D MINGW
+mingw_win_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D GLEW_STATIC -D MINGW -D pp_append
 ifeq ($(LUA_SCRIPTING),true)
 mingw_win_64 : CFLAGS    += -D pp_LUA
 mingw_win_64 : LIBS_PLAT += $(LIB_DIR_PLAT)/lua53.dll
@@ -326,7 +326,7 @@ OSX_INTEL_LIBS = $(IFORT_COMPILER_LIB)/libifcoremt.a $(IFORT_COMPILER_LIB)/libim
 intel_osx_64 : LIB_DIR_PLAT = $(LIB_DIR)/intel_osx_64
 intel_osx_64 : LIBS_PLAT =
 intel_osx_64 : FFLAGS    = -O0 -m64 -static-intel -fpp -D pp_OSX -mmacosx-version-min=10.4 
-intel_osx_64 : CFLAGS    = -O0 -m64 -static-intel -D pp_OSX  -D pp_INTEL -mmacosx-version-min=10.4 $(SMV_TESTFLAG) $(GITINFO)
+intel_osx_64 : CFLAGS    = -O0 -m64 -static-intel -D pp_OSX  -D pp_INTEL -D pp_append -mmacosx-version-min=10.4 $(SMV_TESTFLAG) $(GITINFO)
 intel_osx_64 : LIBLUA    =
 ifeq ($(LUA_SCRIPTING),true)
 intel_osx_64 : CFLAGS    += -D pp_LUA
@@ -347,7 +347,7 @@ intel_osx_64 : $(obj) $(if $(LUA_SCRIPTING),smvluacore)
 # ------------- intel_osx_64_db ----------------
 
 intel_osx_64_db : FFLAGS    = -O0 -m64 -static-intel -fpp -D pp_OSX -mmacosx-version-min=10.4 -stand:f08
-intel_osx_64_db : CFLAGS    = -O0 -g -m64 -static-intel -D _DEBUG -D pp_OSX  -D pp_INTEL -mmacosx-version-min=10.4 $(SMV_TESTFLAG) -Wall -Wextra -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
+intel_osx_64_db : CFLAGS    = -O0 -g -m64 -static-intel -D _DEBUG -D pp_OSX  -D pp_INTEL -D pp_append -mmacosx-version-min=10.4 $(SMV_TESTFLAG) -Wall -Wextra -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
 intel_osx_64_db : LFLAGS    = -m64 -static-intel -framework OpenGL -framework GLUT -mmacosx-version-min=10.4
 intel_osx_64_db : CC        = icc
 intel_osx_64_db : CPP       = icpc
@@ -360,7 +360,7 @@ intel_osx_64_db : $(obj)
 # ------------- gnu_osx_64_db ----------------
 
 gnu_osx_64_db : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form
-gnu_osx_64_db : CFLAGS    = -O0 -m64 -D _DEBUG -D pp_OSX -Wno-write-strings
+gnu_osx_64_db : CFLAGS    = -O0 -m64 -D _DEBUG -D pp_OSX -D pp_append -Wno-write-strings
 gnu_osx_64_db : LFLAGS    = -m64 -framework OpenGL -framework GLUT
 gnu_osx_64_db : CC        = gcc
 gnu_osx_64_db : CPP       = g++
@@ -373,7 +373,7 @@ gnu_osx_64_db : $(obj)
 # ------------- gnu_osx_64 ----------------
 
 gnu_osx_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form
-gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_OSX -Wno-write-strings
+gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_OSX -D pp_append -Wno-write-strings
 gnu_osx_64 : LFLAGS    = -m64 -framework OpenGL -framework GLUT
 gnu_osx_64 : CC        = gcc
 gnu_osx_64 : CPP       = g++

--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -191,7 +191,7 @@ intel_win_64 : $(objwin)
 intel_linux_64 : LIB_DIR_PLAT = $(LIB_DIR)/intel_linux_64
 intel_linux_64 : LIBS_PLAT =
 intel_linux_64 : FFLAGS    = -O0 -traceback -m64 -static-intel -fpp $(SMV_PROFILEFLAG)
-intel_linux_64 : CFLAGS    = -O0 -traceback -m64 -static-intel -D pp_LINUX -D pp_INTEL -D pp_append $(SMV_TESTFLAG) $(SMV_PROFILEFLAG) $(GITINFO)
+intel_linux_64 : CFLAGS    = -O0 -traceback -m64 -static-intel -D pp_LINUX -D pp_INTEL $(SMV_TESTFLAG) $(SMV_PROFILEFLAG) $(GITINFO)
 intel_linux_64 : LIBLUA    =
 ifeq ($(LUA_SCRIPTING),true)
 intel_linux_64 : CFLAGS    += -D pp_LUA
@@ -213,7 +213,7 @@ intel_linux_64 : $(obj)  $(if $(LUA_SCRIPTING),smvluacore)
 # ------------- intel_linux_64_db ----------------
 
 intel_linux_64_db : FFLAGS    = -O0 -m64 -static-intel -traceback -g -fpe0 -fltconsistency -WB -fpp -stand:f08 $(SMV_PROFILEFLAG)
-intel_linux_64_db : CFLAGS    = -O0 -g -m64 -static-intel $(SMV_TESTFLAG) -D _DEBUG -D pp_LINUX -D pp_INTEL -D pp_append $(SMV_PROFILEFLAG) -traceback -Wall -Wextra -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
+intel_linux_64_db : CFLAGS    = -O0 -g -m64 -static-intel $(SMV_TESTFLAG) -D _DEBUG -D pp_LINUX -D pp_INTEL $(SMV_PROFILEFLAG) -traceback -Wall -Wextra -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
 intel_linux_64_db : LFLAGS    = -m64 -static-intel -traceback $(SMV_PROFILEFLAG)
 intel_linux_64_db : CC        = icc
 intel_linux_64_db : CPP       = icpc
@@ -226,7 +226,7 @@ intel_linux_64_db : $(obj)
 # ------------- gnu_linux_64_db ----------------
 
 gnu_linux_64_db : FFLAGS    = -O0 -m64 -ggdb -Wall -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4 -fcheck=all -fbacktrace
-gnu_linux_64_db : CFLAGS    = -O0 -m64 -ggdb -Wall -Wno-write-strings -D _DEBUG -D pp_LINUX -D pp_append -D pp_GCC
+gnu_linux_64_db : CFLAGS    = -O0 -m64 -ggdb -Wall -Wno-write-strings -D _DEBUG -D pp_LINUX -D pp_GCC
 gnu_linux_64_db : LFLAGS    = -m64
 gnu_linux_64_db : CC        = gcc
 gnu_linux_64_db : CPP       = g++
@@ -241,7 +241,7 @@ gnu_linux_64_db : $(obj)
 gnu_linux_64 : LIB_DIR_PLAT = $(LIB_DIR)/gnu_linux_64
 gnu_linux_64 : LIBS_PLAT =
 gnu_linux_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_GCC -D pp_append -Wno-write-strings
+gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_GCC -Wno-write-strings
 ifeq ($(LUA_SCRIPTING),true)
 gnu_linux_64 : CFLAGS    += -D pp_LUA
 gnu_linux_64 : LIBS_PLAT += $(LIB_DIR_PLAT)/lua53.a
@@ -263,7 +263,7 @@ gnu_linux_64 : $(obj) $(if $(LUA_SCRIPTING),smvluacore)
 gnu_linux_32 : LIB_DIR_PLAT = $(LIB_DIR)/gnu_linux_32
 gnu_linux_32 : LIBS_PLAT =
 gnu_linux_32 : FFLAGS    = -O0 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_32 : CFLAGS    = -O0 -D pp_LINUX -D pp_GCC -D pp_append -Wno-write-strings
+gnu_linux_32 : CFLAGS    = -O0 -D pp_LINUX -D pp_GCC -Wno-write-strings
 gnu_linux_32 : LFLAGS    =
 gnu_linux_32 : CC        = gcc
 gnu_linux_32 : CPP       = g++
@@ -277,7 +277,7 @@ gnu_linux_32 : $(obj)
 # ------------- gnu_linux_32_db ----------------
 
 gnu_linux_32_db : FFLAGS    = -O0 -ggdb -Wall -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4 -fcheck=all -fbacktrace
-gnu_linux_32_db : CFLAGS    = -O0 -ggdb -Wall -Wno-write-strings -Wno-comment -Wno-unused-function -D _DEBUG -D pp_LINUX -D pp_GCC -D pp_append 
+gnu_linux_32_db : CFLAGS    = -O0 -ggdb -Wall -Wno-write-strings -Wno-comment -Wno-unused-function -D _DEBUG -D pp_LINUX -D pp_GCC 
 gnu_linux_32_db : LFLAGS    =
 gnu_linux_32_db : CC        = gcc
 gnu_linux_32_db : CPP       = g++
@@ -297,7 +297,7 @@ mingw_win_64 : LIBS_PLAT = $(LIB_DIR_PLAT)/libglui.a \
 mingw_win_64 : INC += -I $(SOURCE_DIR)/GLINC-mingw -I $(SOURCE_DIR)/pthreads
 mingw_win_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC \
 						       -ffree-form -frecord-marker=4 -fno-underscoring
-mingw_win_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D GLEW_STATIC -D MINGW -D pp_append
+mingw_win_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D GLEW_STATIC -D MINGW 
 ifeq ($(LUA_SCRIPTING),true)
 mingw_win_64 : CFLAGS    += -D pp_LUA
 mingw_win_64 : LIBS_PLAT += $(LIB_DIR_PLAT)/lua53.dll
@@ -326,7 +326,7 @@ OSX_INTEL_LIBS = $(IFORT_COMPILER_LIB)/libifcoremt.a $(IFORT_COMPILER_LIB)/libim
 intel_osx_64 : LIB_DIR_PLAT = $(LIB_DIR)/intel_osx_64
 intel_osx_64 : LIBS_PLAT =
 intel_osx_64 : FFLAGS    = -O0 -m64 -static-intel -fpp -D pp_OSX -mmacosx-version-min=10.4 
-intel_osx_64 : CFLAGS    = -O0 -m64 -static-intel -D pp_OSX  -D pp_INTEL -D pp_append -mmacosx-version-min=10.4 $(SMV_TESTFLAG) $(GITINFO)
+intel_osx_64 : CFLAGS    = -O0 -m64 -static-intel -D pp_OSX  -D pp_INTEL -mmacosx-version-min=10.4 $(SMV_TESTFLAG) $(GITINFO)
 intel_osx_64 : LIBLUA    =
 ifeq ($(LUA_SCRIPTING),true)
 intel_osx_64 : CFLAGS    += -D pp_LUA
@@ -347,7 +347,7 @@ intel_osx_64 : $(obj) $(if $(LUA_SCRIPTING),smvluacore)
 # ------------- intel_osx_64_db ----------------
 
 intel_osx_64_db : FFLAGS    = -O0 -m64 -static-intel -fpp -D pp_OSX -mmacosx-version-min=10.4 -stand:f08
-intel_osx_64_db : CFLAGS    = -O0 -g -m64 -static-intel -D _DEBUG -D pp_OSX  -D pp_INTEL -D pp_append -mmacosx-version-min=10.4 $(SMV_TESTFLAG) -Wall -Wextra -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
+intel_osx_64_db : CFLAGS    = -O0 -g -m64 -static-intel -D _DEBUG -D pp_OSX  -D pp_INTEL -mmacosx-version-min=10.4 $(SMV_TESTFLAG) -Wall -Wextra -check=stack,uninit -fp-stack-check -fp-trap-all=divzero,invalid,overflow -ftrapuv -Wuninitialized -Wunused-function -Wunused-variable $(GITINFO)
 intel_osx_64_db : LFLAGS    = -m64 -static-intel -framework OpenGL -framework GLUT -mmacosx-version-min=10.4
 intel_osx_64_db : CC        = icc
 intel_osx_64_db : CPP       = icpc
@@ -360,7 +360,7 @@ intel_osx_64_db : $(obj)
 # ------------- gnu_osx_64_db ----------------
 
 gnu_osx_64_db : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form
-gnu_osx_64_db : CFLAGS    = -O0 -m64 -D _DEBUG -D pp_OSX -D pp_append -Wno-write-strings
+gnu_osx_64_db : CFLAGS    = -O0 -m64 -D _DEBUG -D pp_OSX -Wno-write-strings
 gnu_osx_64_db : LFLAGS    = -m64 -framework OpenGL -framework GLUT
 gnu_osx_64_db : CC        = gcc
 gnu_osx_64_db : CPP       = g++
@@ -373,7 +373,7 @@ gnu_osx_64_db : $(obj)
 # ------------- gnu_osx_64 ----------------
 
 gnu_osx_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form
-gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_OSX -D pp_append -Wno-write-strings
+gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_OSX -Wno-write-strings
 gnu_osx_64 : LFLAGS    = -m64 -framework OpenGL -framework GLUT
 gnu_osx_64 : CC        = gcc
 gnu_osx_64 : CPP       = g++

--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -297,7 +297,7 @@ mingw_win_64 : LIBS_PLAT = $(LIB_DIR_PLAT)/libglui.a \
 mingw_win_64 : INC += -I $(SOURCE_DIR)/GLINC-mingw -I $(SOURCE_DIR)/pthreads
 mingw_win_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC \
 						       -ffree-form -frecord-marker=4 -fno-underscoring
-mingw_win_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D GLEW_STATIC -D MINGW 
+mingw_win_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D GLEW_STATIC -D MINGW
 ifeq ($(LUA_SCRIPTING),true)
 mingw_win_64 : CFLAGS    += -D pp_LUA
 mingw_win_64 : LIBS_PLAT += $(LIB_DIR_PLAT)/lua53.dll

--- a/Build/smokezip/Makefile
+++ b/Build/smokezip/Makefile
@@ -64,7 +64,7 @@ intel_win_64 : $(objwin)
 # ------------- 32 bit gnu Linux ----------------
 
 gnu_linux_32 : FFLAGS    = -O0 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_32 : CFLAGS    = -O0 -Wall -D pp_GCC -D pp_LINUX -D pp_append $(GITINFO)
+gnu_linux_32 : CFLAGS    = -O0 -Wall -D pp_GCC -D pp_LINUX $(GITINFO)
 gnu_linux_32 : LFLAGS    = 
 gnu_linux_32 : CC        = gcc
 gnu_linux_32 : CPP       = g++
@@ -77,7 +77,7 @@ gnu_linux_32 : $(obj)
 # ------------- 64 bit gnu Linux ----------------
 
 gnu_linux_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_64 : CFLAGS    = -O0 -m64 -Wall -D pp_GCC -D pp_LINUX -D pp_append $(GITINFO)
+gnu_linux_64 : CFLAGS    = -O0 -m64 -Wall -D pp_GCC -D pp_LINUX $(GITINFO)
 gnu_linux_64 : LFLAGS    = -m64
 gnu_linux_64 : CC        = gcc
 gnu_linux_64 : CPP       = g++
@@ -108,7 +108,7 @@ LINUXFORTLIBS_64=$(FORTLIBDIR)/intel64/libifcore.a
 
 
 intel_linux_64 : FFLAGS    = -O2 -m64 -fpp -D pp_LINUX
-intel_linux_64 : CFLAGS    = -O2 -m64 ${INC_DIR} -D pp_LINUX -D pp_INTEL -D pp_append $(GITINFO)
+intel_linux_64 : CFLAGS    = -O2 -m64 ${INC_DIR} -D pp_LINUX -D pp_INTEL $(GITINFO)
 intel_linux_64 : CC        = icc
 intel_linux_64 : CPP       = icc
 intel_linux_64 : FC        = ifort
@@ -124,7 +124,7 @@ OSXFORTLIBS=$(FORTLIBDIR)/libifcoremt.a $(FORTLIBDIR)/libimf.a $(FORTLIBDIR)/lib
 #  64 bit OSX
 
 intel_osx_64 : FFLAGS    = -O2 -m64 -fpp -D pp_OSX
-intel_osx_64 : CFLAGS    = -O2 -m64 -D pp_OSX -D pp_INTEL -D pp_append $(GITINFO)
+intel_osx_64 : CFLAGS    = -O2 -m64 -D pp_OSX -D pp_INTEL $(GITINFO)
 intel_osx_64 : CC        = icc
 intel_osx_64 : CPP       = icc
 intel_osx_64 : FC        = ifort

--- a/Build/smokezip/Makefile
+++ b/Build/smokezip/Makefile
@@ -64,7 +64,7 @@ intel_win_64 : $(objwin)
 # ------------- 32 bit gnu Linux ----------------
 
 gnu_linux_32 : FFLAGS    = -O0 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_32 : CFLAGS    = -O0 -Wall -D pp_GCC -D pp_LINUX $(GITINFO)
+gnu_linux_32 : CFLAGS    = -O0 -Wall -D pp_GCC -D pp_LINUX -D pp_append $(GITINFO)
 gnu_linux_32 : LFLAGS    = 
 gnu_linux_32 : CC        = gcc
 gnu_linux_32 : CPP       = g++
@@ -77,7 +77,7 @@ gnu_linux_32 : $(obj)
 # ------------- 64 bit gnu Linux ----------------
 
 gnu_linux_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_64 : CFLAGS    = -O0 -m64 -Wall -D pp_GCC -D pp_LINUX $(GITINFO)
+gnu_linux_64 : CFLAGS    = -O0 -m64 -Wall -D pp_GCC -D pp_LINUX -D pp_append $(GITINFO)
 gnu_linux_64 : LFLAGS    = -m64
 gnu_linux_64 : CC        = gcc
 gnu_linux_64 : CPP       = g++
@@ -108,7 +108,7 @@ LINUXFORTLIBS_64=$(FORTLIBDIR)/intel64/libifcore.a
 
 
 intel_linux_64 : FFLAGS    = -O2 -m64 -fpp -D pp_LINUX
-intel_linux_64 : CFLAGS    = -O2 -m64 ${INC_DIR} -D pp_LINUX -D pp_INTEL $(GITINFO)
+intel_linux_64 : CFLAGS    = -O2 -m64 ${INC_DIR} -D pp_LINUX -D pp_INTEL -D pp_append $(GITINFO)
 intel_linux_64 : CC        = icc
 intel_linux_64 : CPP       = icc
 intel_linux_64 : FC        = ifort
@@ -124,7 +124,7 @@ OSXFORTLIBS=$(FORTLIBDIR)/libifcoremt.a $(FORTLIBDIR)/libimf.a $(FORTLIBDIR)/lib
 #  64 bit OSX
 
 intel_osx_64 : FFLAGS    = -O2 -m64 -fpp -D pp_OSX
-intel_osx_64 : CFLAGS    = -O2 -m64 -D pp_OSX -D pp_INTEL $(GITINFO)
+intel_osx_64 : CFLAGS    = -O2 -m64 -D pp_OSX -D pp_INTEL -D pp_append $(GITINFO)
 intel_osx_64 : CC        = icc
 intel_osx_64 : CPP       = icc
 intel_osx_64 : FC        = ifort

--- a/Source/shared/isodefs.h
+++ b/Source/shared/isodefs.h
@@ -79,10 +79,10 @@ typedef struct {
   int closest;
 } orderdata;
 
-#define CCIsoSurface2File  iso2file
-#define CCIsoSurfaceT2File isot2file
-#define CCIsoHeader        isoheader
-#define CCTIsoHeader       tisoheader
+#define CCIsoSurface2File  _F(iso2file)
+#define CCIsoSurfaceT2File _F(isot2file)
+#define CCIsoHeader        _F(isoheader)
+#define CCTIsoHeader       _F(tisoheader)
 
 SV_EXTERN void CCIsoHeader(char *isofile,
                  char *isolonglabel, char *isoshortlabel, char *isounits,

--- a/Source/shared/isodefs.h
+++ b/Source/shared/isodefs.h
@@ -79,10 +79,10 @@ typedef struct {
   int closest;
 } orderdata;
 
-#define CCIsoSurface2File _F(iso2file)
-#define CCIsoSurfaceT2File _F(isot2file)
-#define CCIsoHeader _F(isoheader)
-#define CCTIsoHeader _F(tisoheader)
+#define CCIsoSurface2File  iso2file
+#define CCIsoSurfaceT2File isot2file
+#define CCIsoHeader        isoheader
+#define CCTIsoHeader       tisoheader
 
 SV_EXTERN void CCIsoHeader(char *isofile,
                  char *isolonglabel, char *isoshortlabel, char *isounits,

--- a/Source/smokediff/options.h
+++ b/Source/smokediff/options.h
@@ -63,12 +63,6 @@
 #define PROGVERSION "test"
 #endif
 
-// used to access fortran routines from C
-
-#ifndef _F
-#define _F(name) name
-#endif
-
 #ifdef pp_release
 #define PROGVERSION "1.0.10"
 #endif

--- a/Source/smokediff/options.h
+++ b/Source/smokediff/options.h
@@ -63,18 +63,10 @@
 #define PROGVERSION "test"
 #endif
 
-#ifdef WIN32
-#define pp_noappend
-#endif
-
 // used to access fortran routines from C
 
 #ifndef _F
-#ifdef pp_noappend
 #define _F(name) name
-#else
-#define _F(name) name ## _
-#endif
 #endif
 
 #ifdef pp_release

--- a/Source/smokediff/options.h
+++ b/Source/smokediff/options.h
@@ -39,6 +39,18 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+#ifdef pp_LINUX
+#define pp_append
+#endif
+
+#ifdef pp_OSX
+#define pp_append
+#endif
+
+#ifdef WIN32
+#undef pp_append
+#endif
+
 // VVVVVVVVVVVVVVVVVVVVVVVVV  set platform defines VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
 
 // used to access Fortran routines from C

--- a/Source/smokediff/options.h
+++ b/Source/smokediff/options.h
@@ -41,6 +41,16 @@
 
 // VVVVVVVVVVVVVVVVVVVVVVVVV  set platform defines VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
 
+// used to access Fortran routines from C
+
+#ifndef _F
+#ifdef pp_append
+#define _F(name) name ## _
+#else
+#define _F(name) name
+#endif
+
+
 #define FILE_SIZE unsigned long long
 
 #ifdef X64

--- a/Source/smokediff/options.h
+++ b/Source/smokediff/options.h
@@ -49,6 +49,7 @@
 #else
 #define _F(name) name
 #endif
+#endif
 
 
 #define FILE_SIZE unsigned long long

--- a/Source/smokediff/svdiff.h
+++ b/Source/smokediff/svdiff.h
@@ -120,22 +120,22 @@ int similar_grid(meshdata *mesh1, meshdata *mesh2, int *factor);
 int exact_grid(meshdata *mesh1, meshdata *mesh2, int *factor);
 int getpatchindex(int in1, boundary *boundaryin, boundary *boundaryout);
 
-#define FORTgetsliceparms _F(getsliceparms)
-#define FORTclosefortranfile _F(closefortranfile)
-#define FORTopenslice _F(openslice)
-#define FORTgetsliceframe _F(getsliceframe)
-#define FORToutsliceframe _F(outsliceframe)
-#define FORToutsliceheader _F(outsliceheader)
-#define FORTgetplot3dq _F(getplot3dq)
-#define FORTplot3dout _F(plot3dout)
-#define FORTgetboundaryheader1 _F(getboundaryheader1)
-#define FORTgetboundaryheader2 _F(getboundaryheader2)
-#define FORTopenboundary _F(openboundary)
-#define FORTgetpatchdata _F(getpatchdata)
-#define FORToutboundaryheader _F(outboundaryheader)
-#define FORToutpatchframe _F(outpatchframe)
-#define FORTendianout _F(endianout)
-#define FORTget_file_unit _F(get_file_unit)
+#define FORTgetsliceparms      getsliceparms
+#define FORTclosefortranfile   closefortranfile
+#define FORTopenslice          openslice
+#define FORTgetsliceframe      getsliceframe
+#define FORToutsliceframe      outsliceframe
+#define FORToutsliceheader     outsliceheader
+#define FORTgetplot3dq         getplot3dq
+#define FORTplot3dout          plot3dout
+#define FORTgetboundaryheader1 getboundaryheader1
+#define FORTgetboundaryheader2 getboundaryheader2
+#define FORTopenboundary       openboundary
+#define FORTgetpatchdata       getpatchdata
+#define FORToutboundaryheader  outboundaryheader
+#define FORToutpatchframe      outpatchframe
+#define FORTendianout          endianout
+#define FORTget_file_unit      get_file_unit
 
 STDCALLF FORTget_file_unit(int *file_unit, int *file_unit_start);
 STDCALLF FORToutpatchframe(int *lunit, int *npatch,

--- a/Source/smokediff/svdiff.h
+++ b/Source/smokediff/svdiff.h
@@ -120,22 +120,22 @@ int similar_grid(meshdata *mesh1, meshdata *mesh2, int *factor);
 int exact_grid(meshdata *mesh1, meshdata *mesh2, int *factor);
 int getpatchindex(int in1, boundary *boundaryin, boundary *boundaryout);
 
-#define FORTgetsliceparms      getsliceparms
-#define FORTclosefortranfile   closefortranfile
-#define FORTopenslice          openslice
-#define FORTgetsliceframe      getsliceframe
-#define FORToutsliceframe      outsliceframe
-#define FORToutsliceheader     outsliceheader
-#define FORTgetplot3dq         getplot3dq
-#define FORTplot3dout          plot3dout
-#define FORTgetboundaryheader1 getboundaryheader1
-#define FORTgetboundaryheader2 getboundaryheader2
-#define FORTopenboundary       openboundary
-#define FORTgetpatchdata       getpatchdata
-#define FORToutboundaryheader  outboundaryheader
-#define FORToutpatchframe      outpatchframe
-#define FORTendianout          endianout
-#define FORTget_file_unit      get_file_unit
+#define FORTgetsliceparms      _F(getsliceparms)
+#define FORTclosefortranfile   _F(closefortranfile)
+#define FORTopenslice          _F(openslice)
+#define FORTgetsliceframe      _F(getsliceframe)
+#define FORToutsliceframe      _F(outsliceframe)
+#define FORToutsliceheader     _F(outsliceheader)
+#define FORTgetplot3dq         _F(getplot3dq)
+#define FORTplot3dout          _F(plot3dout)
+#define FORTgetboundaryheader1 _F(getboundaryheader1)
+#define FORTgetboundaryheader2 _F(getboundaryheader2)
+#define FORTopenboundary       _F(openboundary)
+#define FORTgetpatchdata       _F(getpatchdata)
+#define FORToutboundaryheader  _F(outboundaryheader)
+#define FORToutpatchframe      _F(outpatchframe)
+#define FORTendianout          _F(endianout)
+#define FORTget_file_unit      _F(get_file_unit)
 
 STDCALLF FORTget_file_unit(int *file_unit, int *file_unit_start);
 STDCALLF FORToutpatchframe(int *lunit, int *npatch,

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -129,9 +129,6 @@ void Usage(char **argv,int option){
 #ifdef pp_memstatus
     strcat(label, ", pp_memstatus");
 #endif
-#ifdef pp_noappend
-    strcat(label, ", pp_noappend");
-#endif
 #ifdef pp_OFFICIAL_RELEASE
     strcat(label, ", pp_OFFICIAL_RELEASE");
 #endif

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -75,6 +75,9 @@ void Usage(char **argv,int option){
 #ifdef _DEBUG
     strcat(label, ", _DEBUG");
 #endif
+#ifdef pp_append
+    strcat(label, ", pp_append");
+#endif
 #ifdef pp_BETA
     strcat(label, ", pp_BETA");
 #endif

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -47,7 +47,6 @@
 #define pp_memstatus
 #define pp_COMPRESS
 #define pp_noappend
-//#define GLUT_DISABLE_ATEXIT_HACK
 #include "pragmas.h"
 #endif
 
@@ -57,16 +56,16 @@
 #undef pp_LANG   // turn off language support - doesn't work
 #undef pp_DEG    // turn off degree symbol output - doesn't work
 #define pp_GLUTGET // use d and f key in place of CTRL and ALT key
-// #define pp_OSXGLUT32 // used to test advanced opengl profile on mac
+// #define pp_OSXGLUT32 // used to test advanced OpenGL profile on mac
 #endif
 
 //*** options: options being tested on all platforms
 
 #ifdef pp_BETA
-#define pp_SLICELOAD
+#define pp_SLICELOAD     // use slice file parameters found in .smv file to construct menus
 #define pp_SHOWTERRAIN
-#define pp_GEOMTEST  // used to test tetrahedron box intersections
-#define pp_HAZARD
+#define pp_GEOMTEST      // used to test tetrahedron box intersections
+#define pp_HAZARD        // 
 //#define pp_GPUDEPTH
 #endif
 
@@ -74,8 +73,8 @@
 
 #ifdef _DEBUG
 #define pp_RENDER360_DEBUG
-#define pp_MEMPRINT // output memory allocation info
-#define pp_MEMDEBUG // comment the following line when debugging REALLY large cases (to avoid memory checks)
+#define pp_MEMPRIN      // output memory allocation info
+#define pp_MEMDEBUG     // comment this line when debugging REALLY large cases (to avoid memory checks)
 #endif
 
 //*** used to access fortran routines from C

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -44,6 +44,7 @@
 //*** options: windows
 
 #ifdef WIN32
+#undef pp_append
 #define pp_memstatus
 #define pp_COMPRESS
 #include "pragmas.h"
@@ -55,7 +56,14 @@
 #undef pp_LANG   // turn off language support - doesn't work
 #undef pp_DEG    // turn off degree symbol output - doesn't work
 #define pp_GLUTGET // use d and f key in place of CTRL and ALT key
+#define pp_append // append underscore to Fortran file names
 // #define pp_OSXGLUT32 // used to test advanced OpenGL profile on mac
+#endif
+
+//*** options: Linux
+
+#ifdef pp_LINUX
+#define pp_append // append underscore to Fortran file names
 #endif
 
 //*** options: options being tested on all platforms

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -1,86 +1,47 @@
 #ifndef OPTIONS_H_DEFINED
 #define OPTIONS_H_DEFINED
-// build Smokeview as a standard release unless the pp_BETA directive is defined
-
-#define pp_release
 
 //*** uncomment the following two lines to force all versions to be beta
 //#undef pp_BETA
 //#define pp_BETA
 
-//VVVVVVVVVVVVVVVVVVVVVVVVVVVVV  define smokeview title VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+//*** define smokeview title
+
 #ifdef pp_BETA
-#define PROGVERSION "Test"
-#undef pp_release
-#endif
-
-// comment the following line when building an unofficial release
-#define pp_OFFICIAL_RELEASE
-
-#ifdef pp_release
-#ifdef pp_OFFICIAL_RELEASE
-#define PROGVERSION "6.4.4"
+  #define PROGVERSION "Test"
 #else
-#define PROGVERSION "Unofficial release"
-#endif
+  #define PROGVERSION "6.4.4"
 #endif
 
-//VVVVVVVVVVVVVVVVVVVVVVVVVVVVV  turn on options available on all platforms VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+//*** options: all platforms
 
-#define pp_GPU
-#define pp_ffmpeg
-#define pp_READBUFFER
+#define pp_GPU          // support the GPU
+#define pp_ffmpeg       // support compression
+#define pp_READBUFFER   // read .smv file from a memory buffer
+#define pp_DRAWISO      // turn on drawing routines
+#define pp_LANG         // support other languages
+#define pp_DEG          // output degree symbol
+#define pp_RENDER360    // render 360 images
+//#define pp_PARTTEST   // for debugging, set particle values to 100*parti->seq_id + small random number
+#define pp_THREAD       // turn on multi-threading
+#define pp_THREADIBLANK // construct iblank arrays in background
+#ifdef pp_THREADIBLANK  // turn on multi-threading 
+#define pp_THREAD
+#endif
+
+#define _CRT_SECURE_NO_DEPRECATE   // set to eliminate compiler warnings
 
 #ifdef pp_GPU
 #define pp_CULL
 #define pp_GPUTHROTTLE
 #endif
 
-#ifdef VS2015
+#ifdef VS2015            // needed in visual studio to prevent compiler warning/errors
 #define HAVE_SNPRINTF
 #define HAVE_STRUCT_TIMESPEC
 #endif
-#define pp_DRAWISO
-#define pp_LANG
-#define pp_DEG
 
-#define pp_THREAD
-#define pp_THREADIBLANK // test iblank computation in background.
-#ifdef pp_THREADIBLANK  // if pp_THREADIBLANK is set then pp_THREAD also has to be set
-#define pp_THREAD
-#endif
-
-#define _CRT_SECURE_NO_DEPRECATE
-
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-//VVVVVVVVVVVVVVVVVVVVVVVVVVVVV  turn on options that are being tested VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
-
-#ifdef pp_BETA
-#define pp_SLICELOAD
-#define pp_SHOWTERRAIN
-#define pp_GEOMTEST  // used to test tetrahedron box intersections
-// #define pp_OSXGLUT32 // used to test advanced opengl profile on mac
-#define pp_HAZARD
-//#define pp_GPUDEPTH
-#endif
-
-#define pp_RENDER360
-#ifdef _DEBUG
-#define pp_RENDER360_DEBUG
-#define pp_MEMPRINT
-#endif
-
-// for debugging, set particle values to 100*parti->seq_id + small random number
-//#define pp_PARTTEST
-
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-#ifdef _DEBUG  // comment the following line when debugging REALLY large cases (to avoid memory checks)
-#define pp_MEMDEBUG
-#endif
-
-//VVVVVVVVVVVVVVVVVVVVVVVVVVVVV  turn on windows only options VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+//*** options: windows
 
 #ifdef WIN32
 #define pp_memstatus
@@ -89,9 +50,35 @@
 //#define GLUT_DISABLE_ATEXIT_HACK
 #include "pragmas.h"
 #endif
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-//VVVVVVVVVVVVVVVVVVVVVVVVVVVVV  used to access fortran routines from C VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+//*** options: MAC
+
+#ifdef pp_OSX
+#undef pp_LANG   // turn off language support - doesn't work
+#undef pp_DEG    // turn off degree symbol output - doesn't work
+#define pp_GLUTGET // use d and f key in place of CTRL and ALT key
+// #define pp_OSXGLUT32 // used to test advanced opengl profile on mac
+#endif
+
+//*** options: options being tested on all platforms
+
+#ifdef pp_BETA
+#define pp_SLICELOAD
+#define pp_SHOWTERRAIN
+#define pp_GEOMTEST  // used to test tetrahedron box intersections
+#define pp_HAZARD
+//#define pp_GPUDEPTH
+#endif
+
+//*** options: debug options
+
+#ifdef _DEBUG
+#define pp_RENDER360_DEBUG
+#define pp_MEMPRINT // output memory allocation info
+#define pp_MEMDEBUG // comment the following line when debugging REALLY large cases (to avoid memory checks)
+#endif
+
+//*** used to access fortran routines from C
 
 #ifndef _F
 #ifdef pp_noappend
@@ -101,10 +88,7 @@
 #endif
 #endif
 
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-
-// VVVVVVVVVVVVVVVVVVVVVVVVV  set platform defines VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+//*** defines used by various headers
 
 #define FILE_SIZE unsigned long long
 
@@ -126,24 +110,12 @@
 #endif
 #endif
 
-//*** turn off features on the Mac that don't work there
-
-#ifdef pp_OSX
-#undef pp_LANG
-#undef pp_DEG
-#endif
-
-//*** turn on features only available on the Mac
-
-#ifdef pp_OSX
-#define pp_GLUTGET
-#endif
-
-// VVVVVVVVVVVVVVVVVVVVVVVVV  set defines used by various headers VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
 #ifdef CPP
 #define CCC "C"
+#define EXTERNCPP extern "C"
 #else
 #define CCC
+#define EXTERNCPP
 #endif
 
 #ifdef INMAIN
@@ -154,19 +126,12 @@
 #define SVDECL(var,val)  var
 #endif
 
-#ifdef CPP
-#define EXTERNCPP extern "C"
-#else
-#define EXTERNCPP
-#endif
-
 #ifdef pp_OSX
 #define GLUT_H <GLUT/glut.h>
 #else
 #define GLUT_H <GL/glut.h>
 #endif
-
-
 #include "lint.h"
+
 #endif
 

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -25,7 +25,7 @@
 //#define pp_PARTTEST   // for debugging, set particle values to 100*parti->seq_id + small random number
 #define pp_THREAD       // turn on multi-threading
 #define pp_THREADIBLANK // construct iblank arrays in background
-#ifdef pp_THREADIBLANK  // turn on multi-threading 
+#ifdef pp_THREADIBLANK  // turn on multi-threading
 #define pp_THREAD
 #endif
 
@@ -65,7 +65,7 @@
 #define pp_SLICELOAD     // use slice file parameters found in .smv file to construct menus
 #define pp_SHOWTERRAIN
 #define pp_GEOMTEST      // used to test tetrahedron box intersections
-#define pp_HAZARD        // 
+#define pp_HAZARD        //
 //#define pp_GPUDEPTH
 #endif
 

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -86,6 +86,7 @@
 #else
 #define _F(name) name
 #endif
+#endif
 
 #define FILE_SIZE unsigned long long
 

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -78,6 +78,15 @@
 
 //*** defines used by various headers
 
+// used to access Fortran routines from C
+
+#ifndef _F
+#ifdef pp_append
+#define _F(name) name ## _
+#else
+#define _F(name) name
+#endif
+
 #define FILE_SIZE unsigned long long
 
 #ifdef X64

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -76,12 +76,6 @@
 #define pp_MEMDEBUG     // comment this line when debugging REALLY large cases (to avoid memory checks)
 #endif
 
-//*** used to access fortran routines from C
-
-#ifndef _F
-#define _F(name) name
-#endif
-
 //*** defines used by various headers
 
 #define FILE_SIZE unsigned long long

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -46,7 +46,6 @@
 #ifdef WIN32
 #define pp_memstatus
 #define pp_COMPRESS
-#define pp_noappend
 #include "pragmas.h"
 #endif
 
@@ -80,11 +79,7 @@
 //*** used to access fortran routines from C
 
 #ifndef _F
-#ifdef pp_noappend
 #define _F(name) name
-#else
-#define _F(name) name ## _
-#endif
 #endif
 
 //*** defines used by various headers

--- a/Source/smokeview/smokefortheaders.h
+++ b/Source/smokeview/smokefortheaders.h
@@ -7,38 +7,38 @@
 #define STDCALLF extern void
 #endif
 
-#define FORTgetslicefiledirection getslicefiledirection
-#define FORTfpoly2tri             fpoly2tri
-#define FORTget_in_triangle       get_in_triangle
-#define FORTget_is_angle_ge_180   get_is_angle_ge_180
-#define FORTtest_in_tetra         test_in_tetra
-#define FORTgetverts              getverts2
-#define FORTgettetravol           get_tetrabox_volume_fb
-#define FORTgeomout               geomout
-#define FORTgetembeddatasize      getembeddatasize
-#define FORTgetembeddata          getembeddata
-#define FORTopenboundary          openboundary
-#define FORTfcreate_part5sizefile fcreate_part5sizefile
-#define FORTgetzonesize           getzonesize
-#define FORTgetzonedata           getzonedata
-#define FORTgetxyzdata            getxyzdata
-#define FORTgetpatchsizes1        getpatchsizes1
-#define FORTgetpatchsizes2        getpatchsizes2
-#define FORTgetpatchdata          getpatchdata
-#define FORTgetdata1              getdata1
-#define FORTgetsizes              getsizes
-#define FORTgetsizesa             getsizesa
-#define FORTgetslicesizes         getslicesizes
-#define FORTwriteslicedata        writeslicedata
-#define FORTwriteslicedata2       writeslicedata2
-#define FORTgetslicedata          getslicedata
-#define FORTgetplot3dq            getplot3dq
-#define FORTgetsliceparms         getsliceparms
-#define FORTcolor2rgb             color2rgb
-#define FORTget_file_unit         get_file_unit
-#define FORTclosefortranfile      closefortranfile
-#define FORTgetboundaryheader1    getboundaryheader1
-#define FORTgetboundaryheader2    getboundaryheader2
+#define FORTgetslicefiledirection _F(getslicefiledirection)
+#define FORTfpoly2tri             _F(fpoly2tri)
+#define FORTget_in_triangle       _F(get_in_triangle)
+#define FORTget_is_angle_ge_180   _F(get_is_angle_ge_180)
+#define FORTtest_in_tetra         _F(test_in_tetra)
+#define FORTgetverts              _F(getverts2)
+#define FORTgettetravol           _F(get_tetrabox_volume_fb)
+#define FORTgeomout               _F(geomout)
+#define FORTgetembeddatasize      _F(getembeddatasize)
+#define FORTgetembeddata          _F(getembeddata)
+#define FORTopenboundary          _F(openboundary)
+#define FORTfcreate_part5sizefile _F(fcreate_part5sizefile)
+#define FORTgetzonesize           _F(getzonesize)
+#define FORTgetzonedata           _F(getzonedata)
+#define FORTgetxyzdata            _F(getxyzdata)
+#define FORTgetpatchsizes1        _F(getpatchsizes1)
+#define FORTgetpatchsizes2        _F(getpatchsizes2)
+#define FORTgetpatchdata          _F(getpatchdata)
+#define FORTgetdata1              _F(getdata1)
+#define FORTgetsizes              _F(getsizes)
+#define FORTgetsizesa             _F(getsizesa)
+#define FORTgetslicesizes         _F(getslicesizes)
+#define FORTwriteslicedata        _F(writeslicedata)
+#define FORTwriteslicedata2       _F(writeslicedata2)
+#define FORTgetslicedata          _F(getslicedata)
+#define FORTgetplot3dq            _F(getplot3dq)
+#define FORTgetsliceparms         _F(getsliceparms)
+#define FORTcolor2rgb             _F(color2rgb)
+#define FORTget_file_unit         _F(get_file_unit)
+#define FORTclosefortranfile      _F(closefortranfile)
+#define FORTgetboundaryheader1    _F(getboundaryheader1)
+#define FORTgetboundaryheader2    _F(getboundaryheader2)
 
 STDCALLF FORTgetslicefiledirection(int *is1, int *is2, int *js1, int *js2, int *ks1, int *ks2, int *idir, int *joff, int *koff, int *volslice);
 STDCALLF FORTfpoly2tri(float *verts, int *nverts, int *poly, int *npoly, int *tris, int *ntris);

--- a/Source/smokeview/smokefortheaders.h
+++ b/Source/smokeview/smokefortheaders.h
@@ -7,38 +7,38 @@
 #define STDCALLF extern void
 #endif
 
-#define FORTgetslicefiledirection _F(getslicefiledirection)
-#define FORTfpoly2tri _F(fpoly2tri)
-#define FORTget_in_triangle _F(get_in_triangle)
-#define FORTget_is_angle_ge_180 _F(get_is_angle_ge_180)
-#define FORTtest_in_tetra _F(test_in_tetra)
-#define FORTgetverts _F(getverts2)
-#define FORTgettetravol _F(get_tetrabox_volume_fb)
-#define FORTgeomout _F(geomout)
-#define FORTgetembeddatasize _F(getembeddatasize)
-#define FORTgetembeddata _F(getembeddata)
-#define FORTopenboundary _F(openboundary)
-#define FORTfcreate_part5sizefile _F(fcreate_part5sizefile)
-#define FORTgetzonesize _F(getzonesize)
-#define FORTgetzonedata _F(getzonedata)
-#define FORTgetxyzdata _F(getxyzdata)
-#define FORTgetpatchsizes1 _F(getpatchsizes1)
-#define FORTgetpatchsizes2 _F(getpatchsizes2)
-#define FORTgetpatchdata _F(getpatchdata)
-#define FORTgetdata1 _F(getdata1)
-#define FORTgetsizes _F(getsizes)
-#define FORTgetsizesa _F(getsizesa)
-#define FORTgetslicesizes _F(getslicesizes)
-#define FORTwriteslicedata _F(writeslicedata)
-#define FORTwriteslicedata2 _F(writeslicedata2)
-#define FORTgetslicedata _F(getslicedata)
-#define FORTgetplot3dq _F(getplot3dq)
-#define FORTgetsliceparms _F(getsliceparms)
-#define FORTcolor2rgb _F(color2rgb)
-#define FORTget_file_unit _F(get_file_unit)
-#define FORTclosefortranfile _F(closefortranfile)
-#define FORTgetboundaryheader1 _F(getboundaryheader1)
-#define FORTgetboundaryheader2 _F(getboundaryheader2)
+#define FORTgetslicefiledirection getslicefiledirection
+#define FORTfpoly2tri             fpoly2tri
+#define FORTget_in_triangle       get_in_triangle
+#define FORTget_is_angle_ge_180   get_is_angle_ge_180
+#define FORTtest_in_tetra         test_in_tetra
+#define FORTgetverts              getverts2
+#define FORTgettetravol           get_tetrabox_volume_fb
+#define FORTgeomout               geomout
+#define FORTgetembeddatasize      getembeddatasize
+#define FORTgetembeddata          getembeddata
+#define FORTopenboundary          openboundary
+#define FORTfcreate_part5sizefile fcreate_part5sizefile
+#define FORTgetzonesize           getzonesize
+#define FORTgetzonedata           getzonedata
+#define FORTgetxyzdata            getxyzdata
+#define FORTgetpatchsizes1        getpatchsizes1
+#define FORTgetpatchsizes2        getpatchsizes2
+#define FORTgetpatchdata          getpatchdata
+#define FORTgetdata1              getdata1
+#define FORTgetsizes              getsizes
+#define FORTgetsizesa             getsizesa
+#define FORTgetslicesizes         getslicesizes
+#define FORTwriteslicedata        writeslicedata
+#define FORTwriteslicedata2       writeslicedata2
+#define FORTgetslicedata          getslicedata
+#define FORTgetplot3dq            getplot3dq
+#define FORTgetsliceparms         getsliceparms
+#define FORTcolor2rgb             color2rgb
+#define FORTget_file_unit         get_file_unit
+#define FORTclosefortranfile      closefortranfile
+#define FORTgetboundaryheader1    getboundaryheader1
+#define FORTgetboundaryheader2    getboundaryheader2
 
 STDCALLF FORTgetslicefiledirection(int *is1, int *is2, int *js1, int *js2, int *ks1, int *ks2, int *idir, int *joff, int *koff, int *volslice);
 STDCALLF FORTfpoly2tri(float *verts, int *nverts, int *poly, int *npoly, int *tris, int *ntris);

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -515,9 +515,7 @@ void InitOpenGL(void){
   PRINTF("%s",_("   Initializing Glut display mode - "));
 #endif
 #ifdef pp_OSXGLUT32
-#ifdef pp_OSX
   type|=GLUT_3_2_CORE_PROFILE;
-#endif
 #endif
   glutInitDisplayMode(type);
 #ifdef _DEBUG

--- a/Source/smokezip/CNVplot3d.c
+++ b/Source/smokezip/CNVplot3d.c
@@ -9,7 +9,7 @@
 #include "MALLOC.h"
 #include "compress.h"
 
-#define FORTgetplot3dq getplot3dq
+#define FORTgetplot3dq _F(getplot3dq)
 
 STDCALLF FORTgetplot3dq(char *qfilename, int *nx, int *ny, int *nz, float *qq, int *error, int *isotest, FILE_SIZE filelen);
 

--- a/Source/smokezip/CNVplot3d.c
+++ b/Source/smokezip/CNVplot3d.c
@@ -9,7 +9,7 @@
 #include "MALLOC.h"
 #include "compress.h"
 
-#define FORTgetplot3dq _F(getplot3dq)
+#define FORTgetplot3dq getplot3dq
 
 STDCALLF FORTgetplot3dq(char *qfilename, int *nx, int *ny, int *nz, float *qq, int *error, int *isotest, FILE_SIZE filelen);
 

--- a/Source/smokezip/options.h
+++ b/Source/smokezip/options.h
@@ -67,7 +67,6 @@
 
 #ifdef WIN32
 #define pp_noappend
-#define pp_cvf
 #endif
 
 // used to access fortran routines from C

--- a/Source/smokezip/options.h
+++ b/Source/smokezip/options.h
@@ -77,6 +77,7 @@
 #else
 #define _F(name) name
 #endif
+#endif
 
 
 #define FILE_SIZE unsigned long long

--- a/Source/smokezip/options.h
+++ b/Source/smokezip/options.h
@@ -65,18 +65,10 @@
 #define pp_PART2
 #endif
 
-#ifdef WIN32
-#define pp_noappend
-#endif
-
 // used to access fortran routines from C
 
 #ifndef _F
-#ifdef pp_noappend
 #define _F(name) name
-#else
-#define _F(name) name ## _
-#endif
 #endif
 
 #ifdef pp_release

--- a/Source/smokezip/options.h
+++ b/Source/smokezip/options.h
@@ -65,12 +65,6 @@
 #define pp_PART2
 #endif
 
-// used to access fortran routines from C
-
-#ifndef _F
-#define _F(name) name
-#endif
-
 #ifdef pp_release
 #define PROGVERSION "1.4.9"
 #endif

--- a/Source/smokezip/options.h
+++ b/Source/smokezip/options.h
@@ -69,6 +69,15 @@
 #define PROGVERSION "1.4.9"
 #endif
 
+// used to access Fortran routines from C
+
+#ifndef _F
+#ifdef pp_append
+#define _F(name) name ## _
+#else
+#define _F(name) name
+#endif
+
 
 #define FILE_SIZE unsigned long long
 

--- a/Source/smokezip/options.h
+++ b/Source/smokezip/options.h
@@ -69,6 +69,14 @@
 #define PROGVERSION "1.4.9"
 #endif
 
+#ifdef pp_OSX
+#define pp_append
+#endif
+
+#ifdef pp_LINUX
+#define pp_append
+#endif
+
 // used to access Fortran routines from C
 
 #ifndef _F

--- a/Source/smokezip/svzip.h
+++ b/Source/smokezip/svzip.h
@@ -302,18 +302,18 @@ void initvolrender(void);
 void getsliceparms_c(char *file, int *ni, int *nj, int *nk);
 
 
-#define FORTgetpartheader1 _F(getpartheader1)
-#define FORTgetpartheader2 _F(getpartheader2)
-#define FORTgetpartdataframe _F(getpartdataframe)
-#define FORTclosefortranfile _F(closefortranfile)
-#define FORTgetboundaryheader1 _F(getboundaryheader1)
-#define FORTgetboundaryheader2 _F(getboundaryheader2)
-#define FORTopenboundary _F(openboundary)
-#define FORTgetpatchdata _F(getpatchdata)
-#define FORTopenslice _F(openslice)
-#define FORTopenpart _F(openpart)
-#define FORTgetsliceframe _F(getsliceframe)
-#define FORTget_file_unit _F(get_file_unit)
+#define FORTgetpartheader1     getpartheader1
+#define FORTgetpartheader2     getpartheader2
+#define FORTgetpartdataframe   getpartdataframe
+#define FORTclosefortranfile   closefortranfile
+#define FORTgetboundaryheader1 getboundaryheader1
+#define FORTgetboundaryheader2 getboundaryheader2
+#define FORTopenboundary       openboundary
+#define FORTgetpatchdata       getpatchdata
+#define FORTopenslice          openslice
+#define FORTopenpart           openpart
+#define FORTgetsliceframe      getsliceframe
+#define FORTget_file_unit      get_file_unit
 
 #ifdef WIN32
 #define STDCALLF extern void _stdcall

--- a/Source/smokezip/svzip.h
+++ b/Source/smokezip/svzip.h
@@ -302,18 +302,18 @@ void initvolrender(void);
 void getsliceparms_c(char *file, int *ni, int *nj, int *nk);
 
 
-#define FORTgetpartheader1     getpartheader1
-#define FORTgetpartheader2     getpartheader2
-#define FORTgetpartdataframe   getpartdataframe
-#define FORTclosefortranfile   closefortranfile
-#define FORTgetboundaryheader1 getboundaryheader1
-#define FORTgetboundaryheader2 getboundaryheader2
-#define FORTopenboundary       openboundary
-#define FORTgetpatchdata       getpatchdata
-#define FORTopenslice          openslice
-#define FORTopenpart           openpart
-#define FORTgetsliceframe      getsliceframe
-#define FORTget_file_unit      get_file_unit
+#define FORTgetpartheader1     _F(getpartheader1)
+#define FORTgetpartheader2     _F(getpartheader2)
+#define FORTgetpartdataframe   _F(getpartdataframe)
+#define FORTclosefortranfile   _F(closefortranfile)
+#define FORTgetboundaryheader1 _F(getboundaryheader1)
+#define FORTgetboundaryheader2 _F(getboundaryheader2)
+#define FORTopenboundary       _F(openboundary)
+#define FORTgetpatchdata       _F(getpatchdata)
+#define FORTopenslice          _F(openslice)
+#define FORTopenpart           _F(openpart)
+#define FORTgetsliceframe      _F(getsliceframe)
+#define FORTget_file_unit      _F(get_file_unit)
 
 #ifdef WIN32
 #define STDCALLF extern void _stdcall


### PR DESCRIPTION
besides cleanup header files, switch logic to use pp_append to add an underscore to Fortran routine names (rather than not adding an underscore if pp_noappend is set).  Set pp_append in the various options.h header rather than in the makefile when pp_LINUX or pp_OSX directives are set

Jake this shouldn't affect you but let me know if it does.