### PR TITLE
smokeview source: correct variable declaration , was causing smokevie…

### DIFF
--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -5846,7 +5846,8 @@ int ReadSMV(bufferstreamdata *stream){
 
 
     if(Match(buffer, "TITLE")==1){
-      char *fds_title_local, len_title;
+      char *fds_title_local;
+      int len_title;
 
       FGETS(buffer, 255, stream);
       fds_title_local = TrimFrontBack(buffer);


### PR DESCRIPTION
…w to crash when a title was longer than 128 characters - addresses fds issue 8644