### PR TITLE
Factor out CLI parsing into a separate file/module

### DIFF
--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -67,13 +67,13 @@ obj = assert.o callbacks.o camera.o color2rgb.o colortimebar.o compress.o cspher
       IOscript.o IOshooter.o IOslice.o IOsmoke.o IOtour.o IOvolsmoke.o IOwui.o IOzone.o isobox.o \
       main.o md5.o menus.o output.o readsmv.o renderhtml.o renderimage.o scontour2d.o sha1.o \
       sha256.o shaders.o showscene.o skybox.o smokestream.o smokeview.o smv_geometry.o startup.o \
-      stdio_buffer.o stdio_m.o string_util.o threader.o translate.o unit.o update.o viewports.o colortable.o
+      stdio_buffer.o stdio_m.o string_util.o threader.o translate.o unit.o update.o viewports.o colortable.o command_args.o
 
 incs = compress.h contourdefs.h csphere.h datadefs.h dirent_win.h file_util.h glui_bounds.h \
        glui_motion.h glui_smoke.h glui_tour.h histogram.h infoheader.h interp.h isodefs.h \
        IOobjects.h IOscript.h IOvolsmoke.h lint.h lua_api.h MALLOCC.h options.h options_common.h \
        pragmas.h smokefortheaders.h smokeheaders.h smokeviewdefs.h smokeviewvars.h smv_assert.h \
-       stdio_buffer.h stdio_m.h string_util.h structures.h translate.h threader.h viewports.h
+       stdio_buffer.h stdio_m.h string_util.h structures.h translate.h threader.h viewports.h command_args.h
 
 ifeq ($(ICON),icon)
 obj += resource.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(smokeview Source/smokeview/main.c Source/smokeview/menus.c Source
     Source/smokeview/IOplot2d.c
     Source/smokeview/IOhvac.c
     Source/smokeview/colortable.c
+    Source/smokeview/command_args.c
 )
 # target_include_directories(smokeview PRIVATE ${OPENGL_INCLUDE_DIRS}  )
 

--- a/Source/smokeview/command_args.c
+++ b/Source/smokeview/command_args.c
@@ -1,0 +1,322 @@
+/// @file command_args.
+
+// This file explicitly does not include "smokeviewcars.h" to avoid separate
+// this parsing from global variables.
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "MALLOCC.h"
+#include "command_args.h"
+
+const char *CLE_Message(enum CommandLineError cle) {
+  switch (cle) {
+  case CLE_OK:
+    return NULL;
+    break;
+  case CLE_MULTIPLE_LANG:
+    return "-lang defined multiple times";
+    break;
+  case CLE_NO_LANG:
+    return "-lang must be given an argument";
+    break;
+  default:
+    return "a commandline parsing error occurred";
+    break;
+  }
+}
+
+CommandlineArgs ParseCommandlineNew(int argc, char **argv,
+                                    enum CommandLineError *error) {
+  CommandlineArgs args = {0};
+  *error = CLE_OK;
+  if (argc >= 1) {
+    NewMemory((void **)&args.prog, strlen(argv[0]) + 1);
+    strcpy(args.prog, argv[0]);
+  }
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "-ini") == 0) {
+      args.ini = true;
+    } else if (strcmp(argv[i], "-ng_ini") == 0) {
+      args.ng_ini = true;
+    } else if (strcmp(argv[i], "-volrender") == 0) {
+      args.volrender = true;
+    }
+    // We don't show the version if volrender is set? This is probably an
+    // unecesary hack
+    else if (strcmp(argv[i], "-volrender") != 0 &&
+             (strcmp(argv[i], "-version") == 0 || strcmp(argv[i], "-v") == 0)) {
+      args.print_version = true;
+    }
+#ifdef pp_OSX_HIGHRES
+    else if (strcmp(argv[i], "-1x") == 0) {
+      args.x1 = true;
+    } else if (strcmp(argv[i], "-2x") == 0) {
+      args.x2 = true;
+    }
+#endif
+    else if (strcmp(argv[i], "-update_bounds") == 0) {
+      args.update_bounds = true;
+    } else if (strcmp(argv[i], "-no_graphics") == 0) {
+      args.no_graphics = true;
+    } else if (strcmp(argv[i], "-update_slice") == 0) {
+      args.update_slice = true;
+    } else if (strcmp(argv[i], "-update") == 0) {
+      args.update = true;
+    } else if (strcmp(argv[i], "-nogpu") == 0) {
+      args.nogpu = true;
+    } else if (strcmp(argv[i], "-demo") == 0) {
+      args.demo = true;
+    } else if (strcmp(argv[i], "-info") == 0) {
+      args.info = true;
+    } else if (strcmp(argv[i], "-sizes") == 0) {
+      args.sizes = true;
+    } else if (strcmp(argv[i], "-stereo") == 0) {
+      args.stereo = true;
+    } else if (strcmp(argv[i], "-big") == 0) {
+      args.big = true;
+    } else if (strcmp(argv[i], "-timings") == 0) {
+      args.timings = true;
+    } else if (strcmp(argv[i], "-lang") == 0) {
+      // The next argument is a language name
+      ++i;
+      if (i < argc) {
+        if (args.lang != NULL) {
+          *error = CLE_MULTIPLE_LANG;
+          return args;
+        }
+        // Why the additional 48 bytes?
+        NewMemory((void **)&args.lang, strlen(argv[i]) + 48 + 1);
+        strcpy(args.lang, argv[i]);
+      } else {
+        *error = CLE_NO_LANG;
+        return args;
+      }
+    } else if (strcmp(argv[i], "-convert_ini") == 0) {
+      args.convert_ini = true;
+      // The next two arguments are the from and to paths for ini conversion.
+      char *local_ini_from = NULL, *local_ini_to = NULL;
+
+      if (++i < argc) {
+        local_ini_from = argv[i];
+      } else {
+        *error = CLE_NO_INI_ARGS;
+        return args;
+      }
+      if (++i < argc) {
+        local_ini_to = argv[i];
+      } else {
+        *error = CLE_NO_INI_ARGS;
+        return args;
+      }
+      if (local_ini_from != NULL && local_ini_to != NULL) {
+        NewMemory((void **)&args.ini_from, strlen(local_ini_from) + 1);
+        strcpy(args.ini_from, local_ini_from);
+
+        NewMemory((void **)&args.ini_to, strlen(local_ini_to) + 1);
+        strcpy(args.ini_to, local_ini_to);
+      }
+    } else if (strcmp(argv[i], "-convert_ssf") == 0) {
+      args.convert_ssf = true;
+      // The next two arguments are the from and to paths for ssf conversion.
+      char *local_ssf_from = NULL, *local_ssf_to = NULL;
+
+      if (++i < argc) {
+        local_ssf_from = argv[i];
+      } else {
+        *error = CLE_NO_SSF_ARGS;
+        return args;
+      }
+      if (++i < argc) {
+        local_ssf_to = argv[i];
+      } else {
+        *error = CLE_NO_SSF_ARGS;
+        return args;
+      };
+      if (local_ssf_from != NULL && local_ssf_to != NULL) {
+        NewMemory((void **)&args.ssf_from, strlen(local_ssf_from) + 1);
+        strcpy(args.ssf_from, local_ssf_from);
+
+        NewMemory((void **)&args.ssf_to, strlen(local_ssf_to) + 1);
+        strcpy(args.ssf_to, local_ssf_to);
+      }
+    } else if (strcmp(argv[i], "-update_ssf") == 0) {
+      args.update_ssf = true;
+    } else if (strcmp(argv[i], "-update_ini") == 0) {
+      // As per convert_ini, but in-place
+      args.update_ini = true;
+      char *local_ini_from = NULL, *local_ini_to = NULL;
+
+      if (++i < argc) {
+        local_ini_from = argv[i];
+      } else {
+        *error = CLE_NO_INI_ARGS;
+        return args;
+      }
+      local_ini_to = local_ini_from;
+      if (local_ini_from != NULL) {
+        NewMemory((void **)&args.ini_from, strlen(local_ini_from) + 1);
+        strcpy(args.ini_from, local_ini_from);
+
+        NewMemory((void **)&args.ini_to, strlen(local_ini_to) + 1);
+        strcpy(args.ini_to, local_ini_to);
+      }
+    } else if (strcmp(argv[i], "-isotest") == 0) {
+      args.isotest = true;
+    } else if (strcmp(argv[i], "-smoke3d") == 0) {
+      args.smoke3d = true;
+    } else if (strcmp(argv[i], "-no_slcf") == 0) {
+      args.no_slcf = true;
+    } else if (strcmp(argv[i], "-h") == 0 &&
+               strcmp(argv[i], "-help_all") != 0 &&
+               strcmp(argv[i], "-html") != 0) {
+      args.show_help_summary = true;
+    } else if (strcmp(argv[i], "-help_all") == 0) {
+      args.show_help_all = true;
+    } else if (strcmp(argv[i], "-noblank") == 0) {
+      args.noblank = true;
+    } else if (strcmp(argv[i], "-fed") == 0) {
+      args.fed = true;
+    } else if (strcmp(argv[i], "-verbose") == 0) {
+      args.verbose = true;
+    } else if (strcmp(argv[i], "-outline") == 0) {
+      args.outline = true;
+    } else if (strcmp(argv[i], "-make_movie") == 0) {
+      args.make_movie = true;
+    } else if (strcmp(argv[i], "-geominfo") == 0) {
+      args.geominfo = true;
+    } else if (strcmp(argv[i], "-fast") == 0) {
+      args.fast = true;
+    } else if (strcmp(argv[i], "-blank") == 0) {
+      args.blank = true;
+    } else if (strcmp(argv[i], "-gversion") == 0) {
+      args.gversion = true;
+    } else if (strcmp(argv[i], "-redirect") == 0) {
+      args.redirect = true;
+    } else if (strcmp(argv[i], "-runscript") == 0) {
+      args.runscript = true;
+    } else if (strcmp(argv[i], "-runhtmlscript") == 0) {
+      args.runhtmlscript = true;
+    }
+#ifdef pp_LUA
+    else if (strcmp(argv[i], "-runluascript") == 0) {
+      args.runluascript = true;
+    } else if (strcmp(argv[i], "-killscript") == 0) {
+      args.killscript = true;
+    } else if (strcmp(argv[i], "-luascript") == 0) {
+      ++i;
+      if (i < argc) {
+        NewMemory((void **)&args.scriptrenderdir, strlen(argv[i]) + 1);
+        strcpy(args.scriptrenderdir, argv[i]);
+      } else {
+        *error = CLE_ARGUMENT_EXPECTED;
+        return args;
+      }
+    }
+#endif
+    else if (strcmp(argv[i], "-scriptrenderdir") == 0) {
+      i++;
+      if (i < argc) {
+        NewMemory((void **)&args.scriptrenderdir, strlen(argv[i]) + 1);
+        strcpy(args.scriptrenderdir, argv[i]);
+      } else {
+        *error = CLE_ARGUMENT_EXPECTED;
+        return args;
+      }
+    } else if (strcmp(argv[i], "-skipframe") == 0) {
+      args.skipframe_defined = true;
+      ++i;
+      if (i < argc) {
+        sscanf(argv[i], "%i", &args.skipframe);
+      } else {
+        *error = CLE_ARGUMENT_EXPECTED;
+        return args;
+      }
+    } else if (strcmp(argv[i], "-startframe") == 0) {
+      args.startframe_defined = true;
+      ++i;
+      if (i < argc) {
+        sscanf(argv[i], "%i", &args.startframe);
+      } else {
+        *error = CLE_ARGUMENT_EXPECTED;
+        return args;
+      }
+    } else if (strcmp(argv[i], "-volrender") == 0) {
+      args.volrender = true;
+    } else if (strcmp(argv[i], "-script") == 0) {
+      ++i;
+      if (i < argc) {
+        NewMemory((void **)&args.script, strlen(argv[i]) + 1);
+        strcpy(args.script, argv[i]);
+      } else {
+        *error = CLE_ARGUMENT_EXPECTED;
+        return args;
+      }
+    } else if (strcmp(argv[i], "-htmlscript") == 0) {
+      ++i;
+      if (i < argc) {
+        NewMemory((void **)&args.htmlscript, strlen(argv[i]) + 1);
+        strcpy(args.htmlscript, argv[i]);
+      } else {
+        *error = CLE_ARGUMENT_EXPECTED;
+        return args;
+      }
+    } else if (strcmp(argv[i], "-noexit") == 0) {
+      args.noexit = true;
+    } else if (strcmp(argv[i], "-setup") == 0) {
+      args.setup = true;
+    } else if (strcmp(argv[i], "-bindir") == 0) {
+      ++i;
+      if (i < argc) {
+        NewMemory((void **)&args.bindir, strlen(argv[i]) + 1);
+        strcpy(args.bindir, argv[i]);
+      } else {
+        *error = CLE_ARGUMENT_EXPECTED;
+        return args;
+      }
+    } else if (strcmp(argv[i], "-casedir") == 0) {
+      ++i;
+      if (i < argc) {
+        NewMemory((void **)&args.casedir, strlen(argv[i]) + 1);
+        strcpy(args.casedir, argv[i]);
+      } else {
+        *error = CLE_ARGUMENT_EXPECTED;
+        return args;
+      }
+    } else if (strcmp(argv[i], "-threads") == 0) {
+      args.threads_defined = true;
+      ++i;
+      if (i < argc) {
+        sscanf(argv[i], "%i", &args.threads);
+      } else {
+        *error = CLE_ARGUMENT_EXPECTED;
+        return args;
+      }
+    } else {
+      if (args.input_file == NULL) {
+        NewMemory((void **)&args.input_file, strlen(argv[i]) + 1);
+        strcpy(args.input_file, argv[i]);
+      } else {
+        *error = CLE_MULTIPLE_INPUTS;
+        return args;
+      }
+    }
+  }
+  return args;
+}
+
+/// @brief Free any allocated buffers in @ref CommandlineArgs. Performs
+/// null-checks on all buffers.
+/// @param args The previously parse command line arguments.
+void FreeCommandlineArgs(CommandlineArgs *args) {
+  FREEMEMORY(args->prog);
+  FREEMEMORY(args->input_file);
+  FREEMEMORY(args->bindir);
+  FREEMEMORY(args->casedir);
+  FREEMEMORY(args->lang);
+  FREEMEMORY(args->ini_from);
+  FREEMEMORY(args->ini_to);
+  FREEMEMORY(args->ssf_from);
+  FREEMEMORY(args->ssf_to);
+}

--- a/Source/smokeview/command_args.c
+++ b/Source/smokeview/command_args.c
@@ -9,6 +9,7 @@
 
 #include "MALLOCC.h"
 #include "command_args.h"
+#include "options.h"
 
 const char *CLE_Message(enum CommandLineError cle) {
   switch (cle) {

--- a/Source/smokeview/command_args.h
+++ b/Source/smokeview/command_args.h
@@ -1,0 +1,127 @@
+/// @file command_args.h
+#ifndef PATHS_H_DEFINED
+#define PATHS_H_DEFINED
+
+#include <stdbool.h>
+
+/// @brief The parsed version of commandline arguments.
+typedef struct CommandlineArgs {
+  /// @brief output smokeview parameter values to smokeview.ini
+  bool ini;
+  /// @brief non-graphics version of -ini
+  bool ng_ini;
+  /// @brief generate images of volume rendered smoke and fire
+  bool volrender;
+  /// @brief Either -version or -v was set, so print the version of smokeview
+  /// and exit.
+  bool print_version;
+  bool update_bounds;
+  bool no_graphics;
+  /// @brief calculate slice file parameters
+  bool update_slice;
+  bool nogpu;
+  /// @brief use demonstrator mode of Smokeview"
+  bool demo;
+  /// @brief generate casename.slcf and casename.viewpoint files containing
+  /// slice file and viewpiont info
+  bool info;
+  /// @brief output files sizes then exit
+  bool sizes;
+  /// @brief activate stereo mode
+  bool stereo;
+  /// @brief hide scene and data when moving scene or selecting menus
+  bool big;
+#ifdef pp_OSX_HIGHRES
+  /// @brief On Mac, turn off 2x scene scaling (do not scale scene)
+  bool x1;
+  /// @brief On Mac, turn on 2x scene scaling
+  bool x2;
+#endif
+  /// @brief show startup timings
+  bool timings;
+  bool convert_ini;
+  bool convert_ssf;
+  /// @brief update case.ini to the current format
+  bool update_ini;
+  bool update_ssf;
+  bool isotest;
+  /// @brief only show 3D smoke
+  bool smoke3d;
+  bool no_slcf;
+  bool show_help_summary;
+  bool show_help_all;
+  bool noblank;
+  /// @brief pre-calculate all FED slice files
+  bool fed;
+  bool verbose;
+  /// @brief show geometry bound boxes instead of geometry
+  bool outline;
+  /// @brief open the movie generating dialog box
+  bool make_movie;
+  /// @brief output information about geometry triangles
+  bool geominfo;
+  /// @brief assume slice files exist in order to reduce startup time
+  bool fast;
+  bool blank;
+  bool gversion;
+  bool redirect;
+  /// @brief Run the default SSF script, i.e. CHID.ssf
+  bool runscript;
+  bool runhtmlscript;
+  /// @brief Run the SSF script at this path
+  char *script;
+  /// @brief Run the HTML script at this path
+  char *htmlscript;
+#ifdef pp_LUA
+  /// @brief Run the default lua script, i.e. CHID.lua
+  bool runluascript;
+  /// @brief If the lua script fails, kill smokeview and return an error exit
+  /// code.
+  bool killscript;
+  /// @brief Run a custom lua script at this path.
+  char *luascript;
+#endif
+  /// @brief set directory containing script rendered images (override directory
+  /// specified by RENDERDIR script keyword)
+  char *scriptrenderdir;
+  // TODO: consider sentinel values
+  bool skipframe_defined;
+  /// @brief render every n frames, only valid if skipframe_defined is true
+  int skipframe;
+  bool startframe_defined;
+  /// @brief start rendering at frame n, only valid if startframe_defined is
+  /// true
+  int startframe;
+  bool noexit;
+  /// @brief only show geometry
+  bool setup;
+  bool threads_defined;
+  /// @brief equivalent to -update_bounds and -update_slice
+  bool update;
+  int threads;
+  char *prog;
+  char *input_file;
+  char *bindir;
+  char *casedir;
+  /// @brief language code e.g., de, es, fr, for German, Spanish, French or
+  /// Italian
+  char *lang;
+  char *ini_from;
+  char *ini_to;
+  char *ssf_from;
+  char *ssf_to;
+} CommandlineArgs;
+
+enum CommandLineError {
+  CLE_MULTIPLE_LANG,
+  CLE_NO_LANG,
+  CLE_NO_SSF_ARGS,
+  CLE_NO_INI_ARGS,
+  CLE_MULTIPLE_INPUTS,
+  CLE_OK,
+  CLE_ARGUMENT_EXPECTED,
+};
+const char *CLE_Message(enum CommandLineError cle);
+CommandlineArgs ParseCommandlineNew(int argc, char **argv,
+                                    enum CommandLineError *error);
+#endif

--- a/Source/smokeview/command_args.h
+++ b/Source/smokeview/command_args.h
@@ -3,6 +3,7 @@
 #define PATHS_H_DEFINED
 
 #include <stdbool.h>
+#include "options.h"
 
 /// @brief The parsed version of commandline arguments.
 typedef struct CommandlineArgs {

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -20,8 +20,6 @@
 #include "lua_api.h"
 #endif
 
-static bool showbuild = false;
-
 /* ------------------ Usage ------------------------ */
 
 void Usage(char *prog,int option){
@@ -100,12 +98,11 @@ char *ParseCommandline(int argc, char **argv) {
 /// are parsed into @ref CommandlineArgs.
 /// @return The iput file name (the SMV file).
 char *ProcessCommandLine(CommandlineArgs *args) {
-  int i, len_casename;
+  int len_casename;
   int iarg;
   size_t len_memory;
   char *argi, *smv_ext;
   char SMVFILENAME[MAX_SMV_FILENAME_BUFFER];
-  int smv_parse;
   char *filename_local = NULL;
 
   CheckMemory;

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -9,6 +9,7 @@
 
 #include "string_util.h"
 #include "smokeviewvars.h"
+#include "command_args.h"
 
 #ifdef WIN32
 #include <direct.h>
@@ -18,6 +19,8 @@
 #include "c_api.h"
 #include "lua_api.h"
 #endif
+
+static bool showbuild = false;
 
 /* ------------------ Usage ------------------------ */
 
@@ -76,79 +79,65 @@ void Usage(char *prog,int option){
   }
 }
 
-/* ------------------ ParseCommandline ------------------------ */
+char *ProcessCommandLine(CommandlineArgs *args);
 
-char *ParseCommandline(int argc, char **argv){
+char *ParseCommandline(int argc, char **argv) {
+  enum CommandLineError error;
+  CommandlineArgs args = ParseCommandlineNew(argc, argv, &error);
+  if (error != CLE_OK) {
+    const char *msg = CLE_Message(error);
+    if (msg != NULL) {
+      fprintf(stderr, "%s\n", msg);
+    }
+    SMV_EXIT(0);
+  }
+  return ProcessCommandLine(&args);
+}
+
+/// @brief Once the commandline arguments ahve been parsed, they can be passed
+/// to this function to update global settings and undertake various actions.
+/// @param args The args which were previously parsed. All commandline arguments
+/// are parsed into @ref CommandlineArgs.
+/// @return The iput file name (the SMV file).
+char *ProcessCommandLine(CommandlineArgs *args) {
   int i, len_casename;
   int iarg;
   size_t len_memory;
   char *argi, *smv_ext;
-  char SMVFILENAME[1024];
+  char SMVFILENAME[MAX_SMV_FILENAME_BUFFER];
   int smv_parse;
   char *filename_local = NULL;
 
   CheckMemory;
 
-  for(iarg = 1; iarg < argc; iarg++){
-    if(strncmp(argv[iarg], "-ini", 4)==0){
-      InitCameraList();
-      InitOpenGL(NO_PRINT);
-      UpdateRGBColors(COLORBAR_INDEX_NONE);
-      InitStartupDirs();
-      WriteIni(GLOBAL_INI, NULL);
-      SMV_EXIT(0);
-    }
-    if(strncmp(argv[iarg], "-ng_ini", 7)==0){
-      InitCameraList();
-      use_graphics = 0;
-      UpdateRGBColors(COLORBAR_INDEX_NONE);
-      InitStartupDirs();
-      WriteIni(GLOBAL_INI, NULL);
-      SMV_EXIT(0);
-    }
-    if(
-      strncmp(argv[iarg], "-volrender", 10)!=0&&(strncmp(argv[iarg], "-version", 8)==0||strncmp(argv[iarg], "-v", 2)==0)
-      ){
-      DisplayVersionInfo("Smokeview ");
-      SMV_EXIT(0);
-    }
+  if (args->ini) {
+    InitCameraList();
+    InitOpenGL(NO_PRINT);
+    UpdateRGBColors(COLORBAR_INDEX_NONE);
+    InitStartupDirs();
+    WriteIni(GLOBAL_INI, NULL);
+    SMV_EXIT(0);
+  }
+  if (args->ng_ini) {
+    InitCameraList();
+    use_graphics = 0;
+    UpdateRGBColors(COLORBAR_INDEX_NONE);
+    InitStartupDirs();
+    WriteIni(GLOBAL_INI, NULL);
+    SMV_EXIT(0);
+  }
+  if (args->print_version) {
+    DisplayVersionInfo("Smokeview ");
+    SMV_EXIT(0);
   }
   strcpy(SMVFILENAME, "");
-  smv_parse = 0;
-  for(iarg = 1; iarg < argc; iarg++){
-    argi = argv[iarg];
-    if(strncmp(argi, "-", 1) == 0){
-      if(
-        strncmp(argi, "-points", 7) == 0      ||
-        strncmp(argi, "-frames", 7) == 0      ||
-        strncmp(argi, "-lang", 5) == 0        ||
-        strncmp(argi, "-script", 7) == 0      ||
-        strncmp(argi, "-htmlscript", 11)==0   ||
-#ifdef pp_LUA
-        strncmp(argi, "-luascript", 10) == 0  ||
-#endif
-        strncmp(argi, "-startframe", 11) == 0 ||
-        strncmp(argi, "-skipframe", 10) == 0  ||
-        strncmp(argi, "-bindir", 7) == 0      ||
-        strncmp(argi, "-casedir", 8)==0       ||
-        strncmp(argi, "-threads", 8)==0       ||
-        strncmp(argi, "-update_ini", 11) == 0
-        ){
-        iarg++;
-      }
-      if(strncmp(argi, "-convert_ini", 12) == 0 ||
-         strncmp(argi, "-convert_ssf", 12) == 0){
-        iarg += 2;
-      }
-
-      if(smv_parse == 0)continue;
-      if(smv_parse == 1)break;
+  if (args->input_file != NULL) {
+    if (strlen(args->input_file) > MAX_SMV_FILENAME_BUFFER-1) {
+      fprintf(stderr, "*** Error: input filename exceeds maximum length of %d\n", MAX_SMV_FILENAME_BUFFER-1);
+      SMV_EXIT(1);
     }
-    if(smv_parse == 1)strcat(SMVFILENAME, " ");
-    smv_parse = 1;
-    strcat(SMVFILENAME, argi);
+    strcat(SMVFILENAME, args->input_file);
   }
-
 // strip .smv extension if present
   char *smvext;
   smvext = strstr(SMVFILENAME, ".smv");
@@ -376,182 +365,150 @@ char *ParseCommandline(int argc, char **argv){
     STRCAT(test_filename, ".svd");
   }
 
-  for(i = 1; i < argc; i++){
-    if(strncmp(argv[i], "-", 1) != 0)continue;
 #ifdef pp_OSX_HIGHRES
-    if(strncmp(argv[1], "-1x", 3) == 0){
+    if(args->x1){
       double_scale = 0;
       force_scale  = 1;
     }
-    else if(strncmp(argv[1], "-2x", 3)==0){
+    else if(args->x2){
       double_scale = 1;
       force_scale = 1;
     }
 #endif
-    else if(strncmp(argv[i], "-update_bounds", 14) == 0){
+    if(args->update_bounds){
       use_graphics = 0;
       update_bounds = 1;
     }
-    else if(strncmp(argv[i], "-no_graphics", 12)==0){
+    if(args->no_graphics){
       use_graphics = 0;
     }
-    else if(strncmp(argv[i], "-update_slice", 13)==0){
+    if(args->update_slice){
       use_graphics = 0;
       update_slice = 1;
     }
-    else if(strncmp(argv[i], "-update", 7)==0&&strncmp(argv[i], "-update_ini", 11)!=0){
-      if(strncmp(argv[i], "-update_slice", 13)!=0&&strncmp(argv[i], "-update_bounds", 14)!=0){
+    if(args->update){
         use_graphics = 0;
         update_slice = 1;
         update_bounds = 1;
-      }
     }
-    else if(strncmp(argv[i], "-nogpu", 6) == 0){
+    if(args->nogpu){
       disable_gpu = 1;
     }
-    else if(strncmp(argv[i], "-demo", 5) == 0){
+    if(args->demo){
       demo_option = 1;
     }
-    else if(strncmp(argv[i], "-info", 5)==0){
+    if(args->info){
       generate_info_from_commandline = 1;
       use_graphics = 0;
     }
-    else if(strncmp(argv[1], "-sizes", 6)==0){
+    if(args->sizes){
       update_filesizes = 1;
       use_graphics = 0;
     }
-    else if(strncmp(argv[i], "-stereo", 7) == 0){
+    if(args->stereo){
       stereoactive = 1;
       stereotype = STEREO_TIME;
       PRINTF("stereo option activated\n");
     }
-    else if(strncmp(argv[i], "-big", 4)==0){
+    if(args->big){
       show_geom_boundingbox = SHOW_BOUNDING_BOX_MOUSE_DOWN;
     }
-    else if(strncmp(argv[i], "-timings", 8)==0){
+    if(args->timings){
       show_timings = 1;
     }
-    else if(strncmp(argv[i], "-lang", 5) == 0){
-      ++i;
-      if(i < argc){
-        int langlen;
-        char *lang;
-
+    if(args->lang != NULL){
         FREEMEMORY(tr_name);
-        lang = argv[i];
-        langlen = strlen(lang);
-        NewMemory((void **)&tr_name, langlen + 48 + 1);
-        strcpy(tr_name, lang);
-      }
+        NewMemory((void **)&tr_name, strlen(args->lang)+1);
+        strcpy(tr_name, args->lang);
     }
-    else if(strncmp(argv[i], "-convert_ini", 12) == 0){
-      char *local_ini_from = NULL, *local_ini_to = NULL;
+    if(args->convert_ini){
+      if(args->ini_from != NULL&&args->ini_to != NULL){
+        NewMemory((void **)&ini_from, strlen(args->ini_from) + 1);
+        strcpy(ini_from, args->ini_from);
 
-      if(++i < argc)local_ini_from = argv[i];
-      if(++i < argc)local_ini_to = argv[i];
-      if(local_ini_from != NULL&&local_ini_to != NULL){
-        NewMemory((void **)&ini_from, strlen(local_ini_from) + 1);
-        strcpy(ini_from, local_ini_from);
-
-        NewMemory((void **)&ini_to, strlen(local_ini_to) + 1);
-        strcpy(ini_to, local_ini_to);
+        NewMemory((void **)&ini_to, strlen(args->ini_to) + 1);
+        strcpy(ini_to, args->ini_to);
         convert_ini = 1;
       }
     }
-    else if(strncmp(argv[i], "-convert_ssf", 12) == 0){
-      char *local_ssf_from = NULL, *local_ssf_to = NULL;
+    if(args->convert_ssf){
+      if(args->ssf_from != NULL&&args->ssf_to != NULL){
+        NewMemory((void **)&ssf_from, strlen(args->ssf_from) + 1);
+        strcpy(ssf_from, args->ssf_from);
 
-      if(++i < argc)local_ssf_from = argv[i];
-      if(++i < argc)local_ssf_to = argv[i];
-      if(local_ssf_from != NULL&&local_ssf_to != NULL){
-        NewMemory((void **)&ssf_from, strlen(local_ssf_from) + 1);
-        strcpy(ssf_from, local_ssf_from);
-
-        NewMemory((void **)&ssf_to, strlen(local_ssf_to) + 1);
-        strcpy(ssf_to, local_ssf_to);
+        NewMemory((void **)&ssf_to, strlen(args->ssf_to) + 1);
+        strcpy(ssf_to, args->ssf_to);
         convert_ssf = 1;
       }
     }
-    else if(strncmp(argv[i], "-update_ssf", 11) == 0){
+    if(args->update_ssf){
       update_ssf = 1;
     }
-    else if(strncmp(argv[i], "-update_ini", 11) == 0){
-      char *local_ini_from = NULL, *local_ini_to = NULL;
+    if(args->update_ini){
+      if(args->ini_from != NULL){
+        NewMemory((void **)&ini_from, strlen(args->ini_from) + 1);
+        strcpy(ini_from, args->ini_from);
 
-      if(++i < argc)local_ini_from = argv[i];
-      local_ini_to = local_ini_from;
-      if(local_ini_from != NULL){
-        NewMemory((void **)&ini_from, strlen(local_ini_from) + 1);
-        strcpy(ini_from, local_ini_from);
-
-        NewMemory((void **)&ini_to, strlen(local_ini_to) + 1);
-        strcpy(ini_to, local_ini_to);
+        NewMemory((void **)&ini_to, strlen(args->ini_from) + 1);
+        strcpy(ini_to, args->ini_from);
         convert_ini = 1;
       }
     }
-    else if(strncmp(argv[i], "-isotest", 8) == 0){
+    if(args->isotest){
       isotest = 1;
     }
-    else if(strncmp(argv[i], "-smoke3d", 8) == 0){
+    if(args->smoke3d){
       smoke3d_only = 1;
     }
-    else if(strncmp(argv[i], "-no_slcf", 8)==0){
+    if(args->no_slcf){
     handle_slice_files = 0;
     }
-    else if(strncmp(argv[i], "-h", 2) == 0&&strncmp(argv[i], "-help_all", 9)!=0&&strncmp(argv[1], "-html", 5)!=0){
-      Usage(argv[0],HELP_SUMMARY);
+    if(args->show_help_summary){
+      Usage(args->prog,HELP_SUMMARY);
       SMV_EXIT(0);
     }
-    else if(strncmp(argv[i], "-help_all", 9)==0){
-      Usage(argv[0],HELP_ALL);
+    if(args->show_help_all){
+      Usage(args->prog,HELP_ALL);
       SMV_EXIT(0);
     }
-    else if(strncmp(argv[i], "-noblank", 8) == 0){
+    if(args->noblank){
       iblank_set_on_commandline = 1;
       use_iblank = 0;
     }
-    else if(strncmp(argv[i], "-fed", 4) == 0){
+    if(args->fed){
       compute_fed = 1;
     }
-    else if(strncmp(argv[i], "-verbose", 8)==0){
+    if(args->verbose){
       verbose_output = 1;
     }
-    else if(strncmp(argv[i], "-outline", 8)==0){
+    if(args->outline){
       show_geom_boundingbox = SHOW_BOUNDING_BOX_ALWAYS;
     }
-    else if(strncmp(argv[i], "-make_movie", 11)==0){
+    if(args->make_movie){
       open_movie_dialog = 1;
     }
-    else if(strncmp(argv[i], "-geominfo", 9)==0){
+    if(args->geominfo){
       print_geominfo = 1;
     }
-    else if(strncmp(argv[i], "-fast", 5) == 0){
+    if(args->fast){
       fast_startup = 1;
       lookfor_compressed_slice = 0;
     }
-    else if(strncmp(argv[i], "-blank", 6) == 0){
+    if(args->blank){
       iblank_set_on_commandline = 1;
       use_iblank = 1;
     }
-    else if(strncmp(argv[i], "-gversion", 9) == 0){
+    if(args->gversion){
       vis_title_gversion = 1;
     }
-    else if(
-      strncmp(argv[i], "-volrender", 10) != 0 && (strncmp(argv[i], "-version", 8) == 0 || strncmp(argv[i], "-v", 2) == 0)
-      ){
-      DisplayVersionInfo("Smokeview ");
-      SMV_EXIT(0);
-    }
-    else if(
-      strncmp(argv[i], "-redirect", 9) == 0
-      ){
+    if(args->redirect){
       LOG_FILENAME = fopen(log_filename, "w");
       if(LOG_FILENAME != NULL){
         redirect = 1;
         SetStdOut(LOG_FILENAME);
       }
     }
-    else if(strncmp(argv[i], "-runscript", 10) == 0){
+    if(args->runscript){
       from_commandline = 1;
       iso_multithread=0;
 #ifdef pp_LUA
@@ -559,132 +516,110 @@ char *ParseCommandline(int argc, char **argv){
 #endif
       runscript = 1;
     }
-    else if(strncmp(argv[i], "-runhtmlscript", 14)==0){
+    if(args->runhtmlscript){
       from_commandline = 1;
       use_graphics = 0;
       iso_multithread = 0;
       runhtmlscript = 1;
     }
 #ifdef pp_LUA
-    else if(strncmp(argv[i], "-runluascript", 13) == 0){
+    if(args->runluascript){
       from_commandline = 1;
       iso_multithread=0;
       strcpy(luascript_filename, "");
-      strncpy(luascript_filename, fdsprefix, 1020);
+      strncpy(luascript_filename, fdsprefix, MAX_LUASCRIPT_FILENAME_BUFFER-5);
       strcat(luascript_filename, ".lua");
       runluascript = 1;
     }
-    else if(strncmp(argv[i], "-killscript", 11) == 0){
+    if(args->killscript){
       from_commandline = 1;
       exit_on_script_crash = 1;
     }
 #endif
-    else if(strncmp(argv[i], "-scriptrenderdir", 16)==0){
-      int nrenderdir;
-      char *renderdir;
-
-      i++;
-      if(i<argc){
-        renderdir = argv[i];
-        nrenderdir = strlen(renderdir);
-        if(nrenderdir>0){
-          NewMemory((void **)&script_renderdir_cmd, nrenderdir+1);
-          strcpy(script_renderdir_cmd, renderdir);
-        }
+    if(args->scriptrenderdir != NULL){
+      int nrenderdir = strlen(args->scriptrenderdir);
+      if(nrenderdir>0){
+        NewMemory((void **)&script_renderdir_cmd, nrenderdir+1);
+        strcpy(script_renderdir_cmd, args->scriptrenderdir);
       }
     }
-    else if(strncmp(argv[i], "-skipframe", 10) == 0){
+    if(args->skipframe_defined){
       from_commandline = 1;
-      ++i;
-      if(i < argc){
-        sscanf(argv[i], "%i", &render_skipframe0);
-      }
+      render_skipframe0 = args->skipframe;
     }
-    else if(strncmp(argv[i], "-startframe", 11) == 0){
+    if(args->startframe_defined){
       from_commandline = 1;
-      ++i;
-      if(i < argc){
-        sscanf(argv[i], "%i", &render_startframe0);
-      }
+      render_startframe0 = args->startframe;
     }
-    else if(strncmp(argv[i], "-volrender", 10) == 0){
+    if(args->volrender){
       from_commandline = 1;
       make_volrender_script = 1;
     }
-    else if(strncmp(argv[i], "-script", 7)==0||strncmp(argv[i], "-htmlscript", 11)==0){
-      int is_htmlscript;
-
-      is_htmlscript = strncmp(argv[i], "-htmlscript", 11);
-      if(is_htmlscript==0){
+    if(args->script!=NULL||args->htmlscript!=NULL){
+      bool is_htmlscript = args->htmlscript!=NULL;
+      if(is_htmlscript){
         use_graphics = 0;
         runhtmlscript = 1;
       }
       from_commandline = 1;
       iso_multithread=0;
-      ++i;
-      if(i < argc){
-        char scriptbuffer[256];
+        char scriptbuffer[MAX_SCRIPT_FILENAME_BUFFER];
         scriptfiledata *sfd;
-
-        strcpy(scriptbuffer, argv[i]);
+        if (args->script != NULL) {
+          if (strlen(args->script) > MAX_SCRIPT_FILENAME_BUFFER-1) {
+            fprintf(stderr, "*** Error: script filename exceeds maximum length of %d\n", MAX_SCRIPT_FILENAME_BUFFER-1);
+            SMV_EXIT(1);
+          }
+          strcpy(scriptbuffer, args->script);
+        } else {
+          if (strlen(args->htmlscript) > MAX_SCRIPT_FILENAME_BUFFER-1) {
+            fprintf(stderr, "*** Error: luascript filename exceeds maximum length of %d\n", MAX_SCRIPT_FILENAME_BUFFER-1);
+            SMV_EXIT(1);
+          }
+          strcpy(scriptbuffer, args->htmlscript);
+        }
         sfd = InsertScriptFile(scriptbuffer);
         if(sfd != NULL)default_script = sfd;
-        if(is_htmlscript!=0){
+        if(!is_htmlscript){
           runscript = 1;
         }
-      }
     }
 #ifdef pp_LUA
-    else if(strncmp(argv[i], "-luascript", 10) == 0){
+    if(args->luascript != NULL){
       from_commandline = 1;
       iso_multithread=0;
-      ++i;
-      if(i < argc){
-        strncpy(luascript_filename, argv[i], 1024);
-        runluascript = 1;
+      if (strlen(args->luascript) > MAX_LUASCRIPT_FILENAME_BUFFER-1) {
+        fprintf(stderr, "*** Error: luascript filename exceeds maximum length of %d\n", MAX_SMV_FILENAME_BUFFER-1);
+        SMV_EXIT(1);
       }
+      strncpy(luascript_filename, args->luascript, MAX_LUASCRIPT_FILENAME_BUFFER-1);
+      runluascript = 1;
     }
 #endif
-    else if(strncmp(argv[i], "-noexit", 7) == 0){
+    if(args->noexit){
       noexit = 1;
     }
-    else if(strncmp(argv[i], "-setup", 6) == 0){
+    if(args->setup){
       setup_only = 1;
     }
-    else if(strncmp(argv[i], "-bindir", 7) == 0){
-      ++i;
-      if(i < argc){
+    if(args->bindir != NULL){
         int len2;
 
-        len2 = strlen(argv[i]);
+        len2 = strlen(args->bindir);
         NewMemory((void **)&smokeview_bindir, len2 + 2);
-        strcpy(smokeview_bindir, argv[i]);
+        strcpy(smokeview_bindir, args->bindir);
         if(smokeview_bindir[len2 - 1] != dirseparator[0])strcat(smokeview_bindir, dirseparator);
-      }
     }
-    else if(strncmp(argv[i], "-casedir", 8)==0){
-      ++i;
-      if(i<argc){
+    if(args->casedir){
         int len2;
 
-        len2 = strlen(argv[i]);
+        len2 = strlen(args->casedir);
         NewMemory((void **)&smokeview_casedir, len2+2);
-        strcpy(smokeview_casedir, argv[i]);
-      }
+        strcpy(smokeview_casedir, args->casedir);
     }
-    else if(strncmp(argv[i], "-threads", 8)==0){
-      ++i;
-      if(i<argc){
-        sscanf(argv[i], "%i", &nreadallgeomthread_ids);
-        nreadallgeomthread_ids = CLAMP(nreadallgeomthread_ids, 1, 16);
-      }
+    if(args->threads_defined){
+        nreadallgeomthread_ids = CLAMP(args->threads, 1, 16);
     }
-    else{
-      fprintf(stderr, "*** Error: unknown option: %s\n", argv[i]);
-      printf("Use -help_all to see a list of valid options\n");
-      SMV_EXIT(1);
-    }
-  }
   if(update_ssf == 1){
     int len_prefix = 0;
 

--- a/Source/smokeview/smokeviewdefs.h
+++ b/Source/smokeview/smokeviewdefs.h
@@ -1086,5 +1086,10 @@ EXTERNCPP void _Sniff_Errors(const char *whereat, const char *file, int line);
 
 #define MENU_SHOWHIDE_FLIP 15
 
-#endif
+#define MAX_SMV_FILENAME_BUFFER 1024
+#define MAX_LUASCRIPT_FILENAME_BUFFER 1024
+// TODO: this was set to 256 in some parts of the code, but should probably be
+// increase (or dynamically allocated).
+#define MAX_SCRIPT_FILENAME_BUFFER 256
 
+#endif

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -1874,7 +1874,7 @@ SVEXTERN char SVDECL(*script_renderdir_cmd, NULL);
 SVEXTERN inifiledata first_inifile, last_inifile;
 SVEXTERN char script_filename[1024];
 #ifdef pp_LUA
-SVEXTERN char luascript_filename[1024];
+SVEXTERN char luascript_filename[MAX_LUASCRIPT_FILENAME_BUFFER];
 #endif
 SVEXTERN int highlight_block, highlight_mesh, highlight_flag;
 SVEXTERN int SVDECL(updategetobstlabels,1);

--- a/Verification/Visualization/CMakeLists.txt
+++ b/Verification/Visualization/CMakeLists.txt
@@ -12,4 +12,3 @@ foreach(smv_path ${TEST_CASES})
         add_test(NAME "Run script ${case_name}" COMMAND smokeview ${smv_path} -runscript WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/Verification/Visualization)
     endif ()
 endforeach()
-


### PR DESCRIPTION
This patch which contains a new CLI parser. This does two important things:

* Disallows the CLI parser from modifying any global variables or otherwise affecting any other parts of the code. This is a first step small step towards reducing the number of global variables.
* Serializes all possible options to a struct which can be documented and type checked.

This might seem like an unimportant reorganisation but will make it easier to do things in the future (next step being clarification of CHID vs filename etc.). This also adds some additional bounds checks.