### PR TITLE
Remove headers mallocc

### DIFF
--- a/Source/mergepo/main.c
+++ b/Source/mergepo/main.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include "MALLOCC.h"
 #include "translate.h"
+#include "string_util.h"
 
 /* ------------------ Usage ------------------------ */
 

--- a/Source/shared/MALLOCC.h
+++ b/Source/shared/MALLOCC.h
@@ -13,8 +13,6 @@
 #include <malloc.h>
 #endif
 #include "ASSERT.h"
-#include "string_util.h"
-#include "file_util.h"
 #define memGarbage 0xA3
 
 typedef int mallocflag;

--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -28,6 +28,8 @@
 #include <dirent.h>
 #endif
 #include "MALLOCC.h"
+#include "string_util.h"
+#include "file_util.h"
 
 FILE *alt_stdout=NULL;
 

--- a/Source/shared/file_util.h
+++ b/Source/shared/file_util.h
@@ -92,6 +92,7 @@ int FileExistsOrig(char *filename);
 #define SEP '/'
 #endif
 
+#include "string_util.h"
 
 // vvvvvvvvvvvvvvvvvvvvvvvv headers vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 

--- a/Source/shared/stdio_buffer.c
+++ b/Source/shared/stdio_buffer.c
@@ -3,6 +3,7 @@
 #include <string.h>
 #include "stdio_buffer.h"
 #include "MALLOCC.h"
+#include "string_util.h"
 
 /* ------------------ OutputFileBuffer ------------------------ */
 

--- a/Source/shared/string_util.c
+++ b/Source/shared/string_util.c
@@ -25,6 +25,7 @@
 #include "MALLOCC.h"
 #include "datadefs.h"
 #include "file_util.h"
+#include "string_util.h"
 #ifdef pp_HASH
 #include "mbedtls/md5.h"
 #include "mbedtls/sha256.h"

--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -769,10 +769,10 @@ int lua_get_devices(lua_State *L) {
   lua_createtable(L, 0, entries);
   int i;
   for (i = 0; i < entries; i++) {
-    lua_pushstring(L, infotable[i].label);
+    lua_pushstring(L, infotable[i].deviceID);
     lua_createtable(L, 0, 2);
 
-    lua_pushstring(L, infotable[i].label);
+    lua_pushstring(L, infotable[i].deviceID);
     lua_setfield(L, -2, "label");
 
     lua_settable(L, -3);

--- a/Source/smokeview/structures.h
+++ b/Source/smokeview/structures.h
@@ -2,6 +2,7 @@
 #define FLOWFILES_H_DEFINED
 
 #include "stdio_m.h"
+#include "string_util.h" // necessary for flowlabels
 
 /* --------------------------  circdata ------------------------------------ */
 


### PR DESCRIPTION
These two header files are no actually necessary in MALLOCC.h. These headers do need to be added elsewhere as they were previously transitively included via MALLOCC.h.

Proposing to merge this to devel2 as it is particularly useful in building tests.