### PR TITLE
build: Trial makefiles for libraries

### DIFF
--- a/Build/LIBS/gnu_linux_64/make_LIBS.make
+++ b/Build/LIBS/gnu_linux_64/make_LIBS.make
@@ -1,0 +1,61 @@
+OPTS="-g -6"
+LIBDIR=$(shell pwd)
+SRCDIR=$(LIBDIR)/../../../Source
+
+all: libgd.a libglui.a libglut.a libjpeg.a libpng.a libz.a liblua.a lpeg.so
+
+# GD
+libgd.a:
+	@echo $(LIBDIR)
+	cd $(SRCDIR)/gd-2.0.15; \
+		./makelib.sh $(OPTS); \
+		cp libgd.a $(LIBDIR)/.
+
+# GLUI
+libglui.a:
+	cd $(SRCDIR)/glui_v2_1_beta; \
+		./makelib.sh $(OPTS); \
+		cp libglui.a $(LIBDIR)/.
+
+# GLUT
+libglut.a:
+	cd $(SRCDIR)/glut-3.7.6; \
+	export TARGET=libglut.a; \
+	./makelib.sh $(OPTS); \
+	cp libglut.a $(LIBDIR)/.
+
+# JPEG
+libjpeg.a:
+	cd $(SRCDIR)/jpeg-9b; \
+		./makelib.sh $(OPTS); \
+		cp libjpeg.a $(LIBDIR)/.
+
+# PNG
+libpng.a:
+	cd $(SRCDIR)/png-1.6.21; \
+		./makelib.sh $(OPTS); \
+		cp libpng.a $(LIBDIR)/.
+
+# ZLIB
+libz.a:
+	cd $(SRCDIR)/zlib128; \
+		./makelib.sh $(OPTS); \
+		cp libz.a $(LIBDIR)/.
+
+# Lua # Lua interpreter
+liblua.a:
+	cd $(SRCDIR)/lua-5.3.1; \
+		export TARGET=linux; \
+		./makelib.sh $(OPTS); \
+		cp src/liblua.a $(LIBDIR)/.
+
+# LPEG # Lua parsing libarary to parse SSF files
+# This depends on lua being built first
+lpeg.so: liblua.a
+	cd $(SRCDIR)/lpeg-1.0.0; \
+		pwd; \
+		export TARGET=linux; \
+		./makelib.sh $(OPTS); \
+		cp lpeg.so $(LIBDIR)/.
+
+.PHONY: all

--- a/Build/LIBS/mingw_win_64/make_LIBS.make
+++ b/Build/LIBS/mingw_win_64/make_LIBS.make
@@ -1,0 +1,62 @@
+OPTS="-g -6"
+LIBDIR=$(shell pwd)
+SRCDIR=$(LIBDIR)/../../../Source
+
+all: libgd.a libglui.a libglutwin.a libjpeg.a libpng.a libz.a lua53.dll lpeg.dll
+
+# GD
+libgd.a:
+	@echo $(LIBDIR)
+	cd $(SRCDIR)/gd-2.0.15; \
+		./makelib.sh $(OPTS); \
+		cp libgd.a $(LIBDIR)/.
+
+# GLUI
+libglui.a:
+	cd $(SRCDIR)/glui_v2_1_beta; \
+		./makelib.sh $(OPTS); \
+		cp libglui.a $(LIBDIR)/.
+
+# GLUT
+libglutwin.a:
+	cd $(SRCDIR)/glut-3.7.6; \
+	export TARGET=libglutwin.a; \
+	./makelib.sh $(OPTS); \
+	cp libglutwin.a $(LIBDIR)/.
+
+# JPEG
+libjpeg.a:
+	cd $(SRCDIR)/jpeg-9b; \
+		./makelib.sh $(OPTS); \
+		cp libjpeg.a $(LIBDIR)/.
+
+# PNG
+libpng.a:
+	cd $(SRCDIR)/png-1.6.21; \
+		./makelib.sh $(OPTS); \
+		cp libpng.a $(LIBDIR)/.
+
+# ZLIB
+libz.a:
+	cd $(SRCDIR)/zlib128; \
+		./makelib.sh $(OPTS); \
+		cp libz.a $(LIBDIR)/.
+
+# Lua # Lua interpreter
+lua53.dll liblua.a:
+	cd $(SRCDIR)/lua-5.3.1; \
+		export TARGET=mingw; \
+		./makelib.sh $(OPTS); \
+		cp src/lua53.dll $(LIBDIR)/.; \
+		cp src/liblua.a $(LIBDIR)/.
+
+# LPEG # Lua parsing libarary to parse SSF files
+# This depends on lua being built first
+lpeg.dll: liblua.a
+	cd $(SRCDIR)/lpeg-1.0.0; \
+		pwd; \
+		export TARGET=mingw; \
+		./makelib.sh $(OPTS); \
+		cp lpeg.dll $(LIBDIR)/.
+
+.PHONY: all

--- a/Build/smokeview/gnu_linux_64/make_smokeview_lua.sh
+++ b/Build/smokeview/gnu_linux_64/make_smokeview_lua.sh
@@ -1,8 +1,11 @@
-#!/bin/bash
+# !/bin/bash
+# Exit immediately if any of the build steps fail
+set -e
+source ../../scripts/setopts.sh $*
 LIBDIR=../../LIBS/gnu_linux_64/
-source ../../scripts/test_libs.sh lua
 LUA_SCRIPTING="LUA_SCRIPTING=true"
+eval make -C ${LIBDIR} -j 4 ${SMV_MAKE_OPTS} ${LUA_SCRIPTING} -f make_LIBS.make all
 
 make -f ../Makefile clean
-eval make -j 4 ${LUA_SCRIPTING} -f ../Makefile gnu_linux_64
+eval make -j 4 ${SMV_MAKE_OPTS} ${LUA_SCRIPTING} -f ../Makefile gnu_linux_64
 

--- a/Build/smokeview/mingw_win_64/make_smokeview_lua.sh
+++ b/Build/smokeview/mingw_win_64/make_smokeview_lua.sh
@@ -1,8 +1,10 @@
 # !/bin/bash
-# source ../../scripts/setopts.sh $*
+# Exit immediately if any of the build steps fail
+set -e
+source ../../scripts/setopts.sh $*
 LIBDIR=../../LIBS/mingw_win_64/
-source ../../scripts/test_libs.sh lua
 LUA_SCRIPTING="LUA_SCRIPTING=true"
+eval make -C ${LIBDIR} -j 4 ${SMV_MAKE_OPTS} ${LUA_SCRIPTING} -f make_LIBS.make all
 
 make -f ../Makefile clean
 eval make -j 4 ${SMV_MAKE_OPTS} ${LUA_SCRIPTING} -f ../Makefile mingw_win_64


### PR DESCRIPTION
Currently, in order to build the library dependencies for Smokeview, the various make_smokeview.sh scripts call test_libs.sh. This script essentially tests for the presence of each library and rebuilds all scripts if any are missing. This is essentially the same job as a makefile, so it makes sense from a maintainability perspective just to use makefiles here as well.

- This is more consistent with the rest of the build system, which uses makefiles.
- The current implementation can result in libraries being built multiple times if there's a build error (this has bitten me).
- By using makefiles it's trivial to enable parallel builds (e.g. with `-j 4`). This cuts my build time in half.