### PR TITLE
Changed rainbow colormap to perceptually uniform

### DIFF
--- a/Source/smokeview/colortimebar.c
+++ b/Source/smokeview/colortimebar.c
@@ -656,38 +656,75 @@ void InitDefaultColorbars(int nini){
   UpdateCurrentColorbar(colorbarinfo + colorbartype);
 
   // rainbow colorbar
-
+  // Default colorbar 
+  // 12-node downsample of CET-R4 from colorcet.com Peter Kovesi. Good Colour Maps: How to Design Them. arXiv:1509.03700 [cs.GR] 2015
+   
   cbi=colorbarinfo;
 
   strcpy(cbi->label,"Rainbow");
   cbi->label_ptr=cbi->label;
-  cbi->nnodes=5;
+  cbi->nnodes=12;
   cbi->nodehilight=0;
-
-  cbi->index_node[0]=0;
-  cbi->rgb_node[0]=0;
-  cbi->rgb_node[1]=0;
-  cbi->rgb_node[2]=255;
-
-  cbi->index_node[1]=64;
-  cbi->rgb_node[3]=0;
-  cbi->rgb_node[4]=255;
-  cbi->rgb_node[5]=255;
-
-  cbi->index_node[2]=128;
-  cbi->rgb_node[6]=0;
-  cbi->rgb_node[7]=255;
-  cbi->rgb_node[8]=0;
-
-  cbi->index_node[3]=192;
-  cbi->rgb_node[9]=255;
-  cbi->rgb_node[10]=255;
-  cbi->rgb_node[11]=0;
-
-  cbi->index_node[4]=255;
-  cbi->rgb_node[12]=255;
-  cbi->rgb_node[13]=0;
-  cbi->rgb_node[14]=0;
+ 
+  cbi->index_node[0]=0;	
+  cbi->rgb_node[0]=4;	
+  cbi->rgb_node[1]=0;	
+  cbi->rgb_node[2]=108;
+  
+  cbi->index_node[1]=20;	
+  cbi->rgb_node[3]=6;	
+  cbi->rgb_node[4]=3;	
+  cbi->rgb_node[5]=167;
+  
+  cbi->index_node[2]=60;	
+  cbi->rgb_node[6]=24;	
+  cbi->rgb_node[7]=69;	
+  cbi->rgb_node[8]=240;
+  
+  cbi->index_node[3]=70;	
+  cbi->rgb_node[9]=31;	
+  cbi->rgb_node[10]=98;	
+  cbi->rgb_node[11]=214;
+  
+  cbi->index_node[4]=80;	
+  cbi->rgb_node[12]=5;	
+  cbi->rgb_node[13]=125;	
+  cbi->rgb_node[14]=170;
+  
+  cbi->index_node[5]=96;	
+  cbi->rgb_node[15]=48;	
+  cbi->rgb_node[16]=155;	
+  cbi->rgb_node[17]=80;
+  
+  cbi->index_node[6]=112;	
+  cbi->rgb_node[18]=82;	
+  cbi->rgb_node[19]=177;	
+  cbi->rgb_node[20]=8;
+  
+  cbi->index_node[7]=163;	
+  cbi->rgb_node[21]=240;	
+  cbi->rgb_node[22]=222;	
+  cbi->rgb_node[23]=3;
+  
+  cbi->index_node[8]=170;	
+  cbi->rgb_node[24]=249;	
+  cbi->rgb_node[25]=214;	
+  cbi->rgb_node[26]=7;
+  
+  cbi->index_node[9]=200;	
+  cbi->rgb_node[27]=252;	
+  cbi->rgb_node[28]=152;	
+  cbi->rgb_node[29]=22;
+  
+  cbi->index_node[10]=230;	
+  cbi->rgb_node[30]=254;	
+  cbi->rgb_node[31]=67;	
+  cbi->rgb_node[32]=13;
+  
+  cbi->index_node[11]=255;	
+  cbi->rgb_node[33]=215;	
+  cbi->rgb_node[34]=5;	
+  cbi->rgb_node[35]=13;
   cbi++;
 
   // Rainbow 2 colorbar


### PR DESCRIPTION

[Colour Comparison.pdf](https://github.com/firemodels/smv/files/10413616/Colour.Comparison.pdf)
Default color map (rainbow) is widely recognized as not perceptually uniform. Based on work by Peter Kovesi. Good Colour Maps: How to Design Them. arXiv:1509.03700 [cs.GR] 2015,  I updated the RGB values to better approximate perceptually uniform color map. The full colormap is 256 entries so I have sampled points to give a close approximation whilst not bloating the code.