### PR TITLE
smokeview source: fix glut submenu warning when for multi mesh cases,…

### DIFF
--- a/Source/smokeview/flowfiles.h
+++ b/Source/smokeview/flowfiles.h
@@ -1125,6 +1125,9 @@ typedef struct _compdata {
 
 typedef struct _menudata {
   int menuvar;
+#ifdef pp_DEBUG_SUBMENU
+  int *menuvar_ptr;
+#endif
   char label[256];
 } menudata;
 

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -5773,16 +5773,31 @@ updatemenu=0;
     if(patchi->loaded==1)npatchloaded++;
   }
 
+#ifdef pp_DEBUG_SUBMENU
+
+#define CREATEMENU(menu,Menu) menu=glutCreateMenu(Menu);\
+  if(nmenus<10000){\
+    strcpy(menuinfo[nmenus].label,#Menu);\
+    menuinfo[nmenus].menuvar_ptr=&menu;\
+    menuinfo[nmenus++].menuvar = menu;\
+  }
+
+#ifdef _DEBUG
+#define GLUTADDSUBMENU(menu_label,menu_value) {ASSERT(menu_value!=0);glutAddSubMenu(menu_label,menu_value);}
+#else
+#define GLUTADDSUBMENU(menu_label,menu_value) {if(menu_value==0){printf("*** warning: sub-menu entry %s added to non-existant menu at line %i in file %s\n",menu_label,__LINE__,__FILE__);};glutAddSubMenu(menu_label,menu_value);}
+#endif
+
+#else
+
 #define CREATEMENU(menu,Menu) menu=glutCreateMenu(Menu);\
   if(nmenus<10000){\
     strcpy(menuinfo[nmenus].label,#Menu);\
     menuinfo[nmenus++].menuvar=menu;\
   }
 
-#ifdef pp_DEBUG_SUBMENU
-#define GLUTADDSUBMENU(menu_label,menu_value) {ASSERT(menu_value!=0);printf("add sub-menu entry %s to menu with id %i\n",menu_label,menu_value);glutAddSubMenu(menu_label,menu_value);}
-#else
 #define GLUTADDSUBMENU(menu_label,menu_value) glutAddSubMenu(menu_label,menu_value)
+
 #endif
 
   {
@@ -5793,6 +5808,9 @@ updatemenu=0;
 
       if(menui->menuvar>0){
         glutDestroyMenu(menui->menuvar);
+#ifdef pp_DEBUG_SUBMENU
+        *(menui->menuvar_ptr) = 0;
+#endif
       }
     }
     nmenus=0;
@@ -9881,7 +9899,7 @@ updatemenu=0;
         // 3d smoke co2 menu
 
         if(nmeshes > 1){
-          CREATEMENU(loadsmoke3dtempmenu, LoadSmoke3DMenu);
+          CREATEMENU(loadsmoke3dco2menu, LoadSmoke3DMenu);
         }
         for(i = 0;i < nsmoke3dinfo;i++){
           smoke3di = smoke3dinfo + i;

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -67,11 +67,11 @@
 //*** options: options being tested on all platforms
 
 #ifdef pp_BETA   
-//#define pp_DEBUG_SUBMENU     // debug output and testing for building menus
+#define pp_DEBUG_SUBMENU       // debug output and testing for building menus
 //#define pp_SMOKE3D_LOAD_TEST // load 3d smoke for all meshes for each time step 
 //#define pp_SMOKEALPHA        // experimental smoke alpha settings
 #define pp_SHOWTERRAIN
-#define pp_GEOMTEST      // used to test tetrahedron box intersections
+#define pp_GEOMTEST            // used to test tetrahedron box intersections
 #define pp_TIMINGS
 //#define pp_GPUDEPTH
 //#define pp_SMOKETEST         // experimental smoke dialog box entries


### PR DESCRIPTION
… also add debug checks so error will be easier to catch if it occurs again - addresses smokeview issue 653

This was a case where the mac correctly identified an error that the PC missed!