### PR TITLE
smokeview source: add short cuts '{' and '}' for loading the previous…

### DIFF
--- a/Source/smokeview/callbacks.c
+++ b/Source/smokeview/callbacks.c
@@ -2452,6 +2452,16 @@ void Keyboard(unsigned char key, int flag){
     case ';':
       ColorbarMenu(COLORBAR_FLIP);
       break;
+    case '{':
+      iplot3dtimelist--;
+      if(iplot3dtimelist<0)iplot3dtimelist=nplot3dtimelist-1;
+      Plot3DListMenu(iplot3dtimelist);
+      break;
+    case '}':
+      iplot3dtimelist++;
+      if(iplot3dtimelist>=nplot3dtimelist)iplot3dtimelist=0;
+      Plot3DListMenu(iplot3dtimelist);
+      break;
   }
 
   skip2=key2-'1'+1;
@@ -3357,12 +3367,6 @@ void DoScript(void){
         SMV_EXIT(0);
       }
       if(current_script_command==NULL){
-        if(use_customview==1){
-//#define RESTORE_VIEW 8
-//          ViewpointCB(RESTORE_VIEW);
-           printf("***warning: you must use the Show/Hide>Viewpoints menu to set a viewpoint\n");
-           printf("            before you can manipulate the scene with the mouse\n");
-        }
         GluiScriptEnable();
       }
     }

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -5002,7 +5002,8 @@ void Plot3DListMenu(int value){
   int i;
   plot3ddata *plot3di;
 
-  if(value<0||value>=nplot3dtimelist)return;
+  value = CLAMP(value, 0, nplot3dtimelist-1);
+  iplot3dtimelist = value;
   LoadPlot3dMenu(UNLOAD_ALL);
   if(scriptoutstream!=NULL){
     fprintf(scriptoutstream,"LOADPLOT3D\n");
@@ -9247,6 +9248,8 @@ updatemenu=0;
     glutAddMenuEntry(_("  s: change interval between adjacent vectors"), MENU_DUMMY);
     glutAddMenuEntry(_("  c: toggle between continuous and 2D stepped contours"), MENU_DUMMY);
     glutAddMenuEntry(_("  i: toggle iso-surface visibility"), MENU_DUMMY);
+    glutAddMenuEntry(_("  {: load previous time Plot3D files"), MENU_DUMMY);
+    glutAddMenuEntry(_("  }: load next time Plot3D files"), MENU_DUMMY);
   }
   glutAddMenuEntry(_("Misc"), MENU_DUMMY);
   glutAddMenuEntry(_("  r/R: render the current scene to an image file"), MENU_DUMMY);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -20,6 +20,8 @@
 #include "smokeheaders.h"
 #include "threader.h"
 
+SVEXTERN int SVDECL(iplot3dtimelist, -1);
+
 #define NRENDER_SKIPS 8
 #ifdef INMAIN
 SVEXTERN int render_skips[NRENDER_SKIPS] = {RENDER_CURRENT_SINGLE, 1, 2, 3, 4, 5, 10, 20};


### PR DESCRIPTION
… plot3d time and next plot3d time respectively - addresses smokeview issue 905