### PR TITLE
dummy commit - git describe doesn't work consistently when there are …

### DIFF
--- a/Source/smokebot_trigger.txt
+++ b/Source/smokebot_trigger.txt
@@ -1,1 +1,1 @@
-  dummy text to trigger smokebot
+   dummy text to trigger smokebot


### PR DESCRIPTION
…zero commits from a tag