### PR TITLE
Add colortable.c

### DIFF
--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -67,7 +67,7 @@ obj = assert.o callbacks.o camera.o color2rgb.o colortimebar.o compress.o cspher
       IOscript.o IOshooter.o IOslice.o IOsmoke.o IOtour.o IOvolsmoke.o IOwui.o IOzone.o isobox.o \
       main.o md5.o menus.o output.o readsmv.o renderhtml.o renderimage.o scontour2d.o sha1.o \
       sha256.o shaders.o showscene.o skybox.o smokestream.o smokeview.o smv_geometry.o startup.o \
-      stdio_buffer.o stdio_m.o string_util.o threader.o translate.o unit.o update.o viewports.o
+      stdio_buffer.o stdio_m.o string_util.o threader.o translate.o unit.o update.o viewports.o colortable.o
 
 incs = compress.h contourdefs.h csphere.h datadefs.h dirent_win.h file_util.h glui_bounds.h \
        glui_motion.h glui_smoke.h glui_tour.h histogram.h infoheader.h interp.h isodefs.h \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(smokeview Source/smokeview/main.c Source/smokeview/menus.c Source
     Source/smokeview/gsmv.c Source/smokeview/getdata.c Source/smokeview/color2rgb.c
     Source/smokeview/IOplot2d.c
     Source/smokeview/IOhvac.c
+    Source/smokeview/colortable.c
 )
 # target_include_directories(smokeview PRIVATE ${OPENGL_INCLUDE_DIRS}  )
 

--- a/Source/smokeview/colortable.c
+++ b/Source/smokeview/colortable.c
@@ -1,0 +1,44 @@
+#include "options.h"
+
+#include <stdio.h>
+#include <string.h>
+#include GLUT_H
+#include <math.h>
+
+#include "smokeviewvars.h"
+#include "IOscript.h"
+#include "MALLOCC.h"
+#include "glui_smoke.h"
+#include "glui_bounds.h"
+#include "histogram.h"
+
+
+/* ------------------ GetColorTableIndex ------------------------ */
+
+int GetColorTableIndex(int *color){
+  int i;
+
+  if(colortableinfo==NULL)return -1;
+  for(i=0;i<ncolortableinfo;i++){
+    colortabledata *cti;
+
+    cti = colortableinfo + i;
+    if(color[0]==cti->color[0]&&color[1]==cti->color[1]&&color[2]==cti->color[2])return i;
+  }
+  return -1;
+}
+
+/* ------------------ GetColorTable ------------------------ */
+
+colortabledata *GetColorTable(char *label){
+  int i;
+
+  if(label==NULL||strlen(label)==0)return NULL;
+  for(i=0;i<ncolortableinfo;i++){
+    colortabledata *cti;
+
+    cti = colortableinfo + i;
+    if(strcmp(label,cti->label)==0)return cti;
+  }
+  return NULL;
+}

--- a/Source/smokeview/glui_bounds.cpp
+++ b/Source/smokeview/glui_bounds.cpp
@@ -5541,36 +5541,6 @@ extern "C" void UpdatePlot3dListIndex(void){
   SetValTypeIndex(BOUND_PLOT3D, plotn-1);
 }
 
-/* ------------------ GetColorTableIndex ------------------------ */
-
-int GetColorTableIndex(int *color){
-  int i;
-
-  if(colortableinfo==NULL)return -1;
-  for(i=0;i<ncolortableinfo;i++){
-    colortabledata *cti;
-
-    cti = colortableinfo + i;
-    if(color[0]==cti->color[0]&&color[1]==cti->color[1]&&color[2]==cti->color[2])return i;
-  }
-  return -1;
-}
-
-/* ------------------ GetColorTable ------------------------ */
-
-colortabledata *GetColorTable(char *label){
-  int i;
-
-  if(label==NULL||strlen(label)==0)return NULL;
-  for(i=0;i<ncolortableinfo;i++){
-    colortabledata *cti;
-
-    cti = colortableinfo + i;
-    if(strcmp(label,cti->label)==0)return cti;
-  }
-  return NULL;
-}
-
 /* ------------------ IsoBoundCB ------------------------ */
 
 extern "C" void IsoBoundCB(int var){

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -361,6 +361,7 @@ EXTERNCPP void UpdateObjectUsed(void);
 EXTERNCPP void UpdateColorTableList(int ncolortableinfo_old);
 EXTERNCPP void UpdateColorTable(colortabledata *ctableinfo, int nctableinfo);
 EXTERNCPP colortabledata *GetColorTable(char *label);
+EXTERNCPP int GetColorTableIndex(int *color);
 EXTERNCPP void UpdateIsoColorlevel(void);
 EXTERNCPP void ReadIsoGeomWrapup(int flag);
 EXTERNCPP void PSystem(char *commandline);


### PR DESCRIPTION
This is a slight tweak of function locations.

There are two functions (`GetColorTableIndex` and `GetColorTable`)  which are currently in glui_bounds.cpp.  For scripting purposes I've begun building without GLUI, but these two functions are still necessary in other parts of the code.

By having a file dedicated to these colorbar table functions we can compile without GLUI at all (see https://github.com/JakeOShannessy/smv/tree/bypass-glui). This also validates the possibility of moving away from GLUT and GLUI in small steps.