### PR TITLE
this pull request

### DIFF
--- a/Build/build_smokeview.html
+++ b/Build/build_smokeview.html
@@ -172,7 +172,7 @@ function install_smv(args){
 
 <tr>
 <td align=center>
-<button onclick="build_smv('windows test')">Build full</button><br>
+<button onclick="build_smv('windows test')">Build</button>
 <button onclick="build_smv('windows testinc')">Build inc</button>
 </td>
 <td align=center><button onclick="build_smv('linux test')">Build</button></td>

--- a/Build/build_smokeview.html
+++ b/Build/build_smokeview.html
@@ -171,7 +171,10 @@ function install_smv(args){
 <tr><th>Windows</th><th>Linux</th><th>OSX</th><th>Windows</th><th>Linux</th><th>OSX</th></tr>
 
 <tr>
-<td align=center><button onclick="build_smv('windows test')">Build</button></td>
+<td align=center>
+<button onclick="build_smv('windows test')">Build full</button><br>
+<button onclick="build_smv('windows testinc')">Build inc</button>
+</td>
 <td align=center><button onclick="build_smv('linux test')">Build</button></td>
 <td align=center><button onclick="build_smv('osx test')">Build</button></td>
 <td align=center><button onclick="build_smv('windows release')">Build</button></td>

--- a/Build/smokeview/intel_win_64/make_smokeview.bat
+++ b/Build/smokeview/intel_win_64/make_smokeview.bat
@@ -26,7 +26,9 @@ if  "x%VS140COMNTOOLS%" == "x" goto endif2
   set OPT=-DHAVE_SNPRINTF -DHAVE_STRUCT_TIMESPEC
 :endif2
 
+if "x%inc%" == "xinc" goto skip_inc
 erase *.obj *.mod
+:skip_inc
 make -j 4 SHELL="%ComSpec%" SMV_TESTFLAG="%SMV_TESTFLAG% %OPT%" SMV_TESTSTRING="%SMV_TESTSTRING%" -f ..\Makefile intel_win_64
 if x%from% == xbot goto skip2
 pause

--- a/Source/shared/histogram.h
+++ b/Source/shared/histogram.h
@@ -18,7 +18,7 @@
 
 /* --------------------------  flowlabels ------------------------------------ */
 
-#define NHIST_BUCKETS 100000
+#define NHIST_BUCKETS 10000
 typedef struct {
   unsigned int *buckets_polar;
   float *buckets, bucket_maxval, bucket_maxr, bucket_maxtheta;

--- a/Source/smokeview/IOboundary.c
+++ b/Source/smokeview/IOboundary.c
@@ -2052,6 +2052,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int flag, int *errorcode){
       meshi->patch_times,meshi->zipoffset,meshi->zipsize,maxtimes_boundary);
     meshi->npatch_times=maxtimes_boundary;
     framestart = 0;
+    return_filesize += ncompressed_buffer;
   }
   else{
     if(meshi->patchval == NULL){
@@ -2309,7 +2310,16 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int flag, int *errorcode){
   IdleCB();
 
   STOP_TIMER(total_time);
-  PRINTF(" - %.1f MB/%.1f s\n",(float)return_filesize/1000000.,total_time);
+
+  if(return_filesize > 1000000000){
+    PRINTF(" - %.1f GB in %.1f s\n", (float)return_filesize / 1000000000., total_time);
+  }
+  else if(return_filesize > 1000000){
+    PRINTF(" - %.1f MB in %.1f s\n", (float)return_filesize / 1000000., total_time);
+  }
+ else{
+   PRINTF(" - %.0f kB in %.1f s\n", (float)return_filesize / 1000., total_time);
+  }
   glutPostRedisplay();
   return return_filesize;
 }

--- a/Source/smokeview/IOscript.c
+++ b/Source/smokeview/IOscript.c
@@ -1208,7 +1208,7 @@ void ScriptLoadParticles(scriptdata *scripti){
 
     parti = partinfo + i;
     if(parti->evac==1)continue;
-    ReadPart(parti->file,i,UNLOAD,PARTDATA,&errorcode);
+    ReadPart(parti->file,i,UNLOAD,&errorcode);
     count++;
   }
   for(i=0;i<npartinfo;i++){
@@ -1216,7 +1216,7 @@ void ScriptLoadParticles(scriptdata *scripti){
 
     parti = partinfo + i;
     if(parti->evac==1)continue;
-    ReadPart(parti->file,i,LOAD,PARTDATA,&errorcode);
+    ReadPart(parti->file,i,LOAD,&errorcode);
     if(scripti->cval!=NULL&&strlen(scripti->cval)>0){
       FREEMEMORY(loaded_file);
       NewMemory((void **)&loaded_file,strlen(scripti->cval)+1);

--- a/Source/smokeview/IOslice.c
+++ b/Source/smokeview/IOslice.c
@@ -1689,7 +1689,6 @@ void SetSliceLabels(float smin, float smax,
   if(pd != NULL)sb->label = &(pd->label);
 
   *errorcode = 0;
-  PRINTF("setting up slice labels \n");
   scale = sb->scale;
   GetSliceLabels(smin, smax, nrgb, sb->colorlabels, &scale, &sb->fscale, sb->levels256);
 }
@@ -3832,7 +3831,7 @@ FILE_SIZE ReadSlice(char *file, int ifile, int flag, int set_slicecolor, int *er
   meshdata *meshi;
 
   FILE_SIZE return_filesize=0;
-  int file_size;
+  int file_size=0;
 #ifdef pp_memstatus
   unsigned int availmemory;
 #endif
@@ -4025,13 +4024,16 @@ FILE_SIZE ReadSlice(char *file, int ifile, int flag, int set_slicecolor, int *er
         *errorcode = 1;
         return 0;
       }
-      if(GetSliceCompressedData(sd->comp_file,
+      return_code=GetSliceCompressedData(sd->comp_file,
         settmin_s, settmax_s, tmin_s, tmax_s, sd->ncompressed, sliceframestep, sd->ntimes,
-        sd->times, sd->qslicedata_compressed, sd->compindex, &sd->globalmin, &sd->globalmax) == 0){
+        sd->times, sd->qslicedata_compressed, sd->compindex, &sd->globalmin, &sd->globalmax);
+      if(return_code == 0){
         ReadSlice("", ifile, UNLOAD, set_slicecolor, &error);
         *errorcode = 1;
         return 0;
       }
+      file_size = sd->ncompressed;
+      return_filesize = (FILE_SIZE)file_size;
     }
     else{
       int return_val;

--- a/Source/smokeview/flowfiles.h
+++ b/Source/smokeview/flowfiles.h
@@ -1093,12 +1093,10 @@ typedef struct _part5data {
 
 typedef struct _partdata {
   char *file, *comp_file, *size_file, *reg_file, *hist_file;
-  int seq_id, autoload, loaded, display, reload, finalize;
+  int seq_id, autoload, loaded, request_load, display, reload, finalize;
   int sort_tags_loaded, compression_type, evac;
   int blocknumber;
   int *timeslist, ntimes, itime;
-  int data_type;
-  int compute_bounds_color;
 
   float zoffset, *times;
   FILE_SIZE reg_file_size;

--- a/Source/smokeview/getdatacolors.c
+++ b/Source/smokeview/getdatacolors.c
@@ -669,14 +669,12 @@ void GetPart5Colors(partdata *parti, int nlevel, int convert_flag){
   }
 // erase data memory in a separate loop (so all "columns" are available when doing any conversions)
   datacopy = parti->data5;
-  if(parti->data_type == PARTDATA){
-    for(i = 0; i < parti->ntimes; i++){
-      int j;
+  for(i = 0; i < parti->ntimes; i++){
+    int j;
 
-      for(j = 0; j < parti->nclasses; j++){
-        FREEMEMORY(datacopy->rvals);
-        datacopy++;
-      }
+    for(j = 0; j < parti->nclasses; j++){
+      FREEMEMORY(datacopy->rvals);
+      datacopy++;
     }
   }
   for(i=0;i<npart5prop;i++){

--- a/Source/smokeview/glui_smoke.cpp
+++ b/Source/smokeview/glui_smoke.cpp
@@ -1023,7 +1023,6 @@ extern "C" void Smoke3dCB(int var){
         ROLLOUT_colormap_temp->open();
       }
 #endif
-      if(PANEL_absorption!=NULL)PANEL_absorption->disable();
       firecolormap_type_save=firecolormap_type;
       firecolormap_type=FIRECOLORMAP_CONSTRAINT;
       RADIO_use_colormap->set_int_val(firecolormap_type);

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -155,9 +155,6 @@ void Usage(char *prog,int option){
 #ifdef pp_OSXGLUT32
     strcat(label, ", pp_OSXGLUT32");
 #endif
-#ifdef pp_PARTDEFER
-    strcat(label, ", pp_PARTDEFER");
-#endif
 #ifdef pp_PARTTEST
     strcat(label, ", pp_PARTTEST");
 #endif

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -3421,7 +3421,7 @@ void LoadParticleMenu(int value){
     ReadPartFile=1;
     parti = partinfo + value;
     partfile = parti->file;
-    parti->finalize2 = 1;
+    parti->finalize = 1;
     if(scriptoutstream!=NULL){
       fprintf(scriptoutstream,"LOADFILE\n");
       fprintf(scriptoutstream," %s\n",partfile);
@@ -3484,7 +3484,7 @@ void LoadParticleMenu(int value){
 
           parti = partinfo+i;
           if(parti->evac==1||parti->loaded==0)continue;
-          parti->finalize2 = 1;
+          parti->finalize = 1;
           ReadPart(parti->file, i, UNLOAD,  &errorcode);
         }
       }
@@ -3500,8 +3500,8 @@ void LoadParticleMenu(int value){
         parti = partinfo + i;
         if(parti->evac == 1)continue;
         if(parti->loaded == 0 && value == PARTFILE_RELOADALL)continue;
-        parti->finalize2 = 0;
-        if(lasti == i)parti->finalize2 = 1;
+        parti->finalize = 0;
+        if(lasti == i)parti->finalize = 1;
         load_size+=ReadPart(parti->file, i, LOAD, &errorcode);
         file_count++;
       }

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -2640,6 +2640,7 @@ void LuaScriptMenu(int value){
 void ReloadMenu(int value){
   int msecs;
 
+  if(value == MENU_DUMMY)return;
   updatemenu=1;
   periodic_value=value;
   switch(value){
@@ -10712,8 +10713,8 @@ updatemenu=0;
       glutAddMenuEntry(_("New data"), RELOAD_MODE_INCREMENTAL);
       glutAddMenuEntry(_("*All data"), RELOAD_MODE_ALL);
     }
-    glutAddMenuEntry("-", -999);
-    glutAddMenuEntry(_("When:"), -999);
+    glutAddMenuEntry("-", MENU_DUMMY);
+    glutAddMenuEntry(_("When:"), MENU_DUMMY);
     glutAddMenuEntry(_("  now"),RELOAD_SWITCH);
     if(periodic_value==1)glutAddMenuEntry(_("   *every minute"),1);
     if(periodic_value!=1)glutAddMenuEntry(_("   every minute"),1);

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -17,6 +17,7 @@
 
 //*** options: all platforms
 
+//#define pp_SMOKEDIAG    // output smoke3d diagnostics (number of meshes, total trianles, triangles drawn)
 //#define pp_GEOMPRINT  // output geometry info
 //#define pp_MAKE_SMOKEIBLANK // generate smoke iblank arrays
 //#define pp_DPRINT       // debug print, printf line number and source file

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -27,7 +27,6 @@
 #define pp_FILELIST     // use list of file names
 #define pp_LANG         // support other languages
 
-#define pp_PARTDEFER    // defer particle bound and coloring until last particle file is loaded
 //#define pp_SPECTRAL
 
 #define pp_GPU          // support the GPU

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -7876,7 +7876,7 @@ typedef struct {
       parti->blocknumber=blocknumber;
       parti->seq_id=nn_part;
       parti->autoload=0;
-      parti->compute_bounds_color = SET_PARTCOLOR;
+      parti->finalize = 1;
       if(FGETS(buffer,255,stream)==NULL){
         npartinfo--;
         BREAK;
@@ -7947,6 +7947,7 @@ typedef struct {
       parti->compression_type=UNCOMPRESSED;
       parti->sort_tags_loaded=0;
       parti->loaded=0;
+      parti->request_load = 0;
       parti->finalize = 0;
       parti->display=0;
       parti->times=NULL;

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -86,7 +86,6 @@ EXTERNCPP void DrawScreenInfo(void);
 #endif
 EXTERNCPP void UpdateShowSliceInObst(void);
 EXTERNCPP void GetGeomZBounds(float *zmin, float *zmax);
-EXTERNCPP void GetPartHistogram(int flag);
 EXTERNCPP void MakeIBlankAll(void);
 EXTERNCPP void UpdateSliceDupDialog(void);
 EXTERNCPP void DrawNorth(void);
@@ -765,7 +764,7 @@ EXTERNCPP void ReadAllGeom(void);
 EXTERNCPP FILE_SIZE ReadGeom(geomdata *geomi, int load_flag, int type, int *geom_frame_index, int *errorcode);
 EXTERNCPP void InitGeom(geomdata *geomi, int hasdata, int fdsblock);
 EXTERNCPP FILE_SIZE ReadBoundary(int ifile, int flag, int *errorcode);
-EXTERNCPP float ReadPart(char *file, int ifile, int loadflag, int set_colorbound, int *errorcode);
+EXTERNCPP FILE_SIZE ReadPart(char *file, int ifile, int loadflag, int *errorcode);
 EXTERNCPP void ReadZone(int ifile, int flag, int *errorcode);
 EXTERNCPP FILE_SIZE ReadVSlice(int ivslice, int flag, int *errorcode);
 

--- a/Source/smokeview/smokeviewdefs.h
+++ b/Source/smokeview/smokeviewdefs.h
@@ -89,13 +89,6 @@ void _Sniff_Errors(char *whereat);
 #define SET_SLICECOLOR   0
 #define DEFER_SLICECOLOR 1
 
-#define DEFER_PARTCOLOR   0
-#define SET_PARTCOLOR     1
-#define SET_ALLPARTCOLORS 2
-
-#define PARTDATA 0
-#define HISTDATA 1
-
 #define SLICEDUP_KEEPALL 0
 #define SLICEDUP_KEEPFINE 1
 #define SLICEDUP_KEEPCOARSE 2

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -20,6 +20,9 @@
 #include "smokeheaders.h"
 #include "threader.h"
 
+#ifdef pp_SMOKEDIAG
+SVEXTERN unsigned int total_triangles, total_drawn_triangles;
+#endif
 SVEXTERN float SVDECL(geomslice_pointsize, 5.0);
 SVEXTERN float SVDECL(geomboundary_pointsize, 5.0);
 SVEXTERN float SVDECL(geomslice_linewidth, 5.0);

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -971,15 +971,15 @@ void InitOpenGL(void){
       partdata *parti;
 
       parti = partinfo + i;
-      if(parti->autoload==0&&parti->loaded==1)ReadPart(parti->file, i, UNLOAD, PARTDATA,&errorcode);
-      if(parti->autoload==1)ReadPart(parti->file, i, UNLOAD, PARTDATA,&errorcode);
+      if(parti->autoload==0&&parti->loaded==1)ReadPart(parti->file, i, UNLOAD, &errorcode);
+      if(parti->autoload==1)ReadPart(parti->file, i, UNLOAD, &errorcode);
     }
     for(i=0;i<npartinfo;i++){
       partdata *parti;
 
       parti = partinfo + i;
-      if(parti->autoload==0&&parti->loaded==1)ReadPart(parti->file, i, UNLOAD, PARTDATA,&errorcode);
-      if(parti->autoload==1)ReadPart(parti->file, i, LOAD, PARTDATA,&errorcode);
+      if(parti->autoload==0&&parti->loaded==1)ReadPart(parti->file, i, UNLOAD, &errorcode);
+      if(parti->autoload==1)ReadPart(parti->file, i, LOAD, &errorcode);
     }
     update_readiso_geom_wrapup = UPDATE_ISO_START_ALL;
     for(i = 0; i<nisoinfo; i++){

--- a/scripts/webBUILDsmv.bat
+++ b/scripts/webBUILDsmv.bat
@@ -29,13 +29,17 @@ set type=
 if "%buildtype%" == "test" (
    set type=-t
 )
+if "%buildtype%" == "testinc" (
+   set type=-t
+   set inc=inc
+)
 if "%buildtype%" == "release" (
    set type=-r
 )
 
 if "%platform%" == "windows" (
   cd %svn_root%\smv\Build\smokeview\intel_win_64
-  call make_smokeview %type%
+  call make_smokeview %type% web %inc%
   goto eof
 )
 if "%platform%" == "linux" (


### PR DESCRIPTION
1.  eliminates the histogram particle pass .  Now particles are essentially only loaded once instead of 3 times .  I say essentially because the "sizing" pass is now done in C not Fortran which is much quicker because C can skip over the data it doesn't need to know.   For the Gatlinburg case load times that were 2 minutes are now  about 15 seconds.  This addresses issue firemodels/smv#665

2.  Fix problem with Reload/When menu.  This menu is now ignored if selected (addresses issue #6744 )