### PR TITLE
Remove -html option from help message

### DIFF
--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -2773,22 +2773,6 @@ int set_smoothgeomnormal(int v) {
   smooth_geom_normal = v;
   return 0;
 }
-int set_showvolumes_interior(int v) {
-  show_volumes_interior = v;
-  return 0;
-}
-int set_showvolumes_exterior(int v) {
-  show_volumes_exterior = v;
-  return 0;
-}
-int set_showvolumes_solid(int v) {
-  show_volumes_solid = v;
-  return 0;
-}
-int set_showvolumes_outline(int v) {
-  show_volumes_outline = v;
-  return 0;
-}
 int set_geomvertexag(int v) {
   geom_vert_exag = v;
   return 0;
@@ -3024,12 +3008,6 @@ int set_showterrain(int v) {
   visTerrainType = v;
   return 0;
 } // SHOWTERRAIN
-
-int set_showtetras(int a, int b) {
-  show_volumes_solid = a;
-  show_volumes_outline = b;
-  return 0;
-} // SHOWTETRAS
 
 int set_showthreshold(int a, int b, float c) {
   vis_threshold = a;

--- a/Source/smokeview/c_api.h
+++ b/Source/smokeview/c_api.h
@@ -369,10 +369,6 @@ int set_showfaces_exterior(int v);
 int set_showfaces_solid(int v);
 int set_showfaces_outline(int v);
 int set_smoothgeomnormal(int v);
-int set_showvolumes_interior(int v);
-int set_showvolumes_exterior(int v);
-int set_showvolumes_solid(int v);
-int set_showvolumes_outline(int v);
 int set_geomvertexag(int v);
 int set_geommaxangle(int v);
 int set_gversion(int v);                                // GVERSION
@@ -419,7 +415,6 @@ int set_showsmokepart(int v);        // SHOWSMOKEPART
 int set_showsprinkpart(int v);       // SHOWSPRINKPART
 int set_showstreak(int show, int step, int showhead, int index); // SHOWSTREAK
 int set_showterrain(int v);                                      // SHOWTERRAIN
-int set_showtetras(int a, int b);                                // SHOWTETRAS
 int set_showthreshold(int a, int b, float c); // SHOWTHRESHOLD
 int set_showticks(int v);                     // SHOWTICKS
 int set_showtimebar(int v);                   // SHOWTIMEBAR

--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -3558,34 +3558,6 @@ int lua_set_smoothgeomnormal(lua_State *L) {
   return 1;
 }
 
-int lua_set_showvolumes_interior(lua_State *L) {
-  int v = lua_tonumber(L, 1);
-  int return_code = set_showvolumes_interior(v);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-
-int lua_set_showvolumes_exterior(lua_State *L) {
-  int v = lua_tonumber(L, 1);
-  int return_code = set_showvolumes_exterior(v);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-
-int lua_set_showvolumes_solid(lua_State *L) {
-  int v = lua_tonumber(L, 1);
-  int return_code = set_showvolumes_solid(v);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-
-int lua_set_showvolumes_outline(lua_State *L) {
-  int v = lua_tonumber(L, 1);
-  int return_code = set_showvolumes_outline(v);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-
 int lua_set_geomvertexag(lua_State *L) {
   int v = lua_tonumber(L, 1);
   int return_code = set_geomvertexag(v);
@@ -3905,14 +3877,6 @@ int lua_set_showstreak(lua_State *L) {
 int lua_set_showterrain(lua_State *L) {
   int v = lua_tonumber(L, 1);
   int return_code = set_showterrain(v);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-
-int lua_set_showtetras(lua_State *L) {
-  int a = lua_tonumber(L, 1);
-  int b = lua_tonumber(L, 2);
-  int return_code = set_showtetras(a, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -5507,10 +5471,6 @@ static luaL_Reg const smvlib[] = {
     {"set_showfaces_solid", lua_set_showfaces_solid},
     {"set_showfaces_outline", lua_set_showfaces_outline},
     {"set_smoothgeomnormal", lua_set_smoothgeomnormal},
-    {"set_showvolumes_interior", lua_set_showvolumes_interior},
-    {"set_showvolumes_exterior", lua_set_showvolumes_exterior},
-    {"set_showvolumes_solid", lua_set_showvolumes_solid},
-    {"set_showvolumes_outline", lua_set_showvolumes_outline},
     {"set_geomvertexag", lua_set_geomvertexag},
     {"set_gversion", lua_set_gversion},
     {"set_isotran2", lua_set_isotran2},
@@ -5555,7 +5515,6 @@ static luaL_Reg const smvlib[] = {
     {"set_showsprinkpart", lua_set_showsprinkpart},
     {"set_showstreak", lua_set_showstreak},
     {"set_showterrain", lua_set_showterrain},
-    {"set_showtetras", lua_set_showterrain},
     {"set_showthreshold", lua_set_showthreshold},
     {"set_showticks", lua_set_showticks},
     {"set_showtimebar", lua_set_showtimebar},

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -45,7 +45,6 @@ void Usage(char *prog,int option){
     PRINTF("%s\n", _(" -fast          - assume slice files exist in order to reduce startup time"));
     PRINTF("%s\n", _(" -fed           - pre-calculate all FED slice files"));
     PRINTF("%s\n", _(" -geominfo      - output information about geometry triangles"));
-    PRINTF("%s\n", _(" -html          - output html version of smokeview scene"));
     PRINTF("%s\n", _(" -info            generate casename.slcf and casename.viewpoint files containing slice file and viewpiont info"));
     PRINTF("%s\n", _(" -lang xx       - where xx is de, es, fr, it for German, Spanish, French or Italian"));
     PRINTF("%s\n", _(" -make_movie    - open the movie generating dialog box"));


### PR DESCRIPTION
Depends on #1593.

I was writing some tests to make sure my changes didn't impact CLI option parsing and -html failed. I notice it doesn't seem to be read anywhere (in contrast to -htmlscript).

Probably just needs removing from the help message.