### PR TITLE
lua: Remove workaround for issue #1384

### DIFF
--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -893,7 +893,7 @@ int lua_get_csventry(lua_State *L) {
       // printf("adding: %s\n", csventry->vectors[j].y->name);
 
       lua_create_vector(L, csventry->time, &(csventry->csvinfo[j]));
-      lua_setfield(L, -2, TrimFront(csventry->csvinfo[j].label.longlabel));
+      lua_setfield(L, -2, csventry->csvinfo[j].label.longlabel);
     }
     lua_setfield(L, -2, "vectors");
   }


### PR DESCRIPTION
Previously TrimFront was applied here as a workaround to an
additional space being left in during the parsing progress. This
issue has been resolved and it is no longer necessary.