### PR TITLE
smokeview source: overlap timebar region by default if timebar is hid…

### DIFF
--- a/Source/smokeview/glui_display.cpp
+++ b/Source/smokeview/glui_display.cpp
@@ -131,6 +131,7 @@ GLUI_Rollout *ROLLOUT_north = NULL;
 GLUI_Rollout *ROLLOUT_extreme2 = NULL;
 GLUI_Rollout *ROLLOUT_split = NULL;
 
+GLUI_Panel *PANEL_timebar_overlap = NULL;
 GLUI_Panel *PANEL_split1L = NULL, *PANEL_split1H = NULL;
 GLUI_Panel *PANEL_split2L = NULL, *PANEL_split2H = NULL;
 GLUI_Panel *PANEL_split3 = NULL;
@@ -155,6 +156,7 @@ GLUI_Panel *PANEL_LB_tick = NULL;
 GLUI_Panel *PANEL_linewidth = NULL;
 GLUI_Panel *PANEL_offset = NULL;
 
+GLUI_RadioGroup *RADIO_timebar_overlap = NULL;
 GLUI_RadioGroup *RADIO2_plot3d_display=NULL;
 GLUI_RadioGroup *RADIO_fontsize = NULL;
 GLUI_RadioButton *RADIOBUTTON_label_1a=NULL;
@@ -574,7 +576,12 @@ extern "C" void GluiLabelsSetup(int main_window){
 
   CHECKBOX_labels_flip = glui_labels->add_checkbox_to_panel(PANEL_gen3, _("Flip background"), &background_flip, LABELS_flip, LabelsCB);
   CHECKBOX_labels_hms = glui_labels->add_checkbox_to_panel(PANEL_gen3, _("hms time"), &vishmsTimelabel, LABELS_HMS, LabelsCB);
-                        glui_labels->add_checkbox_to_panel(PANEL_gen3, _("overlap time/timebar"), &overlap_timebar);
+  PANEL_timebar_overlap = glui_labels->add_panel_to_panel(PANEL_gen3,_("Overlap timebar region"));
+  RADIO_timebar_overlap=glui_labels->add_radiogroup_to_panel(PANEL_timebar_overlap,&timebar_overlap);
+  glui_labels->add_radiobutton_to_group(RADIO_timebar_overlap,_("Always"));
+  glui_labels->add_radiobutton_to_group(RADIO_timebar_overlap,_("Never"));
+  glui_labels->add_radiobutton_to_group(RADIO_timebar_overlap,_("Only if timebar hidden"));
+
   CHECKBOX_label_1=glui_labels->add_checkbox_to_panel(PANEL_gen3,_("Fast blockage drawing"),&use_new_drawface,LABELS_drawface,LabelsCB);
   CHECKBOX_label_2=glui_labels->add_checkbox_to_panel(PANEL_gen3,_("Sort transparent faces"),&sort_transparent_faces,LABELS_drawface,LabelsCB);
   CHECKBOX_label_3=glui_labels->add_checkbox_to_panel(PANEL_gen3,_("Hide overlaps"),&hide_overlaps,LABELS_hide_overlaps,LabelsCB);

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -7883,7 +7883,7 @@ updatemenu=0;
   CREATEMENU(showhidemenu,ShowHideMenu);
   glutAddSubMenu(_("Color"), colorbarmenu);
   glutAddSubMenu(_("Geometry"),geometrymenu);
-  glutAddSubMenu(_("Labels"),labelmenu);
+  glutAddSubMenu(_("Display"),labelmenu);
   glutAddSubMenu(_("Viewpoints"), resetmenu);
   glutAddMenuEntry("-", MENU_DUMMY);
   if(Read3DSmoke3DFile==1&&nsmoke3dloaded>0){

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -11201,7 +11201,7 @@ int ReadIni2(char *inifile, int localfile){
     }
     if(Match(buffer, "SHOWTIMEBAR") == 1){
       fgets(buffer, 255, stream);
-      sscanf(buffer, "%i %i", &visTimebar,&overlap_timebar);
+      sscanf(buffer, "%i %i", &visTimebar,&timebar_overlap);
       continue;
     }
     if(Match(buffer, "SHOWCOLORBARS") == 1){
@@ -13263,7 +13263,7 @@ void WriteIni(int flag,char *filename){
   fprintf(fileout, "SHOWTICKS\n");
   fprintf(fileout, " %i\n", visFDSticks);
   fprintf(fileout, "SHOWTIMEBAR\n");
-  fprintf(fileout, " %i %i\n", visTimebar,overlap_timebar);
+  fprintf(fileout, " %i %i\n", visTimebar,timebar_overlap);
   fprintf(fileout, "SHOWTIMELABEL\n");
   fprintf(fileout, " %i\n", visTimelabel);
   fprintf(fileout, "SHOWTITLE\n");

--- a/Source/smokeview/smokeviewdefs.h
+++ b/Source/smokeview/smokeviewdefs.h
@@ -7,6 +7,10 @@ void _Sniff_Errors(char *whereat);
 #define SNIFF_ERRORS(f)
 #endif
 
+#define TIMEBAR_OVERLAP_ALWAYS 0
+#define TIMEBAR_OVERLAP_NEVER 1
+#define TIMEBAR_OVERLAP_AUTO 2
+
 #define RENDER_START 3
 #define RENDER_START_NORMAL 12
 #define RENDER_START_360 10

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -20,7 +20,7 @@
 #include "smokeheaders.h"
 #include "threader.h"
 
-SVEXTERN int SVDECL(overlap_timebar, 0);
+SVEXTERN int SVDECL(timebar_overlap, TIMEBAR_OVERLAP_AUTO);
 SVEXTERN int SVDECL(toggle_colorbar, 0);
 SVEXTERN int hcolorbar_vis[6];
 #ifdef INMAIN

--- a/Source/smokeview/viewports.c
+++ b/Source/smokeview/viewports.c
@@ -251,7 +251,7 @@ void GetViewportInfo(void){
     int timebar_height;
 
     timebar_height = MAX(VP_timebar.height, VP_info.height);
-    if(overlap_timebar == 1)timebar_height = 0;
+    if(timebar_overlap == TIMEBAR_OVERLAP_ALWAYS||(timebar_overlap==TIMEBAR_OVERLAP_AUTO&&visTimebar==0))timebar_height = 0;
     VP_scene.text_height = text_height;
     VP_scene.text_width = text_width;
     VP_scene.left = titlesafe_offset;


### PR DESCRIPTION
…den also give the option to always or never overlap the timebar region