### PR TITLE
Lua: Update slicedata->slicedir to slicedata->cdir

### DIFF
--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -1851,7 +1851,7 @@ int lua_get_sliceinfo(lua_State *L) {
     lua_pushnumber(L, sliceinfo[i].nslicey);
     lua_setfield(L, -2, "nslicey");
 
-    lua_pushstring(L, sliceinfo[i].slicedir);
+    lua_pushstring(L, sliceinfo[i].cdir);
     lua_setfield(L, -2, "slicedir");
 
     // can't be done until loaded


### PR DESCRIPTION
Took a while to get around to it, smallest PR to date though. The slicedata struct had it's `slicedir` field renamed to `cdir`.