### PR TITLE
Fix linkage on some ancillary exectuables

### DIFF
--- a/Build/flush/Makefile
+++ b/Build/flush/Makefile
@@ -99,7 +99,6 @@ gnu_linux_64: $(obj)
 
 intel_linux_64 : LIB_DIR_PLAT = $(LIB_DIR)/intel_linux_64
 intel_linux_64 : CFLAGS    = -O2 -m64 -D pp_LINUX $(GITINFO) $(INTEL_COMPINFO)
-intel_linux_64 : LFLAGS    = -lifport
 intel_linux_64 : CC        = $(I_ICC)
 intel_linux_64 : exe       = flush_linux_64
 

--- a/Build/makepo/Makefile
+++ b/Build/makepo/Makefile
@@ -81,11 +81,12 @@ intel_linux_64 : $(obj)
 # ------------- gnu linux 64 ----------------
 
 gcc_linux_64 : CFLAGS    = -O2 -m64 -D pp_LINUX $(GITINFO) $(GNU_COMPINFO)
+gcc_linux_64 : LFLAGS    = -lm
 gcc_linux_64 : CC        = gcc
 gcc_linux_64 : exe       = makepo_linux_64
 
 gcc_linux_64 : $(obj)
-	$(CC) -o $(bin)/$(exe) $(obj)
+	$(CC) -o $(bin)/$(exe) $(obj) $(LFLAGS)
 
 # ------------- intel osx 64 ----------------
 

--- a/Build/mergepo/Makefile
+++ b/Build/mergepo/Makefile
@@ -83,11 +83,12 @@ intel_linux_64 : $(obj)
 # ------------- gnu linux 64 ----------------
 
 gcc_linux_64 : CFLAGS    = -O2 -m64 -D pp_LINUX $(GITINFO) $(GNU_COMPINFO)
+gcc_linux_64 : LFLAGS    = -lm
 gcc_linux_64 : CC        = gcc
 gcc_linux_64 : exe       = mergepo_linux_64
 
 gcc_linux_64 : $(obj)
-	$(CC) -o $(bin)/$(exe) $(obj)
+	$(CC) -o $(bin)/$(exe) $(obj) $(LFLAGS)
 
 # ------------- intel osx 64 ----------------
 

--- a/Build/timep/Makefile
+++ b/Build/timep/Makefile
@@ -99,7 +99,6 @@ gnu_linux_64: $(obj)
 
 intel_linux_64 : LIB_DIR_PLAT = $(LIB_DIR)/intel_linux_64
 intel_linux_64 : CFLAGS    = -O2 -m64 -D pp_LINUX $(GITINFO) $(INTEL_COMPINFO)
-intel_linux_64 : LFLAGS    = -lifport
 intel_linux_64 : CC        = $(I_ICC)
 intel_linux_64 : exe       = timep_linux_64
 


### PR DESCRIPTION
This tweaks some linkage of flush, makepo, mergepo, and timep.

The maths library is added to makepo and mergepo.

A Fortran library is removed from flush and timep.