### PR TITLE
smokeview source: fix 'Unload All' menu item when unloading geometry …

### DIFF
--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -2949,7 +2949,14 @@ void LoadUnloadMenu(int value){
       slicedata *slicei;
 
       slicei = sliceinfo + i;
-      ReadSlice(slicei->file, i, UNLOAD, DEFER_SLICECOLOR,&errorcode);
+      if(slicei->loaded == 1){
+        if(slicei->slicefile_type == SLICE_GEOM){
+          ReadGeomData(slicei->patchgeom, slicei, UNLOAD, &errorcode);
+        }
+        else{
+          ReadSlice(slicei->file, i, UNLOAD, DEFER_SLICECOLOR,&errorcode);
+        }
+      }
     }
     for(i = 0; i<nplot3dinfo; i++){
       ReadPlot3D("",i,UNLOAD,&errorcode);


### PR DESCRIPTION
…slice files

When Unloading All files, code was not distinguishing between geometry slice and regular slice files.  (We need to check that a similar type of error is note occurring with geometry boundary and regular boundary files)