### PR TITLE
smokeview cleanup

### DIFF
--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -244,7 +244,7 @@ intel_linux_64_db : $(obj)
 # ------------- gnu_linux_64_db ----------------
 
 gnu_linux_64_db : FFLAGS    = -O0 -m64 -ggdb -Wall -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4 -fcheck=all -fbacktrace
-gnu_linux_64_db : CFLAGS    = -O0 -m64 -ggdb -Wall -Wno-parentheses -Wno-unknown-pragmas -Wno-comment -Wno-write-strings -D _DEBUG -D pp_LINUX -D pp_GCC $(GNU_COMPINFO) $(GITINFO)
+gnu_linux_64_db : CFLAGS    = -O0 -m64 -ggdb -Wall -Wno-parentheses -Wno-unknown-pragmas -Wno-comment -Wno-write-strings -D _DEBUG -D pp_LINUX -D pp_GCC $(SMV_TESTFLAG) $(GNU_COMPINFO) $(GITINFO)
 gnu_linux_64_db : LFLAGS    = -m64
 gnu_linux_64_db : CC        = gcc
 gnu_linux_64_db : CPP       = g++
@@ -259,7 +259,7 @@ gnu_linux_64_db : $(obj)
 gnu_linux_64 : LIB_DIR_PLAT = $(LIB_DIR)/gnu_linux_64
 gnu_linux_64 : LIBS_PLAT =
 gnu_linux_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form -frecord-marker=4
-gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_GCC -Wno-write-strings $(GNU_COMPINFO) $(GITINFO)
+gnu_linux_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D pp_GCC $(SMV_TESTFLAG) -Wno-write-strings $(GNU_COMPINFO) $(GITINFO)
 ifeq ($(LUA_SCRIPTING),true)
 gnu_linux_64 : CFLAGS    += -D pp_LUA
 gnu_linux_64 : LIBS_PLAT += $(LIB_DIR_PLAT)/lua53.a

--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -370,7 +370,7 @@ intel_osx_64_db : $(obj)
 # ------------- gnu_osx_64_db ----------------
 
 gnu_osx_64_db : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form
-gnu_osx_64_db : CFLAGS    = -O0 -m64 -D _DEBUG -D pp_OSX -D pp_GCC -Wno-deprecated-declarations -Wno-write-strings $(GNU_COMPINFO) $(GITINFO)
+gnu_osx_64_db : CFLAGS    = -O0 -m64 -D _DEBUG -D pp_OSX -D pp_GCC $(SMV_TESTFLAG) -Wno-deprecated-declarations -Wno-write-strings $(GNU_COMPINFO) $(GITINFO)
 gnu_osx_64_db : LFLAGS    = -m64 -framework OpenGL -framework GLUT
 gnu_osx_64_db : CC        = gcc
 gnu_osx_64_db : CPP       = g++
@@ -383,7 +383,7 @@ gnu_osx_64_db : $(obj)
 # ------------- gnu_osx_64 ----------------
 
 gnu_osx_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -ffree-form
-gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_OSX -D pp_GCC -Wno-write-strings $(GNU_COMPINFO) $(GITINFO)
+gnu_osx_64 : CFLAGS    = -O0 -m64 -D pp_OSX -D pp_GCC $(SMV_TESTFLAG) -Wno-write-strings $(GNU_COMPINFO) $(GITINFO)
 gnu_osx_64 : LFLAGS    = -m64 -framework OpenGL -framework GLUT
 gnu_osx_64 : CC        = gcc
 gnu_osx_64 : CPP       = g++

--- a/Build/smokeview/gnu_linux_64/make_smokeview.sh
+++ b/Build/smokeview/gnu_linux_64/make_smokeview.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+source ../../scripts/setopts.sh $*
+
 LIBDIR=../../LIBS/gnu_linux_64/
 source ../../scripts/test_libs.sh
 
 make -f ../Makefile clean
-eval make -j 4 -f ../Makefile gnu_linux_64
-
+eval make ${SMV_MAKE_OPTS} -f ../Makefile gnu_linux_64

--- a/Build/smokeview/gnu_linux_64/make_smokeview_db.sh
+++ b/Build/smokeview/gnu_linux_64/make_smokeview_db.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+source ../../scripts/setopts.sh $*
+
 LIBDIR=../../LIBS/gnu_linux_64/
 source ../../scripts/test_libs.sh
 
 make -f ../Makefile clean
-eval make -j 4 -f ../Makefile gnu_linux_64_db
-
+eval make ${SMV_MAKE_OPTS} -f ../Makefile gnu_linux_64_db

--- a/Build/smokeview/gnu_osx_64/make_smokeview.sh
+++ b/Build/smokeview/gnu_osx_64/make_smokeview.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
-rm -rf *.o *.mod
+LIBDIR=../../LIBS/gnu_osx_64/
+source ../../scripts/test_libs.sh
+
+make -f ../Makefile clean
 make -f ../Makefile gnu_osx_64

--- a/Build/smokeview/gnu_osx_64/make_smokeview.sh
+++ b/Build/smokeview/gnu_osx_64/make_smokeview.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+source ../../scripts/setopts.sh $*
+
 LIBDIR=../../LIBS/gnu_osx_64/
 source ../../scripts/test_libs.sh
 
 make -f ../Makefile clean
-make -f ../Makefile gnu_osx_64
+eval make ${SMV_MAKE_OPTS} -f ../Makefile gnu_osx_64

--- a/Build/smokeview/gnu_osx_64/make_smokeview_db.sh
+++ b/Build/smokeview/gnu_osx_64/make_smokeview_db.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
-rm -rf *.o *.mod
-make -f ../Makefile gnu_osx_64_db
+source ../../scripts/setopts.sh $*
+
+LIBDIR=../../LIBS/gnu_osx_64/
+source ../../scripts/test_libs.sh
+
+make -f ../Makefile clean
+eval make ${SMV_MAKE_OPTS} -f ../Makefile gnu_osx_64_db

--- a/Source/smokeview/IOobject.c
+++ b/Source/smokeview/IOobject.c
@@ -6242,7 +6242,7 @@ void DeviceData2WindRose(int nr, int ntheta, int flag){
         for (j = 0; j < nvdeviceinfo; j++) {
           vdevicedata *vdevicej;
           devicedata *angledevj, *veldevj;
-          float *xyzj, rminj, rmaxj;
+          float *xyzj;
 
           vdevicej = vdeviceinfo + j;
           angledevj = vdevicej->angledev;

--- a/Source/smokeview/IOslice.c
+++ b/Source/smokeview/IOslice.c
@@ -2608,14 +2608,8 @@ void UpdateSliceDirCount(void){
 
 void GetSliceParams(void){
   int i;
-#ifndef pp_SLICELOAD
-  char *file;
-#endif
   int error;
 
-#ifndef pp_SLICELOAD
-  FILE_SIZE  lenfile;
-#endif
   int build_cache=0;
   FILE *stream;
 
@@ -2642,10 +2636,6 @@ void GetSliceParams(void){
     }
 #endif
 
-#ifndef pp_SLICELOAD
-    file = sd->file;
-    lenfile = strlen(file);
-#endif
     if(sd->compression_type==UNCOMPRESSED){
       int doit_anyway;
 
@@ -2665,9 +2655,7 @@ void GetSliceParams(void){
         error=0;
       }
       if(build_cache==1||stream==NULL||doit_anyway==1){
-#ifdef pp_SLICELOAD
         int idir, joff, koff, volslice;
-#endif
 
         is1=sd->is1;
         is2=sd->is2;
@@ -2675,7 +2663,6 @@ void GetSliceParams(void){
         js2=sd->js2;
         ks1=sd->ks1;
         ks2=sd->ks2;
-#ifdef pp_SLICELOAD
         FORTgetslicefiledirection(&is1, &is2, &iis1, &iis2, &js1, &js2, &ks1, &ks2, &idir, &joff, &koff,&volslice);
         if(volslice == 1){
           is1 = iis1;
@@ -2686,14 +2673,6 @@ void GetSliceParams(void){
         nk = ks2+1-ks1;
         sd->volslice = volslice;
         error = 0;
-#else
-        ni = is2+1-is1;
-        nj = js2+1-js1;
-        nk = ks2+1-ks1;
-        sd->volslice = 0;
-        if(is1<=0||is2<0||js1<0||js2<0||ks1<0||ks2<0)FORTgetsliceparms(file,
-          &is1,&is2,&js1,&js2,&ks1,&ks2,&ni,&nj,&nk,&sd->volslice,&error,lenfile);
-#endif
         if(stream!=NULL&&doit_anyway==0)fprintf(stream,"%i %i %i %i %i %i %i %i %i %i %i\n",sd->seq_id,is1,is2,js1,js2,ks1,ks2,ni,nj,nk,sd->volslice);
       }
     }

--- a/Source/smokeview/glui_geometry.cpp
+++ b/Source/smokeview/glui_geometry.cpp
@@ -359,179 +359,181 @@ extern "C" void GluiGeometrySetup(int main_window){
   EDIT_zmin->set_float_limits(zplt_orig[0],zplt_orig[kbar],GLUI_LIMIT_CLAMP);
   EDIT_zmax->set_float_limits(zplt_orig[0],zplt_orig[kbar],GLUI_LIMIT_CLAMP);
 
-#ifdef pp_GEOMTEST
-  ROLLOUT_unstructured = glui_geometry->add_rollout("Immersed",false);
-  if(unstructured_isopen==1)ROLLOUT_unstructured->open();
+  if(ngeominfo > 0){
+    ROLLOUT_unstructured = glui_geometry->add_rollout("Immersed", false);
+    if(unstructured_isopen == 1)ROLLOUT_unstructured->open();
 
-  for(i=0;i<nmeshes;i++){
-    meshdata *meshi;
+    for(i = 0;i < nmeshes;i++){
+      meshdata *meshi;
 
-    meshi = meshinfo + i;
-    if(meshi->ncutcells>0){
-      glui_geometry->add_checkbox_to_panel(ROLLOUT_unstructured,_d("Show cutcells"),&show_cutcells);
-      break;
+      meshi = meshinfo + i;
+      if(meshi->ncutcells > 0){
+        glui_geometry->add_checkbox_to_panel(ROLLOUT_unstructured, _d("Show cutcells"), &show_cutcells);
+        break;
+      }
     }
-  }
 
-  PANEL_geom_showhide = glui_geometry->add_panel_to_panel(ROLLOUT_unstructured, "", GLUI_PANEL_NONE);
-  PANEL_group1 = glui_geometry->add_panel_to_panel(PANEL_geom_showhide, "", GLUI_PANEL_NONE);
-  PANEL_triangles = glui_geometry->add_panel_to_panel(PANEL_group1,"faces");
-  CHECKBOX_faces_interior = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "interior", &show_faces_interior);
-  CHECKBOX_faces_exterior = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "exterior", &show_faces_exterior);
-  CHECKBOX_surface_solid = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "solid", &show_faces_solid, VOL_SHOWHIDE, VolumeCB);
-  PANEL_geom_transparency = glui_geometry->add_panel_to_panel(PANEL_triangles, "transparency");
-  CHECKBOX_geom_force_transparent = glui_geometry->add_checkbox_to_panel(PANEL_geom_transparency, "force", &geom_force_transparent);
-  SPINNER_geom_transparency = glui_geometry->add_spinner_to_panel(PANEL_geom_transparency, "level", GLUI_SPINNER_FLOAT, &geom_transparency);
-  SPINNER_geom_transparency->set_float_limits(0.0,1.0);
-  CHECKBOX_surface_outline = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "outline", &show_faces_outline, VOL_SHOWHIDE, VolumeCB);
-  glui_geometry->add_spinner_to_panel(PANEL_geom_transparency, "outline width", GLUI_SPINNER_FLOAT, &geom_outline_width);
-  CHECKBOX_smooth_geom_normal = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "smooth", &smooth_geom_normal);
+    PANEL_geom_showhide = glui_geometry->add_panel_to_panel(ROLLOUT_unstructured, "", GLUI_PANEL_NONE);
+    PANEL_group1 = glui_geometry->add_panel_to_panel(PANEL_geom_showhide, "", GLUI_PANEL_NONE);
+    PANEL_triangles = glui_geometry->add_panel_to_panel(PANEL_group1, "faces");
+    CHECKBOX_faces_interior = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "interior", &show_faces_interior);
+    CHECKBOX_faces_exterior = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "exterior", &show_faces_exterior);
+    CHECKBOX_surface_solid = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "solid", &show_faces_solid, VOL_SHOWHIDE, VolumeCB);
+    PANEL_geom_transparency = glui_geometry->add_panel_to_panel(PANEL_triangles, "transparency");
+    CHECKBOX_geom_force_transparent = glui_geometry->add_checkbox_to_panel(PANEL_geom_transparency, "force", &geom_force_transparent);
+    SPINNER_geom_transparency = glui_geometry->add_spinner_to_panel(PANEL_geom_transparency, "level", GLUI_SPINNER_FLOAT, &geom_transparency);
+    SPINNER_geom_transparency->set_float_limits(0.0, 1.0);
+    CHECKBOX_surface_outline = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "outline", &show_faces_outline, VOL_SHOWHIDE, VolumeCB);
+    glui_geometry->add_spinner_to_panel(PANEL_geom_transparency, "outline width", GLUI_SPINNER_FLOAT, &geom_outline_width);
+    CHECKBOX_smooth_geom_normal = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "smooth", &smooth_geom_normal);
 
-  glui_geometry->add_column_to_panel(PANEL_group1,false);
-
-
-  PANEL_volumes = glui_geometry->add_panel_to_panel(PANEL_group1,"volumes");
-  CHECKBOX_volumes_interior = glui_geometry->add_checkbox_to_panel(PANEL_volumes, "interior", &show_volumes_interior);
-  CHECKBOX_volumes_exterior = glui_geometry->add_checkbox_to_panel(PANEL_volumes, "exterior", &show_volumes_exterior);
-  CHECKBOX_interior_solid=glui_geometry->add_checkbox_to_panel(PANEL_volumes,"solid",&show_volumes_solid,VOL_SHOWHIDE,VolumeCB);
-  CHECKBOX_interior_outline=glui_geometry->add_checkbox_to_panel(PANEL_volumes,"outline",&show_volumes_outline,VOL_SHOWHIDE,VolumeCB);
-
-  PANEL_normals = glui_geometry->add_panel_to_panel(PANEL_geom_showhide,"normals");
-  CHECKBOX_show_geom_normal = glui_geometry->add_checkbox_to_panel(PANEL_normals, "show", &show_geom_normal);
-  SPINNER_geom_ivecfactor = glui_geometry->add_spinner_to_panel(PANEL_normals, "length", GLUI_SPINNER_INT, &geom_ivecfactor, GEOM_IVECFACTOR, VolumeCB);
-  SPINNER_geom_ivecfactor->set_int_limits(0, 200);
-
-  ROLLOUT_geomtest2 = glui_geometry->add_rollout_to_panel(ROLLOUT_unstructured, "parameters",false);
-  SPINNER_geom_vert_exag = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "vertical exaggeration", GLUI_SPINNER_FLOAT, &geom_vert_exag, GEOM_VERT_EXAG, VolumeCB);
-  SPINNER_geom_vert_exag->set_float_limits(0.1, 10.0);
-  CHECKBOX_show_texture_1dimage = glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest2, "show elevation color", &show_texture_1dimage, SHOW_TEXTURE_1D_IMAGE, VolumeCB);
-
-  GetGeomZBounds(&terrain_zmin, &terrain_zmax);
-  SPINNER_geom_zmin = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "zmin", GLUI_SPINNER_FLOAT, &terrain_zmin,TERRAIN_ZMIN,VolumeCB);
-  SPINNER_geom_zmin->set_float_limits(zbar0ORIG, zbarORIG);
-
-  SPINNER_geom_zmax = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "zmax", GLUI_SPINNER_FLOAT, &terrain_zmax,TERRAIN_ZMAX,VolumeCB);
-  SPINNER_geom_zmax->set_float_limits(zbar0ORIG, zbarORIG);
-
-  terrain_zlevel=(terrain_zmin+terrain_zmax)/2.0;
-  CHECKBOX_show_zlevel = glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest2, "show zlevel", &show_zlevel, SHOW_ZLEVEL, VolumeCB);
-  SPINNER_geom_zlevel = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "zlevel", GLUI_SPINNER_FLOAT, &terrain_zlevel, TERRAIN_ZLEVEL, VolumeCB);
-  SPINNER_geom_zlevel->set_float_limits(zbar0ORIG, zbarORIG);
-
-  VolumeCB(GEOM_VERT_EXAG);
-  BUTTON_reset_zbounds = glui_geometry->add_button_to_panel(ROLLOUT_geomtest2, _d("Reset zmin/zmax"), RESET_ZBOUNDS, VolumeCB);
-
-  if(HaveTexture()==1){
-    show_texture_2dimage = GetTextureShow();
-    CHECKBOX_show_texture_2dimage = glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest2, "image",&show_texture_2dimage, SHOW_TEXTURE_2D_IMAGE, VolumeCB);
-    VolumeCB(SHOW_TEXTURE_2D_IMAGE);
-  }
+    glui_geometry->add_column_to_panel(PANEL_group1, false);
 
 
-  glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest2, "use max angle", &use_max_angle, GEOM_MAX_ANGLE, VolumeCB);
-  SPINNER_geom_max_angle = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "max angle", GLUI_SPINNER_FLOAT, &geom_max_angle, GEOM_MAX_ANGLE, VolumeCB);
-  SPINNER_geom_max_angle->set_float_limits(0.0,180.0);
-  SPINNER_geom_outline_ioffset = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "outline offset", GLUI_SPINNER_INT, &geom_outline_ioffset, GEOM_OUTLINE_IOFFSET, VolumeCB);
-  SPINNER_geom_outline_ioffset->set_int_limits(0,200);
-  SPINNER_face_factor = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "face factor", GLUI_SPINNER_FLOAT, &face_factor);
-  SPINNER_face_factor->set_float_limits(0.0, 0.5);
+    PANEL_volumes = glui_geometry->add_panel_to_panel(PANEL_group1, "volumes");
+    CHECKBOX_volumes_interior = glui_geometry->add_checkbox_to_panel(PANEL_volumes, "interior", &show_volumes_interior);
+    CHECKBOX_volumes_exterior = glui_geometry->add_checkbox_to_panel(PANEL_volumes, "exterior", &show_volumes_exterior);
+    CHECKBOX_interior_solid = glui_geometry->add_checkbox_to_panel(PANEL_volumes, "solid", &show_volumes_solid, VOL_SHOWHIDE, VolumeCB);
+    CHECKBOX_interior_outline = glui_geometry->add_checkbox_to_panel(PANEL_volumes, "outline", &show_volumes_outline, VOL_SHOWHIDE, VolumeCB);
 
-  ROLLOUT_geomcheck = glui_geometry->add_rollout_to_panel(ROLLOUT_unstructured, "checks",false);
-  PANEL_geomedgecheck = glui_geometry->add_panel_to_panel(ROLLOUT_geomcheck, "edges - connected triangles");
-  CHECKBOX_highlight_edge0 = glui_geometry->add_checkbox_to_panel(PANEL_geomedgecheck, "0", &highlight_edge0);
-  CHECKBOX_highlight_edge1 = glui_geometry->add_checkbox_to_panel(PANEL_geomedgecheck, "1", &highlight_edge1);
-  CHECKBOX_highlight_edge2 = glui_geometry->add_checkbox_to_panel(PANEL_geomedgecheck, "2", &highlight_edge2);
-  CHECKBOX_highlight_edgeother = glui_geometry->add_checkbox_to_panel(PANEL_geomedgecheck, "3 or more", &highlight_edgeother);
+    PANEL_normals = glui_geometry->add_panel_to_panel(PANEL_geom_showhide, "normals");
+    CHECKBOX_show_geom_normal = glui_geometry->add_checkbox_to_panel(PANEL_normals, "show", &show_geom_normal);
+    SPINNER_geom_ivecfactor = glui_geometry->add_spinner_to_panel(PANEL_normals, "length", GLUI_SPINNER_INT, &geom_ivecfactor, GEOM_IVECFACTOR, VolumeCB);
+    SPINNER_geom_ivecfactor->set_int_limits(0, 200);
 
-  CHECKBOX_highlight_vertexdup = glui_geometry->add_checkbox_to_panel(ROLLOUT_geomcheck, "duplicate vertices", &highlight_vertexdup);
+    ROLLOUT_geomtest2 = glui_geometry->add_rollout_to_panel(ROLLOUT_unstructured, "parameters", false);
+    SPINNER_geom_vert_exag = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "vertical exaggeration", GLUI_SPINNER_FLOAT, &geom_vert_exag, GEOM_VERT_EXAG, VolumeCB);
+    SPINNER_geom_vert_exag->set_float_limits(0.1, 10.0);
+    CHECKBOX_show_texture_1dimage = glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest2, "show elevation color", &show_texture_1dimage, SHOW_TEXTURE_1D_IMAGE, VolumeCB);
 
-  // -------------- Cube/Tetra intersection test -------------------
+    GetGeomZBounds(&terrain_zmin, &terrain_zmax);
+    SPINNER_geom_zmin = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "zmin", GLUI_SPINNER_FLOAT, &terrain_zmin, TERRAIN_ZMIN, VolumeCB);
+    SPINNER_geom_zmin->set_float_limits(zbar0ORIG, zbarORIG);
 
-  ROLLOUT_geomtest = glui_geometry->add_rollout_to_panel(ROLLOUT_unstructured,"Geometry tests",false);
-  PANEL_geom_testoptions=glui_geometry->add_panel_to_panel(ROLLOUT_geomtest,"geometry test:");
-  RADIO_geomtest_option = glui_geometry->add_radiogroup_to_panel(PANEL_geom_testoptions, &geomtest_option, GEOMETRYTEST, VolumeCB);
-  glui_geometry->add_radiobutton_to_group(RADIO_geomtest_option, "none");
-  glui_geometry->add_radiobutton_to_group(RADIO_geomtest_option, "triangle");
-  glui_geometry->add_radiobutton_to_group(RADIO_geomtest_option, "polygon");
-  glui_geometry->add_radiobutton_to_group(RADIO_geomtest_option, "tetrahedron");
+    SPINNER_geom_zmax = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "zmax", GLUI_SPINNER_FLOAT, &terrain_zmax, TERRAIN_ZMAX, VolumeCB);
+    SPINNER_geom_zmax->set_float_limits(zbar0ORIG, zbarORIG);
 
-  glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest, "show area labels", &show_tetratest_labels);
-  SPINNER_tetra_line_thickness=glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest,"line thickness",GLUI_SPINNER_FLOAT,&tetra_line_thickness);
-//  SPINNER_tetra_line_thickness->set_float_limits(1.0, 10.0);
-  SPINNER_tetra_point_size = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest, "point size", GLUI_SPINNER_FLOAT, &tetra_point_size);
-//  SPINNER_tetra_point_size->set_float_limits(1.0, 20.0);
+    terrain_zlevel = (terrain_zmin + terrain_zmax) / 2.0;
+    CHECKBOX_show_zlevel = glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest2, "show zlevel", &show_zlevel, SHOW_ZLEVEL, VolumeCB);
+    SPINNER_geom_zlevel = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "zlevel", GLUI_SPINNER_FLOAT, &terrain_zlevel, TERRAIN_ZLEVEL, VolumeCB);
+    SPINNER_geom_zlevel->set_float_limits(zbar0ORIG, zbarORIG);
 
-  PANEL_geom1 = glui_geometry->add_panel_to_panel(ROLLOUT_geomtest,"bounding planes");
+    VolumeCB(GEOM_VERT_EXAG);
+    BUTTON_reset_zbounds = glui_geometry->add_button_to_panel(ROLLOUT_geomtest2, _d("Reset zmin/zmax"), RESET_ZBOUNDS, VolumeCB);
 
-  PANEL_geom1d=glui_geometry->add_panel_to_panel(PANEL_geom1,"",GLUI_PANEL_NONE);
-  PANEL_geom1a=glui_geometry->add_panel_to_panel(PANEL_geom1d,"",GLUI_PANEL_NONE);
-  glui_geometry->add_column_to_panel(PANEL_geom1d,false);
-  PANEL_geom1b=glui_geometry->add_panel_to_panel(PANEL_geom1d,"",GLUI_PANEL_NONE);
-
-  PANEL_geom1c=glui_geometry->add_panel_to_panel(PANEL_geom1,"",GLUI_PANEL_NONE);
-
-  SPINNER_box_bounds[0]=glui_geometry->add_spinner_to_panel(PANEL_geom1a,"xmin",GLUI_SPINNER_FLOAT,box_bounds2,VOL_BOXTRANSLATE,VolumeCB);
-  SPINNER_box_bounds[2]=glui_geometry->add_spinner_to_panel(PANEL_geom1a,"ymin",GLUI_SPINNER_FLOAT,box_bounds2+2,VOL_BOXTRANSLATE,VolumeCB);
-  SPINNER_box_bounds[4]=glui_geometry->add_spinner_to_panel(PANEL_geom1a,"zmin",GLUI_SPINNER_FLOAT,box_bounds2+4,VOL_BOXTRANSLATE,VolumeCB);
-  SPINNER_box_bounds[1]=glui_geometry->add_spinner_to_panel(PANEL_geom1b,"xmax",GLUI_SPINNER_FLOAT,box_bounds2+1,VOL_BOXTRANSLATE,VolumeCB);
-  SPINNER_box_bounds[3]=glui_geometry->add_spinner_to_panel(PANEL_geom1b,"ymax",GLUI_SPINNER_FLOAT,box_bounds2+3,VOL_BOXTRANSLATE,VolumeCB);
-  SPINNER_box_bounds[5]=glui_geometry->add_spinner_to_panel(PANEL_geom1b,"zmax",GLUI_SPINNER_FLOAT,box_bounds2+5,VOL_BOXTRANSLATE,VolumeCB);
-
-  SPINNER_box_translate[0]=glui_geometry->add_spinner_to_panel(PANEL_geom1c,"translate: x",GLUI_SPINNER_FLOAT,box_translate,VOL_BOXTRANSLATE,VolumeCB);
-  glui_geometry->add_column_to_panel(PANEL_geom1c,false);
-  SPINNER_box_translate[1]=glui_geometry->add_spinner_to_panel(PANEL_geom1c,"y",GLUI_SPINNER_FLOAT,box_translate+1,VOL_BOXTRANSLATE,VolumeCB);
-  glui_geometry->add_column_to_panel(PANEL_geom1c,false);
-  SPINNER_box_translate[2]=glui_geometry->add_spinner_to_panel(PANEL_geom1c,"z",GLUI_SPINNER_FLOAT,box_translate+2,VOL_BOXTRANSLATE,VolumeCB);
-  VolumeCB(VOL_BOXTRANSLATE);
-  PANEL_geom2=glui_geometry->add_panel_to_panel(ROLLOUT_geomtest,"vertices");
-  PANEL_geom2a=glui_geometry->add_panel_to_panel(PANEL_geom2,"",GLUI_PANEL_NONE);
-  glui_geometry->add_column_to_panel(PANEL_geom2,false);
-  PANEL_geom2b=glui_geometry->add_panel_to_panel(PANEL_geom2,"",GLUI_PANEL_NONE);
-  glui_geometry->add_column_to_panel(PANEL_geom2,false);
-  PANEL_geom2c=glui_geometry->add_panel_to_panel(PANEL_geom2,"",GLUI_PANEL_NONE);
-
-  SPINNER_tetra_vertices[0]=glui_geometry->add_spinner_to_panel(PANEL_geom2a,"v1 x:",GLUI_SPINNER_FLOAT,tetra_vertices,VOL_TETRA,VolumeCB);
-  SPINNER_tetra_vertices[3]=glui_geometry->add_spinner_to_panel(PANEL_geom2a,"v2 x:",GLUI_SPINNER_FLOAT,tetra_vertices+3,VOL_TETRA,VolumeCB);
-  SPINNER_tetra_vertices[6]=glui_geometry->add_spinner_to_panel(PANEL_geom2a,"v3 x:",GLUI_SPINNER_FLOAT,tetra_vertices+6,VOL_TETRA,VolumeCB);
-  SPINNER_tetra_vertices[9]=glui_geometry->add_spinner_to_panel(PANEL_geom2a,"v4 x:",GLUI_SPINNER_FLOAT,tetra_vertices+9,VOL_TETRA,VolumeCB);
-
-  SPINNER_tetra_vertices[1]=glui_geometry->add_spinner_to_panel(PANEL_geom2b,"y:",GLUI_SPINNER_FLOAT,tetra_vertices+1,VOL_TETRA,VolumeCB);
-  SPINNER_tetra_vertices[4]=glui_geometry->add_spinner_to_panel(PANEL_geom2b,"y:",GLUI_SPINNER_FLOAT,tetra_vertices+4,VOL_TETRA,VolumeCB);
-  SPINNER_tetra_vertices[7]=glui_geometry->add_spinner_to_panel(PANEL_geom2b,"y:",GLUI_SPINNER_FLOAT,tetra_vertices+7,VOL_TETRA,VolumeCB);
-  SPINNER_tetra_vertices[10]=glui_geometry->add_spinner_to_panel(PANEL_geom2b,"y:",GLUI_SPINNER_FLOAT,tetra_vertices+10,VOL_TETRA,VolumeCB);
-
-  SPINNER_tetra_vertices[2]=glui_geometry->add_spinner_to_panel(PANEL_geom2c,"z:",GLUI_SPINNER_FLOAT,tetra_vertices+2,VOL_TETRA,VolumeCB);
-  SPINNER_tetra_vertices[5]=glui_geometry->add_spinner_to_panel(PANEL_geom2c,"z:",GLUI_SPINNER_FLOAT,tetra_vertices+5,VOL_TETRA,VolumeCB);
-  SPINNER_tetra_vertices[8]=glui_geometry->add_spinner_to_panel(PANEL_geom2c,"z:",GLUI_SPINNER_FLOAT,tetra_vertices+8,VOL_TETRA,VolumeCB);
-  SPINNER_tetra_vertices[11]=glui_geometry->add_spinner_to_panel(PANEL_geom2c,"z:",GLUI_SPINNER_FLOAT,tetra_vertices+11,VOL_TETRA,VolumeCB);
-
-  PANEL_geom3abc=glui_geometry->add_panel_to_panel(ROLLOUT_geomtest,"box/tetrahedron faces",GLUI_PANEL_NONE);
-
-  glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest,"tetra test",&show_test_in_tetra);
-  glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest,"tetra x:",GLUI_SPINNER_FLOAT,tetra_xyz);
-  glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest,"tetra y:",GLUI_SPINNER_FLOAT,tetra_xyz+1);
-  glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest,"tetra z:",GLUI_SPINNER_FLOAT,tetra_xyz+2);
-
-  PANEL_geom3ab=glui_geometry->add_panel_to_panel(PANEL_geom3abc,"box");
-  PANEL_geom3a=glui_geometry->add_panel_to_panel(PANEL_geom3ab,"",GLUI_PANEL_NONE);
-  glui_geometry->add_column_to_panel(PANEL_geom3ab,false);
-  PANEL_geom3b=glui_geometry->add_panel_to_panel(PANEL_geom3ab,"",GLUI_PANEL_NONE);
+    if(HaveTexture() == 1){
+      show_texture_2dimage = GetTextureShow();
+      CHECKBOX_show_texture_2dimage = glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest2, "image", &show_texture_2dimage, SHOW_TEXTURE_2D_IMAGE, VolumeCB);
+      VolumeCB(SHOW_TEXTURE_2D_IMAGE);
+    }
 
 
-  glui_geometry->add_column_to_panel(PANEL_geom3abc,false);
-  PANEL_geom3c=glui_geometry->add_panel_to_panel(PANEL_geom3abc,"tetrahedron");
+    glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest2, "use max angle", &use_max_angle, GEOM_MAX_ANGLE, VolumeCB);
+    SPINNER_geom_max_angle = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "max angle", GLUI_SPINNER_FLOAT, &geom_max_angle, GEOM_MAX_ANGLE, VolumeCB);
+    SPINNER_geom_max_angle->set_float_limits(0.0, 180.0);
+    SPINNER_geom_outline_ioffset = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "outline offset", GLUI_SPINNER_INT, &geom_outline_ioffset, GEOM_OUTLINE_IOFFSET, VolumeCB);
+    SPINNER_geom_outline_ioffset->set_int_limits(0, 200);
+    SPINNER_face_factor = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest2, "face factor", GLUI_SPINNER_FLOAT, &face_factor);
+    SPINNER_face_factor->set_float_limits(0.0, 0.5);
 
-  CHECKBOX_tetrabox_showhide[0]=glui_geometry->add_checkbox_to_panel(PANEL_geom3a,"xmin",tetrabox_vis+0);
-  CHECKBOX_tetrabox_showhide[1]=glui_geometry->add_checkbox_to_panel(PANEL_geom3b,"xmax",tetrabox_vis+1);
-  CHECKBOX_tetrabox_showhide[2]=glui_geometry->add_checkbox_to_panel(PANEL_geom3a,"ymin",tetrabox_vis+2);
-  CHECKBOX_tetrabox_showhide[3]=glui_geometry->add_checkbox_to_panel(PANEL_geom3b,"ymax",tetrabox_vis+3);
-  CHECKBOX_tetrabox_showhide[4]=glui_geometry->add_checkbox_to_panel(PANEL_geom3a,"zmin",tetrabox_vis+4);
-  CHECKBOX_tetrabox_showhide[5]=glui_geometry->add_checkbox_to_panel(PANEL_geom3b,"zmax",tetrabox_vis+5);
-  CHECKBOX_tetrabox_showhide[8]=glui_geometry->add_checkbox_to_panel(PANEL_geom3c,"v1 v3 v4",tetrabox_vis+6);
-  CHECKBOX_tetrabox_showhide[7]=glui_geometry->add_checkbox_to_panel(PANEL_geom3c,"v2 v3 v4",tetrabox_vis+7);
-  CHECKBOX_tetrabox_showhide[6]=glui_geometry->add_checkbox_to_panel(PANEL_geom3c,"v1 v2 v4",tetrabox_vis+8);
-  CHECKBOX_tetrabox_showhide[9]=glui_geometry->add_checkbox_to_panel(PANEL_geom3c,"v1 v2 v3",tetrabox_vis+9);
+    ROLLOUT_geomcheck = glui_geometry->add_rollout_to_panel(ROLLOUT_unstructured, "checks", false);
+    PANEL_geomedgecheck = glui_geometry->add_panel_to_panel(ROLLOUT_geomcheck, "edges - connected triangles");
+    CHECKBOX_highlight_edge0 = glui_geometry->add_checkbox_to_panel(PANEL_geomedgecheck, "0", &highlight_edge0);
+    CHECKBOX_highlight_edge1 = glui_geometry->add_checkbox_to_panel(PANEL_geomedgecheck, "1", &highlight_edge1);
+    CHECKBOX_highlight_edge2 = glui_geometry->add_checkbox_to_panel(PANEL_geomedgecheck, "2", &highlight_edge2);
+    CHECKBOX_highlight_edgeother = glui_geometry->add_checkbox_to_panel(PANEL_geomedgecheck, "3 or more", &highlight_edgeother);
+
+    CHECKBOX_highlight_vertexdup = glui_geometry->add_checkbox_to_panel(ROLLOUT_geomcheck, "duplicate vertices", &highlight_vertexdup);
+
+    // -------------- Cube/Tetra intersection test -------------------
+
+#ifdef pp_GEOMTEST
+    ROLLOUT_geomtest = glui_geometry->add_rollout_to_panel(ROLLOUT_unstructured, "Geometry tests", false);
+    PANEL_geom_testoptions = glui_geometry->add_panel_to_panel(ROLLOUT_geomtest, "geometry test:");
+    RADIO_geomtest_option = glui_geometry->add_radiogroup_to_panel(PANEL_geom_testoptions, &geomtest_option, GEOMETRYTEST, VolumeCB);
+    glui_geometry->add_radiobutton_to_group(RADIO_geomtest_option, "none");
+    glui_geometry->add_radiobutton_to_group(RADIO_geomtest_option, "triangle");
+    glui_geometry->add_radiobutton_to_group(RADIO_geomtest_option, "polygon");
+    glui_geometry->add_radiobutton_to_group(RADIO_geomtest_option, "tetrahedron");
+
+    glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest, "show area labels", &show_tetratest_labels);
+    SPINNER_tetra_line_thickness = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest, "line thickness", GLUI_SPINNER_FLOAT, &tetra_line_thickness);
+    //  SPINNER_tetra_line_thickness->set_float_limits(1.0, 10.0);
+    SPINNER_tetra_point_size = glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest, "point size", GLUI_SPINNER_FLOAT, &tetra_point_size);
+    //  SPINNER_tetra_point_size->set_float_limits(1.0, 20.0);
+
+    PANEL_geom1 = glui_geometry->add_panel_to_panel(ROLLOUT_geomtest, "bounding planes");
+
+    PANEL_geom1d = glui_geometry->add_panel_to_panel(PANEL_geom1, "", GLUI_PANEL_NONE);
+    PANEL_geom1a = glui_geometry->add_panel_to_panel(PANEL_geom1d, "", GLUI_PANEL_NONE);
+    glui_geometry->add_column_to_panel(PANEL_geom1d, false);
+    PANEL_geom1b = glui_geometry->add_panel_to_panel(PANEL_geom1d, "", GLUI_PANEL_NONE);
+
+    PANEL_geom1c = glui_geometry->add_panel_to_panel(PANEL_geom1, "", GLUI_PANEL_NONE);
+
+    SPINNER_box_bounds[0] = glui_geometry->add_spinner_to_panel(PANEL_geom1a, "xmin", GLUI_SPINNER_FLOAT, box_bounds2, VOL_BOXTRANSLATE, VolumeCB);
+    SPINNER_box_bounds[2] = glui_geometry->add_spinner_to_panel(PANEL_geom1a, "ymin", GLUI_SPINNER_FLOAT, box_bounds2 + 2, VOL_BOXTRANSLATE, VolumeCB);
+    SPINNER_box_bounds[4] = glui_geometry->add_spinner_to_panel(PANEL_geom1a, "zmin", GLUI_SPINNER_FLOAT, box_bounds2 + 4, VOL_BOXTRANSLATE, VolumeCB);
+    SPINNER_box_bounds[1] = glui_geometry->add_spinner_to_panel(PANEL_geom1b, "xmax", GLUI_SPINNER_FLOAT, box_bounds2 + 1, VOL_BOXTRANSLATE, VolumeCB);
+    SPINNER_box_bounds[3] = glui_geometry->add_spinner_to_panel(PANEL_geom1b, "ymax", GLUI_SPINNER_FLOAT, box_bounds2 + 3, VOL_BOXTRANSLATE, VolumeCB);
+    SPINNER_box_bounds[5] = glui_geometry->add_spinner_to_panel(PANEL_geom1b, "zmax", GLUI_SPINNER_FLOAT, box_bounds2 + 5, VOL_BOXTRANSLATE, VolumeCB);
+
+    SPINNER_box_translate[0] = glui_geometry->add_spinner_to_panel(PANEL_geom1c, "translate: x", GLUI_SPINNER_FLOAT, box_translate, VOL_BOXTRANSLATE, VolumeCB);
+    glui_geometry->add_column_to_panel(PANEL_geom1c, false);
+    SPINNER_box_translate[1] = glui_geometry->add_spinner_to_panel(PANEL_geom1c, "y", GLUI_SPINNER_FLOAT, box_translate + 1, VOL_BOXTRANSLATE, VolumeCB);
+    glui_geometry->add_column_to_panel(PANEL_geom1c, false);
+    SPINNER_box_translate[2] = glui_geometry->add_spinner_to_panel(PANEL_geom1c, "z", GLUI_SPINNER_FLOAT, box_translate + 2, VOL_BOXTRANSLATE, VolumeCB);
+    VolumeCB(VOL_BOXTRANSLATE);
+    PANEL_geom2 = glui_geometry->add_panel_to_panel(ROLLOUT_geomtest, "vertices");
+    PANEL_geom2a = glui_geometry->add_panel_to_panel(PANEL_geom2, "", GLUI_PANEL_NONE);
+    glui_geometry->add_column_to_panel(PANEL_geom2, false);
+    PANEL_geom2b = glui_geometry->add_panel_to_panel(PANEL_geom2, "", GLUI_PANEL_NONE);
+    glui_geometry->add_column_to_panel(PANEL_geom2, false);
+    PANEL_geom2c = glui_geometry->add_panel_to_panel(PANEL_geom2, "", GLUI_PANEL_NONE);
+
+    SPINNER_tetra_vertices[0] = glui_geometry->add_spinner_to_panel(PANEL_geom2a, "v1 x:", GLUI_SPINNER_FLOAT, tetra_vertices, VOL_TETRA, VolumeCB);
+    SPINNER_tetra_vertices[3] = glui_geometry->add_spinner_to_panel(PANEL_geom2a, "v2 x:", GLUI_SPINNER_FLOAT, tetra_vertices + 3, VOL_TETRA, VolumeCB);
+    SPINNER_tetra_vertices[6] = glui_geometry->add_spinner_to_panel(PANEL_geom2a, "v3 x:", GLUI_SPINNER_FLOAT, tetra_vertices + 6, VOL_TETRA, VolumeCB);
+    SPINNER_tetra_vertices[9] = glui_geometry->add_spinner_to_panel(PANEL_geom2a, "v4 x:", GLUI_SPINNER_FLOAT, tetra_vertices + 9, VOL_TETRA, VolumeCB);
+
+    SPINNER_tetra_vertices[1] = glui_geometry->add_spinner_to_panel(PANEL_geom2b, "y:", GLUI_SPINNER_FLOAT, tetra_vertices + 1, VOL_TETRA, VolumeCB);
+    SPINNER_tetra_vertices[4] = glui_geometry->add_spinner_to_panel(PANEL_geom2b, "y:", GLUI_SPINNER_FLOAT, tetra_vertices + 4, VOL_TETRA, VolumeCB);
+    SPINNER_tetra_vertices[7] = glui_geometry->add_spinner_to_panel(PANEL_geom2b, "y:", GLUI_SPINNER_FLOAT, tetra_vertices + 7, VOL_TETRA, VolumeCB);
+    SPINNER_tetra_vertices[10] = glui_geometry->add_spinner_to_panel(PANEL_geom2b, "y:", GLUI_SPINNER_FLOAT, tetra_vertices + 10, VOL_TETRA, VolumeCB);
+
+    SPINNER_tetra_vertices[2] = glui_geometry->add_spinner_to_panel(PANEL_geom2c, "z:", GLUI_SPINNER_FLOAT, tetra_vertices + 2, VOL_TETRA, VolumeCB);
+    SPINNER_tetra_vertices[5] = glui_geometry->add_spinner_to_panel(PANEL_geom2c, "z:", GLUI_SPINNER_FLOAT, tetra_vertices + 5, VOL_TETRA, VolumeCB);
+    SPINNER_tetra_vertices[8] = glui_geometry->add_spinner_to_panel(PANEL_geom2c, "z:", GLUI_SPINNER_FLOAT, tetra_vertices + 8, VOL_TETRA, VolumeCB);
+    SPINNER_tetra_vertices[11] = glui_geometry->add_spinner_to_panel(PANEL_geom2c, "z:", GLUI_SPINNER_FLOAT, tetra_vertices + 11, VOL_TETRA, VolumeCB);
+
+    PANEL_geom3abc = glui_geometry->add_panel_to_panel(ROLLOUT_geomtest, "box/tetrahedron faces", GLUI_PANEL_NONE);
+
+    glui_geometry->add_checkbox_to_panel(ROLLOUT_geomtest, "tetra test", &show_test_in_tetra);
+    glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest, "tetra x:", GLUI_SPINNER_FLOAT, tetra_xyz);
+    glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest, "tetra y:", GLUI_SPINNER_FLOAT, tetra_xyz + 1);
+    glui_geometry->add_spinner_to_panel(ROLLOUT_geomtest, "tetra z:", GLUI_SPINNER_FLOAT, tetra_xyz + 2);
+
+    PANEL_geom3ab = glui_geometry->add_panel_to_panel(PANEL_geom3abc, "box");
+    PANEL_geom3a = glui_geometry->add_panel_to_panel(PANEL_geom3ab, "", GLUI_PANEL_NONE);
+    glui_geometry->add_column_to_panel(PANEL_geom3ab, false);
+    PANEL_geom3b = glui_geometry->add_panel_to_panel(PANEL_geom3ab, "", GLUI_PANEL_NONE);
+
+
+    glui_geometry->add_column_to_panel(PANEL_geom3abc, false);
+    PANEL_geom3c = glui_geometry->add_panel_to_panel(PANEL_geom3abc, "tetrahedron");
+
+    CHECKBOX_tetrabox_showhide[0] = glui_geometry->add_checkbox_to_panel(PANEL_geom3a, "xmin", tetrabox_vis + 0);
+    CHECKBOX_tetrabox_showhide[1] = glui_geometry->add_checkbox_to_panel(PANEL_geom3b, "xmax", tetrabox_vis + 1);
+    CHECKBOX_tetrabox_showhide[2] = glui_geometry->add_checkbox_to_panel(PANEL_geom3a, "ymin", tetrabox_vis + 2);
+    CHECKBOX_tetrabox_showhide[3] = glui_geometry->add_checkbox_to_panel(PANEL_geom3b, "ymax", tetrabox_vis + 3);
+    CHECKBOX_tetrabox_showhide[4] = glui_geometry->add_checkbox_to_panel(PANEL_geom3a, "zmin", tetrabox_vis + 4);
+    CHECKBOX_tetrabox_showhide[5] = glui_geometry->add_checkbox_to_panel(PANEL_geom3b, "zmax", tetrabox_vis + 5);
+    CHECKBOX_tetrabox_showhide[8] = glui_geometry->add_checkbox_to_panel(PANEL_geom3c, "v1 v3 v4", tetrabox_vis + 6);
+    CHECKBOX_tetrabox_showhide[7] = glui_geometry->add_checkbox_to_panel(PANEL_geom3c, "v2 v3 v4", tetrabox_vis + 7);
+    CHECKBOX_tetrabox_showhide[6] = glui_geometry->add_checkbox_to_panel(PANEL_geom3c, "v1 v2 v4", tetrabox_vis + 8);
+    CHECKBOX_tetrabox_showhide[9] = glui_geometry->add_checkbox_to_panel(PANEL_geom3c, "v1 v2 v3", tetrabox_vis + 9);
 #endif
+  }
 
   glui_geometry->add_separator();
   glui_geometry->add_button(_d("Save settings"),SAVE_SETTINGS, BlockeditDlgCB);

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -175,9 +175,7 @@ void Usage(char *prog,int option){
 #ifdef pp_SHOWTERRAIN
     strcat(label, ", pp_SHOWTERRAIN");
 #endif
-#ifdef pp_SLICELOAD
     strcat(label, ", pp_SLICELOAD");
-#endif
 #ifdef pp_THREAD
     strcat(label, ", pp_THREAD");
 #endif

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -37,7 +37,6 @@
 
 //#define pp_PARTTEST   // for debugging, set particle values to 100*parti->seq_id + small random number
 #define pp_READBUFFER   // read .smv file from a memory buffer
-#define pp_SLICELOAD     // use slice file parameters found in .smv file to construct menus
 
 #define pp_THREAD       // turn on multi-threading
 #ifdef pp_THREAD

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -8223,7 +8223,6 @@ typedef struct {
 
         FORTgetsliceheader(sd->file,&ii1,&ii2,&jj1,&jj2,&kk1,&kk2,&error,strlen(sd->file));
       }
-#ifdef pp_SLICELOAD
       sd->is1=ii1;
       sd->is2=ii2;
       sd->js1=jj1;
@@ -8236,30 +8235,6 @@ typedef struct {
       sd->ijk_max[1] = jj2;
       sd->ijk_min[2] = kk1;
       sd->ijk_max[2] = kk2;
-#else
-      sd->is1=i1;
-      sd->is2=i2;
-      sd->js1=j1;
-      sd->js2=j2;
-      sd->ks1=k1;
-      sd->ks2=k2;
-      if(ii1>=0){
-        sd->ijk_min[0] = ii1;
-        sd->ijk_max[0] = ii2;
-        sd->ijk_min[1] = jj1;
-        sd->ijk_max[1] = jj2;
-        sd->ijk_min[2] = kk1;
-        sd->ijk_max[2] = kk2;
-      }
-      else{
-        sd->ijk_min[0] = i1;
-        sd->ijk_max[0] = i2;
-        sd->ijk_min[1] = j1;
-        sd->ijk_max[1] = j2;
-        sd->ijk_min[2] = k1;
-        sd->ijk_max[2] = k2;
-      }
-#endif
       sd->is_fed=0;
       sd->above_ground_level=above_ground_level;
       sd->seq_id=nn_slice;


### PR DESCRIPTION
1. remove unused variables
2. add -t option to build test gnu osx/linux versions of smokeview
3. remove pp_SLICELOAD preprocessing variable
4. only show immersed geometry dialog box if case has immersed geometry