### PR TITLE
Remove lua builds

### DIFF
--- a/.github/workflows/build-smv.yml
+++ b/.github/workflows/build-smv.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         lua:
-          - lua
+          # - lua
           - no-lua
     runs-on: ${{ matrix.os }}
     steps:
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         lua:
-          - lua
+          # - lua
           - no-lua
     runs-on: windows-latest
     defaults:


### PR DESCRIPTION
Given that when the lua build breaks it sends out warnings to others, this commit disables them. At least until a more permanent solution is found.