### PR TITLE
Clarify config paths (smokeview.ini and objects.svo)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,14 @@ if (BETA)
     add_compile_definitions(pp_BETA)
 endif ()
 
+if (SMOKEVIEW_CONFIG_PATH)
+    target_compile_definitions(smokeview PRIVATE SMOKEVIEW_CONFIG_PATH="${SMOKEVIEW_CONFIG_PATH}")
+endif()
+
+if (SMOKEVIEW_OBJECT_DEFS_PATH)
+    target_compile_definitions(smokeview PRIVATE SMOKEVIEW_OBJECT_DEFS_PATH="${SMOKEVIEW_OBJECT_DEFS_PATH}")
+endif()
+
 if (LUA)
     add_definitions(-Dpp_LUA)
     find_package(Lua)
@@ -712,3 +720,16 @@ include(CTest)
 enable_testing()
 add_subdirectory(Tests)
 add_subdirectory(Verification/Visualization)
+
+# Retrieve configuration and data files from the bot repo
+file(DOWNLOAD "https://raw.githubusercontent.com/firemodels/bot/a0a9d710f7a55b4e04c9ac4e32a04e2efe197c47/Bundlebot/smv/for_bundle/objects.svo" "${CMAKE_BINARY_DIR}/objects.svo" STATUS object_svo_status)
+list(GET object_svo_status 0 object_svo_status_code)
+if (object_svo_status_code)
+    message(FATAL_ERROR "Could not download objects.svo ${smokeview_ini_status_code}")
+endif()
+
+file(DOWNLOAD "https://raw.githubusercontent.com/firemodels/bot/a0a9d710f7a55b4e04c9ac4e32a04e2efe197c47/Bundlebot/smv/for_bundle/smokeview.ini" "${CMAKE_BINARY_DIR}/smokeview.ini" STATUS smokeview_ini_status)
+list(GET smokeview_ini_status 0 smokeview_ini_status_code)
+if (smokeview_ini_status_code)
+    message(FATAL_ERROR "Could not download smokeview.ini ${smokeview_ini_status_code}")
+endif()

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -7247,18 +7247,44 @@ void InitObjectDefs(void){
 
   svofile_exists = 0;
 
+  // There are 5 places to retrieve object definitions from:
+  //
+  //   1. A file within the same directory as the smokeview executable named
+  //      "objects.svo".
+  //   2. A file in the current directory named "objects.svo".
+  //   3. A file in the current directory named "${fdsprefix}.svo".
+  //   4. A file pointed to by SMOKEVIEW_OBJECT_DEFS_PATH.
+  //   5. A file pointed to be envar SMOKEVIEW_OBJECT_DEFS.
+  //
+  // Last definition wins.
+
+  // Read "objects.svo" from bin dir
   if(smokeview_bindir!=NULL){
     strcpy(objectfile,smokeview_bindir);
     strcat(objectfile,"objects.svo");
     ReadObjectDefs(objectfile);
   }
 
+  // Read "objects.svo" from the current directory.
   strcpy(objectfile,"objects.svo");
   ReadObjectDefs(objectfile);
 
+  // Read "${fdsprefix}.svo" from the current directory
   strcpy(objectfile,fdsprefix);
   strcat(objectfile,".svo");
   ReadObjectDefs(objectfile);
+
+#ifdef SMOKEVIEW_OBJECT_DEFS_PATH
+  // Read objects file pointed to be macro SMOKEVIEW_OBJECT_DEFS_PATH. Useful
+  // when install paths differ per platform.
+  ReadObjectDefs(SMOKEVIEW_OBJECT_DEFS_PATH);
+#endif
+
+  // Read objects file from the envar SMOKEVIEW_OBJECT_DEFS
+  char *envar_object_path = getenv("SMOKEVIEW_OBJECT_DEFS");
+  if (envar_object_path != NULL) {
+    ReadObjectDefs(envar_object_path);
+  }
 
   InitAvatar();
 


### PR DESCRIPTION
Smokeview takes configuration settings from a number of locations. This commit comments on these locations and adds two more:

  1. Paths defined at compile time. This is used to set paths on various platforms (where config is held in different places).
  2. Paths defined as environment variables.