### PR TITLE
Rearrange case loading code to allow multiple loads.

### DIFF
--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -156,6 +156,7 @@ int loadsmv(char *input_filename, char *input_filename_ext){
   if(input_filename_ext==NULL){
       printf("ERROR: input_filename_ext is NULL\n");
   }
+  simdata *sim;
   fflush(stdout);
   printf("loading smv: %s\n", input_filename);
   printf("ext: %s\n", input_filename_ext);
@@ -178,7 +179,8 @@ int loadsmv(char *input_filename, char *input_filename_ext){
     else{
       input_file=smv_filename;
     }
-    return_code=ReadSMV(input_file,iso_filename);
+
+    return_code=ReadSMV(input_file,iso_filename, sim);
     if(return_code==0){
       show_glui_trainer();
       show_glui_alert();
@@ -186,7 +188,7 @@ int loadsmv(char *input_filename, char *input_filename_ext){
   }
   else{
     input_file=smv_filename;
-    return_code=ReadSMV(input_file,iso_filename);
+    return_code=ReadSMV(input_file,iso_filename, sim);
   }
   switch(return_code){
     case 1:
@@ -527,8 +529,8 @@ char* form_filename(int view_mode, char *renderfile_name, char *renderfile_dir,
 
         snprintf(renderfile_name, 1024,
                   "%s%s%s",
-                  chidfilebase, view_suffix, renderfile_ext);
-        printf("chidfilebase is: %s\n", chidfilebase);
+                  app.simulation->chid, view_suffix, renderfile_ext);
+        printf("app.simulation->chid is: %s\n", app.simulation->chid);
         printf("fdsprefix is: %s\n", fdsprefix);
         printf("directory is: %s\n", renderfile_dir);
         printf("filename is: %s\n", renderfile_name);

--- a/Source/smokeview/camera.c
+++ b/Source/smokeview/camera.c
@@ -46,10 +46,67 @@ void InitCameraList(void){
   ca->next=NULL;
 }
 
-/* ------------------ AddDefaultViews ------------------------ */
+/* --------------------------- InitDefaultViews ----------------------------- */
+// Initialise some default cameras to add to the camera list.
+void InitDefaultViews() {
+  FREEMEMORY(camera_external);
+  NewMemory((void **)&camera_external,sizeof(cameradata));
 
+  FREEMEMORY(camera_external_save);
+  NewMemory((void **)&camera_external_save,sizeof(cameradata));
+
+  FREEMEMORY(camera_ini);
+  NewMemory((void **)&camera_ini,sizeof(cameradata));
+  camera_ini->defined=0;
+
+  FREEMEMORY(camera_current);
+  NewMemory((void **)&camera_current,sizeof(cameradata));
+
+  FREEMEMORY(camera_internal);
+  NewMemory((void **)&camera_internal,sizeof(cameradata));
+
+  FREEMEMORY(camera_save);
+  NewMemory((void **)&camera_save,sizeof(cameradata));
+
+  FREEMEMORY(camera_last);
+  NewMemory((void **)&camera_last,sizeof(cameradata));
+
+  {
+    char name_external[32];
+
+    strcpy(name_external,"external");
+    InitCamera(camera_external,name_external);
+    camera_external->view_id=EXTERNAL_LIST_ID;
+  }
+  if(camera_ini!=NULL&&camera_ini->defined==1){
+    CopyCamera(camera_current,camera_ini);
+  }
+  else{
+    camera_external->zoom=zoom;
+    CopyCamera(camera_current,camera_external);
+  }
+  strcpy(camera_label,camera_current->name);
+  UpdateCameraLabel();
+  {
+    char name_internal[32];
+    strcpy(name_internal,"internal");
+    InitCamera(camera_internal,name_internal);
+  }
+  camera_internal->eye[0]=0.5*xbar;
+  camera_internal->eye[1]=0.5*ybar;
+  camera_internal->eye[2]=0.5*zbar;
+  camera_internal->view_id=0;
+  CopyCamera(camera_save,camera_current);
+  CopyCamera(camera_last,camera_current);
+
+}
+
+/* ------------------ AddDefaultViews ------------------------ */
+// Add default views to the camera list (i.e. external and internal views).
 void AddDefaultViews(void){
   cameradata *cb, *ca;
+
+  InitDefaultViews();
 
   cb=&camera_list_first;
   ca=cb->next;

--- a/Source/smokeview/flowfiles.h
+++ b/Source/smokeview/flowfiles.h
@@ -1433,4 +1433,20 @@ typedef struct {
   texturedata face[6];
 } skyboxdata;
 
+/* --------------------------  simdata ------------------------------------ */
+typedef struct {
+  // all the simulation data goes here
+  // The CHID of the simulation.
+  char *chid;
+  // The filename of the SMV file which is being read.
+  char *smv_filename;
+  // The filename of the input file (i.e. INPF)
+} simdata;
+
+/* --------------------------  appdata ------------------------------------ */
+typedef struct {
+  // All the application data goes here.
+  simdata *simulation;
+} appdata;
+
 #endif

--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -642,6 +642,7 @@ int lua_initsmvdata(lua_State *L) {
 
   lua_get_csvinfo(L);
   // csvinfo is currently on the stack
+
   // add a metatable to it.
   // first create the table
   lua_createtable(L, 0, 1);
@@ -651,7 +652,7 @@ int lua_initsmvdata(lua_State *L) {
   lua_setmetatable(L, -2);
   lua_setglobal(L, "csvinfo");
 
-  lua_pushstring(L, chidfilebase);
+  lua_pushstring(L, app.simulation->chid);
   lua_setglobal(L, "chid");
 
   // lua_get_geomdata(L);
@@ -1018,8 +1019,8 @@ int lua_get_csvinfo(lua_State *L) {
     lua_pushboolean(L, csvinfo[i].display);
     lua_setfield(L, -2, "display");
 
-
     lua_settable(L, -3);
+
   }
   return 1;
 }
@@ -4330,7 +4331,7 @@ void addLuaPaths(lua_State *L) {
   return;
 }
 
-void initLua() {
+lua_State *initLua() {
   L = luaL_newstate();
 
   luaL_openlibs(L);
@@ -4847,6 +4848,7 @@ void initLua() {
   luaL_dostring(L, "require(\"smv\")");
   // luaL_loadfile(L, "smv.lua");
   // int luaL_1dofile (lua_State *L, const char *filename);
+  return L;
 
 }
 

--- a/Source/smokeview/lua_api.h
+++ b/Source/smokeview/lua_api.h
@@ -1,7 +1,7 @@
 #include "lua.h"
 
 int lua_render(lua_State  *L);
-void initLua();
+lua_State *initLua();
 
 int load_script(char *filename);
 int loadLuaScript(char *filename);
@@ -12,3 +12,4 @@ int runSSFScript();
 void runScriptString(char *string);
 int lua_get_sliceinfo(lua_State *L);
 int lua_get_csvinfo(lua_State *L);
+int lua_initsmvdata(lua_State *L);

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -761,20 +761,19 @@ int main(int argc, char **argv){
   // to free the memory it uses. SetupCase can currently be run multiple times
   // (pending memory leaks).
   simdata *sim1 = SetupCase(smv_filename);
-  simdata *sim2 = SetupCase(smv_filename);
+  // Free the original case we read in.
   FreeCase(sim1);
-  FreeCase(sim2);
+  // Load a new case (the same case again here)
+  simdata *sim2 = SetupCase(smv_filename);
   // InitGUI is run once to set up the GUI. It should always go before SetupCase
   // but currently cannot due to errors.
   InitGUI();
   // Setup GUI updates the GUI (which was initilialised with InitGUI) with the
   // information of the current case.
-  simdata *sim = SetupCase("room_fire.smv");
-  SetupGUI(sim);
-  // sim = SetupCase(argc,argv_sv);
+  SetupGUI(sim2);
   // This simulation data is then assigned to the current simulation field of
   // the app.
-  AssignCase(sim);
+  AssignCase(sim2);
   // If SetupCase fails it returns NULL. Therefore we will have assigned a NULL
   // case and we can exit with an error.
   if(app.simulation==NULL)exit(1);

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -224,7 +224,6 @@ void ParseCommandline(int argc, char **argv){
     exit(1);
   }
   if(strncmp(argv[1], "-ini", 3) == 0){
-    InitCameraList();
     InitOpenGL();
     UpdateRGBColors(COLORBAR_INDEX_NONE);
     WriteINI(GLOBAL_INI, NULL);
@@ -232,7 +231,6 @@ void ParseCommandline(int argc, char **argv){
   }
 
   if(strncmp(argv[1], "-ng_ini", 6) == 0){
-    InitCameraList();
     use_graphics = 0;
     UpdateRGBColors(COLORBAR_INDEX_NONE);
     WriteINI(GLOBAL_INI, NULL);
@@ -678,16 +676,36 @@ void ParseCommandline(int argc, char **argv){
   }
 }
 
+// The application data struct needs to be global.
+appdata app = {0};
+int SetupGUI(simdata *sim);
+int InitGUI();
+
+int FreeCase(simdata *sim) {
+  FREEMEMORY(sim->chid);
+  FREEMEMORY(sim->smv_filename);
+  FREEMEMORY(sim);
+  return 0;
+}
+
+int AssignCase(simdata *sim) {
+  app.simulation = sim;
+  return 0;
+}
+
 /* ------------------ main ------------------------ */
 
 int main(int argc, char **argv){
   char **argv_sv;
   int return_code;
   char *progname;
-
   SetStdOut(stdout);
   initMALLOC();
   InitRandAB(1000000);
+  // InitCameraList simply allocates 2 nodes in a doubly linked list for use as
+  // the camera list. It does not initialise any cameras.
+  InitCameraList();
+  // Initialise various global variables.
   InitVars();
   if(argc==1)DisplayVersionInfo("Smokeview ");
   CopyArgs(&argc, argv, &argv_sv);
@@ -704,7 +722,6 @@ int main(int argc, char **argv){
     PRINTVERSION("smokeview", argv_sv[0]);
     return 1;
   }
-
   prog_fullpath = progname;
 #ifdef pp_LUA
   smokeview_bindir_abs=getprogdirabs(progname,&smokeviewpath);
@@ -729,16 +746,49 @@ int main(int argc, char **argv){
   START_TIMER(startup_time);
   START_TIMER(read_time_elapsed);
 
-#ifdef pp_LUA
-  // Initialise the lua interpreter, it does not take control at this point
-  initLua();
+  InitUnits();
+#ifdef pp_LANG
+  InitLang();
 #endif
-  return_code= SetupCase(argc,argv_sv);
-  if(return_code==0&&update_bounds==1)return_code=Update_Bounds();
-  if(return_code!=0)return 1;
+
+  // SetupCase builds all of the information in a struct for the case, allocates
+  // it and returns a pointer to it. All of the information relevant to this
+  // case is owned by this struct. SetupCase allocates a case totally
+  // independent of any existing case. While there are some globals, in future
+  // it should be possible to hold multiple simulations in memory. Once the
+  // simulation is held in memory it is assigned to be display using the
+  // AssignCase function. TODO: this will also require an UnSetupCase function
+  // to free the memory it uses. SetupCase can currently be run multiple times
+  // (pending memory leaks).
+  simdata *sim1 = SetupCase(smv_filename);
+  simdata *sim2 = SetupCase(smv_filename);
+  FreeCase(sim1);
+  FreeCase(sim2);
+  // InitGUI is run once to set up the GUI. It should always go before SetupCase
+  // but currently cannot due to errors.
+  InitGUI();
+  // Setup GUI updates the GUI (which was initilialised with InitGUI) with the
+  // information of the current case.
+  simdata *sim = SetupCase("room_fire.smv");
+  SetupGUI(sim);
+  // sim = SetupCase(argc,argv_sv);
+  // This simulation data is then assigned to the current simulation field of
+  // the app.
+  AssignCase(sim);
+  // If SetupCase fails it returns NULL. Therefore we will have assigned a NULL
+  // case and we can exit with an error.
+  if(app.simulation==NULL)exit(1);
+  // Update the bounds, this can probably go under the setup case function.
+  if(update_bounds==1)return_code=Update_Bounds();
   if(convert_ini==1){
     ReadINI(ini_from);
   }
+#ifdef pp_LUA
+  // Initialise the lua interpreter, it does not take control at this point
+  lua_State *L = initLua();
+  lua_initsmvdata(L);
+#endif
+
 
   STOP_TIMER(startup_time);
   PRINTF("\nStartup time: %.1f s\n", startup_time);

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -4688,8 +4688,7 @@ int ReadSMV(char *file, char *file2, simdata *sim){
 
       csvi->loaded=0;
       csvi->display=0;
-      NewMemory((void **)&csvi->key,strlen(type_ptr)+1);
-      strcpy(csvi->key,type_ptr);
+
       if(strcmp(type_ptr,"hrr")==0){
         if(FILE_EXISTS_CASEDIR(file_ptr)==YES){
           csvi->type=CSVTYPE_HRR;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -1710,7 +1710,7 @@ void ParseDevicekeyword2(FILE *stream, devicedata *devicei){
 
 /* ------------------ GetInpf ------------------------ */
 
-int GetInpf(char *file, char *file2){
+int GetInpf(char *file, char *file2, simdata *sim){
   FILE *stream=NULL,*stream1=NULL,*stream2=NULL;
   char buffer[255],*bufferptr;
   int len;
@@ -1747,34 +1747,33 @@ int GetInpf(char *file, char *file2){
       if(FILE_EXISTS_CASEDIR(fds_filein)==NO){
         FreeMemory(fds_filein);
       }
-
-      if(chidfilebase==NULL){
+      if(sim->chid==NULL){
         char *chidptr=NULL;
         char buffer_chid[1024];
 
         if(fds_filein!=NULL)chidptr=GetChid(fds_filein,buffer_chid);
         if(chidptr!=NULL){
-          NewMemory((void **)&chidfilebase,(unsigned int)(strlen(chidptr)+1));
-          STRCPY(chidfilebase,chidptr);
+          NewMemory((void **)&sim->chid,(unsigned int)(strlen(chidptr)+1));
+          STRCPY(sim->chid,chidptr);
         }
       }
-      if(chidfilebase!=NULL){
-        NewMemory((void **)&hrr_csv_filename,(unsigned int)(strlen(chidfilebase)+8+1));
-        STRCPY(hrr_csv_filename,chidfilebase);
+      if(sim->chid!=NULL){
+        NewMemory((void **)&hrr_csv_filename,(unsigned int)(strlen(sim->chid)+8+1));
+        STRCPY(hrr_csv_filename,sim->chid);
         STRCAT(hrr_csv_filename,"_hrr.csv");
         if(FILE_EXISTS_CASEDIR(hrr_csv_filename)==NO){
           FREEMEMORY(hrr_csv_filename);
         }
 
-        NewMemory((void **)&devc_csv_filename,(unsigned int)(strlen(chidfilebase)+9+1));
-        STRCPY(devc_csv_filename,chidfilebase);
+        NewMemory((void **)&devc_csv_filename,(unsigned int)(strlen(sim->chid)+9+1));
+        STRCPY(devc_csv_filename,sim->chid);
         STRCAT(devc_csv_filename,"_devc.csv");
         if(FILE_EXISTS_CASEDIR(devc_csv_filename)==NO){
           FREEMEMORY(devc_csv_filename);
         }
 
-        NewMemory((void **)&exp_csv_filename,(unsigned int)(strlen(chidfilebase)+8+1));
-        STRCPY(exp_csv_filename,chidfilebase);
+        NewMemory((void **)&exp_csv_filename,(unsigned int)(strlen(sim->chid)+8+1));
+        STRCPY(exp_csv_filename,sim->chid);
         STRCAT(exp_csv_filename,"_exp.csv");
         if(FILE_EXISTS_CASEDIR(exp_csv_filename)==NO){
           FREEMEMORY(exp_csv_filename);
@@ -3462,8 +3461,10 @@ void MakeFileLists(void){
 }
 
 /* ------------------ ReadSMV ------------------------ */
-
-int ReadSMV(char *file, char *file2){
+// Takes the simdata as a final argument. By only assigning to variables under
+// the sim, and not to any globals, control is maintained on where the data
+// lies.
+int ReadSMV(char *file, char *file2, simdata *sim){
 
 /* read the .smv file */
   float read_time, processing_time, wrapup_time, getfilelist_time;
@@ -3585,30 +3586,6 @@ int ReadSMV(char *file, char *file2){
   ntickinfo=0;
   ntickinfo_smv=0;
 
-  FREEMEMORY(camera_external);
-  if(file!=NULL)NewMemory((void **)&camera_external,sizeof(cameradata));
-
-  FREEMEMORY(camera_external_save);
-  if(file!=NULL)NewMemory((void **)&camera_external_save,sizeof(cameradata));
-
-  FREEMEMORY(camera_ini);
-  if(file!=NULL){
-    NewMemory((void **)&camera_ini,sizeof(cameradata));
-    camera_ini->defined=0;
-  }
-
-  FREEMEMORY(camera_current);
-  if(file!=NULL)NewMemory((void **)&camera_current,sizeof(cameradata));
-
-  FREEMEMORY(camera_internal);
-  if(file!=NULL)NewMemory((void **)&camera_internal,sizeof(cameradata));
-
-  FREEMEMORY(camera_save);
-  if(file!=NULL)NewMemory((void **)&camera_save,sizeof(cameradata));
-
-  FREEMEMORY(camera_last);
-  if(file!=NULL)NewMemory((void **)&camera_last,sizeof(cameradata));
-
   updatefaces=1;
   nfires=0;
   nrooms=0;
@@ -3668,8 +3645,7 @@ int ReadSMV(char *file, char *file2){
     int return_code;
 
   // get input file name
-
-    return_code=GetInpf(file,file2);
+    return_code=GetInpf(file,file2,sim);
     if(return_code!=0)return return_code;
   }
 
@@ -3792,6 +3768,24 @@ int ReadSMV(char *file, char *file2){
     FREEMEMORY(isoinfo);
   }
   nisoinfo=0;
+
+  // Free plot3dinfo
+  if(nplot3dinfo>0){
+    int n;
+
+    for(i=0;i<nplot3dinfo;i++){
+      plot3ddata *plot3di;
+
+      plot3di = plot3dinfo + i;
+      for(n=0;n<6;n++){
+        FreeLabels(&plot3di->label[n]);
+      }
+      FREEMEMORY(plot3di->reg_file);
+      FREEMEMORY(plot3di->comp_file);
+    }
+//    FREEMEMORY(plot3dinfo);
+  }
+  nplot3dinfo=0;
 
   FreeCADInfo();
 
@@ -4694,7 +4688,8 @@ int ReadSMV(char *file, char *file2){
 
       csvi->loaded=0;
       csvi->display=0;
-
+      NewMemory((void **)&csvi->key,strlen(type_ptr)+1);
+      strcpy(csvi->key,type_ptr);
       if(strcmp(type_ptr,"hrr")==0){
         if(FILE_EXISTS_CASEDIR(file_ptr)==YES){
           csvi->type=CSVTYPE_HRR;
@@ -7964,13 +7959,13 @@ typedef struct {
       }
       bufferptr=TrimFrontBack(buffer);
       len=strlen(bufferptr);
-      FREEMEMORY(chidfilebase);
-      NewMemory((void **)&chidfilebase,(unsigned int)(len+1));
-      STRCPY(chidfilebase,bufferptr);
+      FREEMEMORY(sim->chid);
+      NewMemory((void **)&(sim->chid),(unsigned int)(len+1));
+      STRCPY(sim->chid,bufferptr);
 
-      if(chidfilebase!=NULL){
-        NewMemory((void **)&hrr_csv_filename,(unsigned int)(strlen(chidfilebase)+8+1));
-        STRCPY(hrr_csv_filename,chidfilebase);
+      if(sim->chid!=NULL){
+        NewMemory((void **)&hrr_csv_filename,(unsigned int)(strlen(sim->chid)+8+1));
+        STRCPY(hrr_csv_filename,sim->chid);
         STRCAT(hrr_csv_filename,"_hrr.csv");
         if(FILE_EXISTS_CASEDIR(hrr_csv_filename)==NO){
           FREEMEMORY(hrr_csv_filename);
@@ -11259,7 +11254,6 @@ int ReadINI2(char *inifile, int localfile){
       TrimBack(buffer);
       bufferptr = TrimFront(buffer);
       strcpy(camera_ini->name, bufferptr);
-      InitCameraList();
       InsertCamera(&camera_list_first, camera_ini, bufferptr);
 
       EnableResetSavedView();

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -758,7 +758,7 @@ EXTERNCPP void AdjustPlot3DBounds(int iplot3d, int setpmin, float *pmin, int set
 EXTERNCPP void ScaleFloat2String(float floatfrom, char *stringto, const float *scale);
 EXTERNCPP void ScaleString(const char *stringfrom, char *stringto, const float *scale);
 EXTERNCPP void Num2String(char *string, float tval);
-EXTERNCPP int SetupCase(int argc, char **argv);
+EXTERNCPP simdata *SetupCase(char *input_path);
 EXTERNCPP int GetMinPartFrames(int flag);
 EXTERNCPP int Update_Bounds(void);
 
@@ -788,10 +788,11 @@ EXTERNCPP void ReadSmoke3D(int ifile,int flag, int *errorcode);
 EXTERNCPP void ReadFed(int ifile, int flag, int file_type, int *errorcode);
 EXTERNCPP void ReadSlice(char *file, int ifile, int flag, int set_slicecolor, int *errorcode);
 EXTERNCPP void readiso(const char *file, int ifile, int flag, int *geom_frame_index, int *errorcode);
+EXTERNCPP void InitLang(void);
 
 EXTERNCPP void InitMenus(int unload);
 EXTERNCPP void SmoothLabel(float *min, float *max, int n);
-EXTERNCPP int ReadSMV(char *file, char *file2);
+EXTERNCPP int ReadSMV(char *file, char *file2, simdata *sim);
 EXTERNCPP void ReadSMVDynamic(char *file);
 EXTERNCPP int STRCMP(const char *s1, const char *s2);
 EXTERNCPP void OutputAxisLabels(void);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -1161,6 +1161,8 @@ SVEXTERN char SVDECL(*fdsprefix,NULL), SVDECL(*fdsprefix2,NULL);
 SVEXTERN char SVDECL(*endian_filename,NULL);
 SVEXTERN char SVDECL(*target_filename,NULL);
 
+SVEXTERN appdata app;
+
 SVEXTERN int SVDECL(update_bounds,0);
 SVEXTERN int SVDECL(*sorted_surfidlist,NULL),SVDECL(*inv_sorted_surfidlist,NULL),nsorted_surfidlist;
 SVEXTERN char SVDECL(*trainer_filename,NULL), SVDECL(*test_filename,NULL);


### PR DESCRIPTION
This is more of a discussion piece and this code needn't necessarily be merged.

This seems to be the minimum amount of changes necessary to allow for multiple different Smokeview cases to be loaded and unloaded.  The purpose of this patch is to determine which parts of  the logic would need to be changed to support this. This patch has been tested to load multiple times and works, but hasn't been tested exhaustively.

The main architectural difference that needs to occur is to distinguish between initialisation procedures that need to occur for Smokeview itself, and initialisations that occur only for a particular case. If app-wide initialisations are run multiple times they result in errors, as they weren't designed to be run multiple times. In this patch these initialisations were moved from the read procedure into the `main` function, alongside other app-wide initialisation procedures.

For language and unit initialisations this was simple, but cameras were troublesome because of the way the read procedure interacted with the camera list. In this patch the camera list is initialised in the main function along with all the other initialisations, and then specific cameras, include default cameras, are loaded and added to the list as part of the case loading procedure.

This patch also includes two new data structures that are currently fairly empty, by represent this splitting of application initialisation and case initialisation. Notice that the simdata  struct, which is for case data, is created when setting up an new case and is passed to `ReadSMV`, which takes the smv file and populates this struct. The `appdata` contains all of the data for the application itself. By doing this we can enforce this application/case division by ensuring that loading the case only affects data in the `simdata` struct, and the loading of the application doesn't interact the the case data.

The logic should go like this:

1. Start the application.
2. Initialise application data such as global variables and data structures.
3. Parse commandline information.
4. Initialise GUI.
5. Read in case data from an .smv file and store it in a new struct.
6. Assign this case data to be the current data.
7. Update the GUI to relate to this case.
8. To load a new case repeat steps 5-7.

There is a single application wide data structure (`appdata`) that will hold most of the current global variables that define the state of the program. This also contains a field pointing to the currently loaded case.

Simulation cases can be read into data structures (`simdata`, of which there may be multiple), which can then be loaded as the current simulation (setting the current simulation case in the `appdata`).

If this makes sense architecturally I will continue to develop it more. It's still at very early stages, I just want to see if this approach is agreeable.