### PR TITLE
smokeview source: eliminate cface surface hard wired vertical offset,…

### DIFF
--- a/Source/smokeview/IOgeometry.c
+++ b/Source/smokeview/IOgeometry.c
@@ -4332,7 +4332,6 @@ void DrawCGeom(int flag, geomdata *cgeom){
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
       glTranslatef(-xbar0, -ybar0, -zbar0);
-      if(auto_terrain==1)glTranslatef(0.0, 0.0, SCALE2FDS(0.01));
       glBegin(GL_TRIANGLES);
       for(j = 0; j<ntris; j++){
         float *color, *xyzptr[3];

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -549,7 +549,7 @@ SVEXTERN float SVDECL(geom_vecfactor, .030);
 SVEXTERN int SVDECL(geom_ivecfactor, 30);
 SVEXTERN int SVDECL(geom_outline_ioffset, 1);
 SVEXTERN float SVDECL(geom_norm_offset,0.01);
-SVEXTERN float SVDECL(geom_dz_offset,0.01);
+SVEXTERN float SVDECL(geom_dz_offset,0.001);
 SVEXTERN int SVDECL(iso_outline_ioffset, 1);
 SVEXTERN float SVDECL(iso_outline_offset, 0.001);
 SVEXTERN float SVDECL(geom_max_angle, 30.0), cos_geom_max_angle;


### PR DESCRIPTION
… change default user settable vertical offset to 0.001 (smv units)