### PR TITLE
add stdlib.h for qsort

### DIFF
--- a/Source/smokeview/colortimebar.c
+++ b/Source/smokeview/colortimebar.c
@@ -1,5 +1,6 @@
 #include "options.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 #include <ctype.h>


### PR DESCRIPTION
colortimebar.c uses qsort which comes from stdlib.h.