### PR TITLE
smokeview source: obtain header info from .sf files (used to generate…

### DIFF
--- a/Source/smokeview/getdata.f90
+++ b/Source/smokeview/getdata.f90
@@ -400,6 +400,40 @@ end subroutine getsliceparms
 
 !  ------------------ getslicesizes ------------------------
 
+subroutine getsliceheader(slicefilename, ip1, ip2, jp1, jp2, kp1, kp2, error)
+use cio
+implicit none
+
+character(len=*), intent(in) :: slicefilename
+integer, intent(out) :: ip1, ip2, jp1, jp2, kp1, kp2
+integer, intent(out) :: error
+
+logical :: exists
+integer :: lu11, nsizes, sizes(3)
+
+error=0
+inquire(file=trim(slicefilename),exist=exists)
+if(exists)then
+  open(newunit=lu11,file=trim(slicefilename),form="unformatted",action="read")
+ else
+  error=1
+  return
+endif
+
+sizes(1) = 30
+sizes(2) = 30
+sizes(3) = 30
+nsizes = 3
+
+call ffseek(lu11,sizes,nsizes,seek_set,error)
+
+read(lu11,iostat=error)ip1, ip2, jp1, jp2, kp1, kp2
+close(lu11)
+
+end subroutine getsliceheader
+   
+!  ------------------ getslicesizes ------------------------
+
 subroutine getslicesizes(slicefilename, nslicei, nslicej, nslicek, nsteps, sliceframestep,&
    error, settmin_s, settmax_s, tmin_s, tmax_s, headersize, framesize)
 use cio

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -8041,6 +8041,7 @@ typedef struct {
       int blocknumber;
       slicedata *sd;
       size_t len;
+      int read_slice_header=0;
 
       if(setup_only == 1)continue;
 
@@ -8052,7 +8053,10 @@ typedef struct {
       }
 
       sliceparms=strchr(buffer,'&');
-      if(sliceparms!=NULL){
+      if(sliceparms==NULL){
+        read_slice_header=1;
+      }
+      else{
         sliceparms++;
         sliceparms[-1]=0;
         sscanf(sliceparms,"%i %i %i %i %i %i",&ii1,&ii2,&jj1,&jj2,&kk1,&kk2);
@@ -8213,6 +8217,11 @@ typedef struct {
         lenslicelabel=strlen(slicelabel)+1;
         NewMemory((void **)&sd->slicelabel,lenslicelabel);
         strcpy(sd->slicelabel,slicelabel);
+      }
+      if(read_slice_header==1){
+        int error;
+
+        FORTgetsliceheader(sd->file,&ii1,&ii2,&jj1,&jj2,&kk1,&kk2,&error,strlen(sd->file));
       }
 #ifdef pp_SLICELOAD
       sd->is1=ii1;

--- a/Source/smokeview/smokefortheaders.h
+++ b/Source/smokeview/smokefortheaders.h
@@ -7,6 +7,7 @@
 #define STDCALLF extern void
 #endif
 
+#define FORTgetsliceheader        _F(getsliceheader)
 #define FORTgetslicefiledirection _F(getslicefiledirection)
 #define FORTfpoly2tri             _F(fpoly2tri)
 #define FORTget_in_triangle       _F(get_in_triangle)
@@ -75,6 +76,7 @@ STDCALLF FORTgetpatchdata(int *lunit, int *npatch,int *pi1,int *pi2,int *pj1,int
 STDCALLF FORTskipdata(int *lunit, int *size);
 STDCALLF FORTgetdata1(int *file_unit, int *ipart, int *error);
 
+STDCALLF FORTgetsliceheader(char *slicefilename, int *is1, int *is2, int *js1, int *js2, int *ks1, int *ks2, int *error, FILE_SIZE slicefilelen);
 STDCALLF FORTgetslicesizes(char *slicefilename, int *nslicei, int *nslicej, int *nslicek,
                           int *nsteps,int *sliceframestep, int *error,
                           int *settime_p, int *settmax_p, float *tmin_p, float *tmax_p,


### PR DESCRIPTION
… slice file menus) if not found in the .smv file (generated by an older version of fds)