### PR TITLE
lua: correct lua behaviour with -v

### DIFF
--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -64,10 +64,9 @@ int ProgramSetupLua(lua_State *L, int argc, char **argv) {
   if (smokeview_bindir == NULL) {
     smokeview_bindir = GetProgDir(progname, &smokeviewpath);
   }
-
-  if (show_version == 1 || smv_filename == NULL) {
-    PRINTVERSION("smokeview", argv[0]);
-    return 1;
+  if(show_version == 1 || smv_filename == NULL){
+    DisplayVersionInfo("Smokeview ");
+    SMV_EXIT(0);
   }
   if (CheckSMVFile(smv_filename, smokeview_casedir) == 0) {
     SMV_EXIT(1);


### PR DESCRIPTION
Some upstream changes meant that lua versions would crash when run with `-v` and no display attached.

This PR correct that behaviour.