### PR TITLE
Remove references to evac code in C and Lua APIs

### DIFF
--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -1540,7 +1540,6 @@ void loadparticles(const char *name){
     partdata *parti;
 
     parti = partinfo + i;
-    if(parti->evac==1)continue;
     ReadPart(parti->file,i,UNLOAD,&errorcode);
     count++;
   }
@@ -1548,7 +1547,6 @@ void loadparticles(const char *name){
     partdata *parti;
 
     parti = partinfo + i;
-    if(parti->evac==1)continue;
       ReadPart(parti->file,i,LOAD,&errorcode);
       if(name!=NULL&&strlen(name)>0){
         FREEMEMORY(loaded_file);
@@ -3024,13 +3022,6 @@ int set_showdummyvents(int v) {
   return 0;
 } // SHOWDUMMYVENTS
 
-int set_showevacslices(int a, int b, int c) {
-  show_evac_slices = a;
-  constant_evac_coloring = b;
-  show_evac_colorbar = c;
-  return 0;
-} // SHOWEVACSLICES
-
 int set_showfloor(int v) {
   visFloor = v;
   return 0;
@@ -3693,11 +3684,6 @@ int set_viewtourfrompath(int v) {
   viewtourfrompath = v;
   return 0;
 } // VIEWTOURFROMPATH
-
-int set_avatarevac(int v) {
-  iavatar_evac = v;
-  return 0;
-} // AVATAREVAC
 
 int set_devicevectordimensions(float baselength, float basediameter,
                                float headlength, float headdiameter) {

--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -3677,16 +3677,6 @@ int lua_set_showdummyvents(lua_State *L) {
   return 1;
 }
 
-int lua_set_showevacslices(lua_State *L) {
-  int show_slices = lua_tonumber(L, 1);
-  int constant_coloring = lua_tonumber(L, 2);
-  int show_colorbar = lua_tonumber(L, 3);
-  int return_code = set_showevacslices(show_slices, constant_coloring,
-                                       show_colorbar);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-
 int lua_set_showfloor(lua_State *L) {
   int v = lua_tonumber(L, 1);
   int return_code = set_showfloor(v);
@@ -4571,13 +4561,6 @@ int lua_set_viewtourfrompath(lua_State *L) {
   return 1;
 }
 
-int lua_set_avatarevac(lua_State *L) {
-  int v = lua_tonumber(L, 1);
-  int return_code = set_avatarevac(v);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-
 int *lua_get_int_array(lua_State *L, int snumber) {
   // count the length of vals
   int nvals = 0;
@@ -5448,7 +5431,6 @@ lua_State *initLua() {
   lua_register(L, "set_showcolorbars", lua_set_showcolorbars);
   lua_register(L, "set_showcvents", lua_set_showcvents);
   lua_register(L, "set_showdummyvents", lua_set_showdummyvents);
-  lua_register(L, "set_showevacslices", lua_set_showevacslices);
   lua_register(L, "set_showfloor", lua_set_showfloor);
   lua_register(L, "set_showframe", lua_set_showframe);
   lua_register(L, "set_showframelabel", lua_set_showframelabel);
@@ -5569,7 +5551,6 @@ lua_State *initLua() {
   lua_register(L, "set_viewalltours", lua_set_viewalltours);
   lua_register(L, "set_viewtimes", lua_set_viewtimes);
   lua_register(L, "set_viewtourfrompath", lua_set_viewtourfrompath);
-  lua_register(L, "set_avatarevac", lua_set_avatarevac);
   lua_register(L, "set_devicevectordimensions",
                lua_set_devicevectordimensions);
   lua_register(L, "set_devicebounds", lua_set_devicebounds);


### PR DESCRIPTION
There were only a couple of references to evac in the C and Lua APIs, I've removed them completely removed them as I don't plan on ever building it with EVAC on.