### PR TITLE
Don't force Intel compiler by default

### DIFF
--- a/Source/shared/options_common.h
+++ b/Source/shared/options_common.h
@@ -7,11 +7,8 @@
 #define pp_HASH   // md5, sha1 and sha255 hashing
 #endif
 
-#ifndef pp_GCC
-#define INTEL_LLVM_COMPILER_FORCE
 #ifdef __INTEL_COMPILER
 #define INTEL_COMPILER_ANY
-#endif
 #endif
 
 #ifdef __INTEL_LLVM_COMPILER
@@ -33,6 +30,11 @@
 #define HAVE_MSVS
 #define INTEL_WIN_COMPILER
 #endif
+#endif
+
+// Microsofts MSVC has timespec defined
+#ifdef _MSC_VER
+#define HAVE_STRUCT_TIMESPEC
 #endif
 
 //*** options: windows


### PR DESCRIPTION
Previously if the compiler was not identified as gcc the preprocessor directives forced the assumption that it was an Intel compiler. The Intel preprocessor defines seem to work sufficiently enough for this not to be necessary.

This is mainly for the benefit of MSVC (and also clang).