### PR TITLE
Reintroduce dependencies between fortran files

### DIFF
--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -507,6 +507,11 @@ string_util.obj:	.FORCE
 .FORCE:
 
 # *** Object Dependencies ***
+gsmv.o : fdsmodules.o
+getdata.o : gsmv.o fdsmodules.o
+
+gsmv.obj : fdsmodules.obj
+getdata.obj : gsmv.obj fdsmodules.obj
 
 # *** do a full rebuild if any header file has changed
 #

--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -508,10 +508,8 @@ string_util.obj:	.FORCE
 
 # *** Object Dependencies ***
 gsmv.o : fdsmodules.o
-getdata.o : gsmv.o fdsmodules.o
 
 gsmv.obj : fdsmodules.obj
-getdata.obj : gsmv.obj fdsmodules.obj
 
 # *** do a full rebuild if any header file has changed
 #


### PR DESCRIPTION
This reintroduces dependencies between the fortran modules to ensure that they're build in the right order. Explicitly specifying these dependencies removes a race condition during build.

This builds successfully as seen here: [https://github.com/JakeOShannessy/smv/actions/runs/1660593294](https://github.com/JakeOShannessy/smv/actions/runs/1660593294).