### PR TITLE
Correct length of the file buffer passed to GetOpenFilename

### DIFF
--- a/.github/workflows/build-smv.yml
+++ b/.github/workflows/build-smv.yml
@@ -165,7 +165,7 @@ jobs:
         lua:
           # - lua
           - no-lua
-    runs-on: windows-latest
+    runs-on: windows-2019
     defaults:
       run:
         shell: bash

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -259,7 +259,7 @@ char *ParseCommandline(int argc, char **argv){
 
     openfile=0;
     filelength = 1024;
-    NewMemory((void **)&filename_local, (unsigned int)len_memory+4);
+    NewMemory((void **)&filename_local, (unsigned int)filelength);
     OpenSMVFile(filename_local,filelength,&openfile);
     if(openfile==1&&ResizeMemory((void **)&filename_local,strlen(filename_local)+1)!=0){
     }


### PR DESCRIPTION
The buffer passed to GetOpenFileName (via OpenSMVFile) is `filename_local` and has length `filelength`. However, the memory allocated to `filename_local` is only `len_memory+4`, which is far less than `filelength`. This can cause memory corruption on Windows when longer paths are used.