### PR TITLE
Use firemodels/fig repo for test data

### DIFF
--- a/Tests/get_test_data.ps1
+++ b/Tests/get_test_data.ps1
@@ -1,8 +1,8 @@
-$commit = "06449f1db6f42c41f0d43d71f1c46513f98c7d3c"
+$commit = "97c852beff8c6142ec09dc0092381a605d08d943"
 
 $zip_path = "$env:temp\test-data.zip"
 $unzip_path = "$env:temp\test-data-out"
-Invoke-WebRequest -Uri https://github.com/JakeOShannessy/fig/archive/$commit.zip -OutFile $zip_path
+Invoke-WebRequest -Uri https://github.com/firemodels/fig/archive/$commit.zip -OutFile $zip_path
 Expand-Archive $zip_path -DestinationPath $unzip_path -Force
 mkdir fig -Force
 Move-Item $unzip_path/fig-$commit/* fig -Force

--- a/Tests/get_test_data.sh
+++ b/Tests/get_test_data.sh
@@ -1,8 +1,8 @@
-COMMIT=06449f1db6f42c41f0d43d71f1c46513f98c7d3c
+COMMIT=97c852beff8c6142ec09dc0092381a605d08d943
 
 TEMP_DIR=$(mktemp -d)
 ZIP_PATH=$TEMP_DIR/test-data.zip
-wget https://github.com/JakeOShannessy/fig/archive/$COMMIT.zip -O $ZIP_PATH
+wget https://github.com/firemodels/fig/archive/$COMMIT.zip -O $ZIP_PATH
 unzip $ZIP_PATH
 mkdir -p fig
 mv fig-$COMMIT/* fig


### PR DESCRIPTION
Now that firemodels/fig has merged the appropriate test data we can use it directly.