### PR TITLE
Add other executables

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,10 +1,10 @@
 name: CMake Build
 on: [push, pull_request]
 env:
-  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18418/w_BaseKit_p_2022.1.0.116_offline.exe
-  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18417/w_HPCKit_p_2022.1.0.93_offline.exe
-  LINUX_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18445/l_BaseKit_p_2022.1.1.119_offline.sh
-  LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18438/l_HPCKit_p_2022.1.1.97_offline.sh
+  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18599/w_BaseKit_p_2022.1.3.210_offline.exe
+  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18578/w_HPCKit_p_2022.1.3.145_offline.exe
+  LINUX_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18487/l_BaseKit_p_2022.1.2.146_offline.sh
+  LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18479/l_HPCKit_p_2022.1.2.117_offline.sh
   MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18341/m_HPCKit_p_2022.1.0.86_offline.dmg
   WINDOWS_CPP_COMPONENTS: intel.oneapi.win.cpp-compiler
   WINDOWS_FORTRAN_COMPONENTS: intel.oneapi.win.ifort-compiler
@@ -16,6 +16,9 @@ env:
   LINUX_FORTRAN_COMPONENTS_WEB: intel.oneapi.lin.ifort-compiler
   LINUX_DPCPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler
   MACOS_CPP_COMPONENTS: intel.oneapi.mac.cpp-compiler
+  MACOS_FORTRAN_COMPONENTS: intel.oneapi.mac.ifort-compiler
+  CACHE_NUMBER: 2
+  COMPILER_VERSION: 2022.0.3
   BUILD_TYPE: Release
 
 jobs:
@@ -167,15 +170,23 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      # - name: cache install cpp
-      #   id: cache-install-cpp
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: C:\Program Files (x86)\Intel\oneAPI
-      #     key: install3-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}-compiler-${{ hashFiles('**/.github/workflows/cache_exclude_windows.sh') }}
-      - name: install cpp
-        # if: steps.cache-install-cpp.outputs.cache-hit != 'true'
-        run: .github/workflows/install_windows_oneapi.bat $WINDOWS_HPCKIT_URL
+      - name: cache install
+        id: cache-install
+        uses: actions/cache@v2
+        with:
+          path: |
+              C:\Program Files (x86)\Intel\oneAPI\setvars.bat
+              C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat
+              C:\Program Files (x86)\Intel\oneAPI\compiler
+          key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
+      - name: install
+        if: steps.cache-install.outputs.cache-hit != 'true'
+        run: .github/workflows/install_windows_oneapi.bat $WINDOWS_HPCKIT_URL $WINDOWS_CPP_COMPONENTS
+      - name: Make latest link
+        shell: cmd
+        run: |
+          rmdir "C:\Program Files (x86)\Intel\oneAPI\compiler\latest"
+          mklink /D "C:\Program Files (x86)\Intel\oneAPI\compiler\latest" "C:\Program Files (x86)\Intel\oneAPI\compiler\2022.0.3"
       - name: build smokeview lua
         shell: cmd
         run: |
@@ -197,10 +208,10 @@ jobs:
       - name: Set exec suffix
         if: ${{ matrix.lua }} == lua
         run: echo "exec_suffix=-lua" >> $GITHUB_ENV
-      # - name: exclude unused files from cache
-      #   if: steps.cache-install.outputs.cache-hit != 'true'
-      #   shell: bash
-      #   run: .github/workflows/cache_exclude_windows.sh
+      - name: exclude unused files from cache
+        if: steps.cache-install.outputs.cache-hit != 'true'
+        shell:  bash
+        run: .github/workflows/cache_exclude_windows.sh
       - name: Archive production artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/make-scripts.yml
+++ b/.github/workflows/make-scripts.yml
@@ -1,10 +1,10 @@
 name: Scripts & Make Build
 on: [push, pull_request]
 env:
-  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18418/w_BaseKit_p_2022.1.0.116_offline.exe
-  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18417/w_HPCKit_p_2022.1.0.93_offline.exe
-  LINUX_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18445/l_BaseKit_p_2022.1.1.119_offline.sh
-  LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18438/l_HPCKit_p_2022.1.1.97_offline.sh
+  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18599/w_BaseKit_p_2022.1.3.210_offline.exe
+  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18578/w_HPCKit_p_2022.1.3.145_offline.exe
+  LINUX_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18487/l_BaseKit_p_2022.1.2.146_offline.sh
+  LINUX_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18479/l_HPCKit_p_2022.1.2.117_offline.sh
   MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/18341/m_HPCKit_p_2022.1.0.86_offline.dmg
   WINDOWS_CPP_COMPONENTS: intel.oneapi.win.cpp-compiler
   WINDOWS_FORTRAN_COMPONENTS: intel.oneapi.win.ifort-compiler
@@ -16,17 +16,29 @@ env:
   LINUX_FORTRAN_COMPONENTS_WEB: intel.oneapi.lin.ifort-compiler
   LINUX_DPCPP_COMPONENTS_WEB: intel.oneapi.lin.dpcpp-cpp-compiler
   MACOS_CPP_COMPONENTS: intel.oneapi.mac.cpp-compiler
+  MACOS_FORTRAN_COMPONENTS: intel.oneapi.mac.ifort-compiler
+  CACHE_NUMBER: 2
+  COMPILER_VERSION: 2022.0.3
 
 jobs:
-  build-macos:
-    name: intel_osx
+  build-macos-intel:
+    name: intel_osx_${{ matrix.program }}
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        lua:
-          # - lua
-          - no-lua
-    runs-on: macos-latest
+        program:
+          - background
+          - convert
+          - env2mod
+          - flush
+          - makepo
+          - mergepo
+          - smokediff
+          - smokeview
+          - smokezip
+          - timep
+          - wind2fds
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -34,82 +46,40 @@ jobs:
         run: |
           sudo mkdir -p /opt/intel
           sudo chown $USER /opt/intel
-      # - name: cache install
-      #   id: cache-install
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: /opt/intel/oneapi
-      #     key: install2-${{ env.MACOS_HPCKIT_URL }}-${{ env.MACOS_CPP_COMPONENTS }}
+      - name: cache install
+        id: cache-install
+        uses: actions/cache@v2
+        with:
+          path: /opt/intel/oneapi
+          key: install2-${{ env.MACOS_HPCKIT_URL }}-${{ env.MACOS_CPP_COMPONENTS }}
       - name: install
-        # if: steps.cache-install.outputs.cache-hit != 'true'
+        if: steps.cache-install.outputs.cache-hit != 'true'
         run: bash .github/workflows/install_macos_oneapi.sh $MACOS_HPCKIT_URL
-      - name: build smokeview
+      - name: build ${{ matrix.program }}
         shell: bash
-        env:
-          LUA: ${{ matrix.lua }}
         run: |
           source /opt/intel/oneapi/setvars.sh
-          pushd Build/smokeview/intel_osx_64
-          if [[ "$LUA" == "lua" ]]; then
-            ./make_smokeview_lua.sh
-          else
-            ./make_smokeview.sh
-          fi
+          pushd Build/${{ matrix.program }}/intel_osx_64
+          ./make_${{ matrix.program }}.sh
           popd
-          cp Build/smokeview/intel_osx_64/smokeview_osx_64 smokeview
-      - name: Set exec suffix
-        if: ${{ matrix.lua }} == lua
-        run: echo "exec_suffix=-lua" >> $GITHUB_ENV
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: smokeview-macos${{ env.exec_suffix }}
-          path: smokeview
-  build-linux-gnu:
-    name: gnu_linux
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        lua:
-          # - lua
-          - no-lua
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Build
-        shell: bash
-        env:
-          PLATFORM: ${{ matrix.os }}
-          LUA: ${{ matrix.lua }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install build-essential freeglut3-dev libx11-dev libxmu-dev libxi-dev
-          pushd Build/smokeview/gnu_linux_64
-          if [[ "$LUA" == "lua" ]]; then
-            ./make_smokeview_lua.sh
-          else
-            ./make_smokeview.sh
-          fi
-          popd
-          cp Build/smokeview/gnu_linux_64/smokeview_linux_64 smokeview
-      - name: Set exec suffix
-        if: ${{ matrix.lua }} == lua
-        run: echo "exec_suffix=-lua" >> $GITHUB_ENV
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: smokeview-linux${{ env.exec_suffix }}
-          path: smokeview
+
   build-linux-intel:
-    name: intel_linux
+    name: intel_linux_${{ matrix.program }}
     strategy:
       fail-fast: false
       matrix:
-        lua:
-          # - lua
-          - no-lua
+        program:
+          - background
+          - convert
+          - env2mod
+          - flush
+          - makepo
+          - mergepo
+          - smokediff
+          - smokeview
+          - smokezip
+          - timep
+          - wind2fds
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -127,38 +97,69 @@ jobs:
       - name: install
         if: steps.cache-install.outputs.cache-hit != 'true'
         run: bash .github/workflows/install_linux_oneapi.sh $LINUX_HPCKIT_URL
-      - name: build smokeview
+      - name: build ${{ matrix.program }}
         shell: bash
-        env:
-          LUA: ${{ matrix.lua }}
         run: |
           source /opt/intel/oneapi/setvars.sh
           sudo apt-get update
           sudo apt-get install build-essential freeglut3-dev libx11-dev libxmu-dev libxi-dev
-          pushd Build/smokeview/intel_linux_64
-          if [[ "$LUA" == "lua" ]]; then
-            ./make_smokeview_lua.sh
-          else
-            ./make_smokeview.sh
-          fi
+          pushd Build/${{ matrix.program }}/intel_linux_64
+          ./make_${{ matrix.program }}.sh
           popd
-          cp Build/smokeview/intel_linux_64/smokeview_linux_64 smokeview
-      - name: Set exec suffix
-        if: ${{ matrix.lua }} == lua
-        run: echo "exec_suffix=-lua" >> $GITHUB_ENV
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: smokeview-linux${{ env.exec_suffix }}
-          path: smokeview
-  build-windows:
-    name: intel_win
+
+  build-linux-gnu:
+    name: gnu_linux_${{ matrix.program }}
     strategy:
       fail-fast: false
       matrix:
-        lua:
-          # - lua
-          - no-lua
+        os: [ubuntu-latest]
+        program:
+          - background
+          - convert
+          - env2mod
+          - flush
+          - makepo
+          - mergepo
+          - smokediff
+          - smokeview
+          - smokezip
+          - timep
+          - wind2fds
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential freeglut3-dev libx11-dev libxmu-dev libxi-dev
+          pushd Build/${{ matrix.program }}/gnu_linux_64 || pushd Build/${{ matrix.program }}/gcc_linux_64
+          ./make_${{ matrix.program }}.sh
+          popd
+
+  build-windows:
+    name: intel_win_${{ matrix.program }}
+    strategy:
+      fail-fast: false
+      matrix:
+        program:
+          - background
+          - convert
+          - env2mod
+          - flush
+          - getdate
+          - get_time
+          - hashfile
+          - makepo
+          - mergepo
+          - set_path
+          - sh2bat
+          - smokediff
+          - smokeview
+          - smokezip
+          - timep
+          - wind2fds
     runs-on: windows-2019
     defaults:
       run:
@@ -166,75 +167,49 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      # - name: cache install cpp
-      #   id: cache-install-cpp
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: C:\Program Files (x86)\Intel\oneAPI
-      #     key: install3-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}-compiler-${{ hashFiles('**/.github/workflows/cache_exclude_windows.sh') }}
-      - name: install cpp
-        # if: steps.cache-install-cpp.outputs.cache-hit != 'true'
-        run: .github/workflows/install_windows_oneapi.bat $WINDOWS_HPCKIT_URL
-      - name: set LUA_SCRIPTING
-        shell: bash
-        run: echo "LUA_SCRIPTING=false" >> $GITHUB_ENV
-      - name: set LUA_SCRIPTING
-        if: ${{ matrix.lua }}
-        shell: bash
-        run: echo "LUA_SCRIPTING=true" >> $GITHUB_ENV
-      - name: build libs
-        if: matrix.lua != 'lua'
+      - name: cache install
+        id: cache-install
+        uses: actions/cache@v2
+        with:
+          path: |
+              C:\Program Files (x86)\Intel\oneAPI\setvars.bat
+              C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat
+              C:\Program Files (x86)\Intel\oneAPI\compiler
+          key: install-${{ env.CACHE_NUMBER }}-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_CPP_COMPONENTS }}-compiler-${{ hashFiles('**/scripts/cache_exclude_windows.sh') }}
+      - name: install
+        if: steps.cache-install.outputs.cache-hit != 'true'
+        run: .github/workflows/install_windows_oneapi.bat $WINDOWS_HPCKIT_URL $WINDOWS_CPP_COMPONENTS
+      - name: Make latest link
         shell: cmd
-        env:
-          LUA: ${{ matrix.lua }}
+        run: |
+          rmdir "C:\Program Files (x86)\Intel\oneAPI\compiler\latest"
+          mklink /D "C:\Program Files (x86)\Intel\oneAPI\compiler\latest" "C:\Program Files (x86)\Intel\oneAPI\compiler\2022.0.3"
+      - name: build libs
+        if: matrix.program == 'smokezip'  || matrix.program == 'smokeview'
+        shell: cmd
         run: |
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           pushd Build\LIBS\intel_win_64
           call make_LIBS.bat bot
           dir
           popd
-      - name: build libs lua
-        if: matrix.lua == 'lua'
+      - name: build ${{ matrix.program }}
         shell: cmd
-        env:
-          LUA: ${{ matrix.lua }}
         run: |
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          pushd Build\LIBS\intel_win_64
-          call make_LIBS.bat bot lua
-          dir
+          "C:\Program Files (x86)\Intel\oneAPI\compiler\latest\windows\bin\icx.exe" -V
+          where icx
+          icx -V
+          set PATH
+          dir "C:\Program Files (x86)\Intel\oneAPI\compiler\2022.0.3"
+          dir "C:\Program Files (x86)\Intel\oneAPI\compiler\2022.0.3"
+          dir "C:\Program Files (x86)\Intel\oneAPI\compiler\2022.0.3\windows"
+          dir "C:\Program Files (x86)\Intel\oneAPI\compiler\2022.0.3\windows\bin"
+          pushd Build\${{ matrix.program }}\intel_win_64
+          call make_${{ matrix.program }}.bat
           popd
-      - name: build smokeview lua
-        if: matrix.lua == 'lua'
-        shell: cmd
-        env:
-          LUA: ${{ matrix.lua }}
-        run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          pushd Build\smokeview\intel_win_64
-          call make_smokeview_lua.bat -release
-          popd
-          copy Build\smokeview\intel_win_64\smokeview_win_64.exe smokeview.exe
-      - name: build smokeview
-        if:  matrix.lua != 'lua'
-        shell: cmd
-        env:
-          LUA: ${{ matrix.lua }}
-        run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
-          pushd Build\smokeview\intel_win_64
-          call make_smokeview.bat -release
-          popd
-          copy Build\smokeview\intel_win_64\smokeview_win_64.exe smokeview.exe
-      - name: Set exec suffix
-        if: ${{ matrix.lua }} == lua
-        run: echo "exec_suffix=-lua" >> $GITHUB_ENV
-      # - name: exclude unused files from cache
-      #   if: steps.cache-install.outputs.cache-hit != 'true'
-      #   shell: bash
-      #   run: .github/workflows/cache_exclude_windows.sh
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: smokeview-windows${{ env.exec_suffix }}
-          path: smokeview.exe
+      - name: exclude unused files from cache
+        if: steps.cache-install.outputs.cache-hit != 'true'
+        shell:  bash
+        run: .github/workflows/cache_exclude_windows.sh
+

--- a/Tests/get_test_data.sh
+++ b/Tests/get_test_data.sh
@@ -1,8 +1,9 @@
+#!/bin/sh
 COMMIT=97c852beff8c6142ec09dc0092381a605d08d943
 
 TEMP_DIR=$(mktemp -d)
 ZIP_PATH=$TEMP_DIR/test-data.zip
-wget https://github.com/firemodels/fig/archive/$COMMIT.zip -O $ZIP_PATH
-unzip $ZIP_PATH
+wget --tries=5 https://github.com/firemodels/fig/archive/$COMMIT.zip -O "$ZIP_PATH"
+unzip "$ZIP_PATH"
 mkdir -p fig
 mv fig-$COMMIT/* fig


### PR DESCRIPTION
Previously, executables other than smokeview were not built using scripts and makefiles. This commit now builds all executables except hashfort.

This will show some failures until #1338 is merged.

(Note this commit only affects Github CI files)