### PR TITLE
Remove some duplicate functions

### DIFF
--- a/Source/shared/getdata.c
+++ b/Source/shared/getdata.c
@@ -298,7 +298,7 @@ void getsliceparms(const char *slicefilename, int *ip1, int *ip2, int *jp1,
   } else {
     *slice3d = 1;
   }
-  getslicefiledirection(ip1, ip2, &iip1, &iip2, jp1, jp2, kp1, kp2, &idir,
+  getslicefiledirection(*ip1, ip2, &iip1, &iip2, *jp1, jp2, *kp1, kp2, &idir,
                         &joff, &koff, &volslice);
 
   return;
@@ -379,7 +379,7 @@ void getslicesizes(const char *slicefilename, int *nslicei, int *nslicej,
   nysp = jp2 + 1 - jp1;
   nzsp = kp2 + 1 - kp1;
 
-  getslicefiledirection(&ip1, &ip2, &iip1, &iip2, &jp1, &jp2, &kp1, &kp2, &idir,
+  getslicefiledirection(ip1, &ip2, &iip1, &iip2, jp1, &jp2, kp1, &kp2, &idir,
                         &joff, &koff, &volslice);
   *nslicei = nxsp;
   *nslicej = nysp + joff;
@@ -807,43 +807,43 @@ void getdata1(FILE *file, int *ipart, int *error) {
 }
 
 // !  ------------------ getslicefiledirection ------------------------
-void getslicefiledirection(int *is1, int *is2, int *iis1, int *iis2, int *js1,
-                           int *js2, int *ks1, int *ks2, int *idir, int *joff,
+void getslicefiledirection(int is1, int *is2, int *iis1, int *iis2, int js1,
+                           int *js2, int ks1, int *ks2, int *idir, int *joff,
                            int *koff, int *volslice) {
   int nxsp, nysp, nzsp;
 
-  nxsp = *is2 + 1 - *is1;
-  nysp = *js2 + 1 - *js1;
-  nzsp = *ks2 + 1 - *ks1;
+  nxsp = *is2 + 1 - is1;
+  nysp = *js2 + 1 - js1;
+  nzsp = *ks2 + 1 - ks1;
   *joff = 0;
   *koff = 0;
   *volslice = 0;
-  *iis1 = *is1;
+  *iis1 = is1;
   *iis2 = *is2;
-  if (*is1 != *is2 && *js1 != *js2 && *ks1 != *ks2) {
+  if (is1 != *is2 && js1 != *js2 && ks1 != *ks2) {
     *idir = 1;
-    *is2 = *is1;
+    *is2 = is1;
     *volslice = 1;
     return;
   }
   int imin = MIN(MIN(nxsp, nysp), nzsp);
   if (nxsp == imin) {
     *idir = 1;
-    *is2 = *is1;
+    *is2 = is1;
   } else if (nysp == imin) {
     *idir = 2;
-    *js2 = *js1;
+    *js2 = js1;
   } else {
     *idir = 3;
-    *ks2 = *ks1;
+    *ks2 = ks1;
   }
-  if (*is1 == *is2 && *js1 == *js2) {
+  if (is1 == *is2 && js1 == *js2) {
     *idir = 1;
     *joff = 1;
-  } else if (*is1 == *is2 && *ks1 == *ks2) {
+  } else if (is1 == *is2 && ks1 == *ks2) {
     *idir = 1;
     *koff = 1;
-  } else if (*js1 == *js2 && *ks1 == *ks2) {
+  } else if (js1 == *js2 && ks1 == *ks2) {
     *idir = 2;
     *koff = 1;
   }

--- a/Source/shared/getdata.h
+++ b/Source/shared/getdata.h
@@ -17,10 +17,10 @@ void getsliceparms(const char *slicefilename, int *ip1, int *ip2, int *jp1,
                    int *slice3d, int *error);
 void getsliceheader(const char *slicefilename, int *ip1, int *ip2, int *jp1,
                     int *jp2, int *kp1, int *kp2, int *error);
-void getslicesizes(const char *slicefilename, int *nslicei, int *nslicej,
-                   int *nslicek, int *nsteps, int sliceframestep, int *error,
-                   int settmin_s, int settmax_s, float tmin_s, float tmax_s,
-                   int *headersize, int *framesize);
+void getslicesizes(const char *slicefilename, int time_frame, int *nslicei,
+                   int *nslicej, int *nslicek, int *nsteps, int sliceframestep,
+                   int *error, int settmin_s, int settmax_s, float tmin_s,
+                   float tmax_s, int *headersize, int *framesize);
 FILE *openpart(const char *partfilename, int *error);
 void openslice(const char *slicefilename, FILE **file, int *is1, int *is2,
                int *js1, int *js2, int *ks1, int *ks2, int *error);

--- a/Source/shared/getdata.h
+++ b/Source/shared/getdata.h
@@ -43,8 +43,8 @@ void getpatchdata(FILE *file, int npatch, int *pi1, int *pi2, int *pj1,
                   int *pj2, int *pk1, int *pk2, float *patchtime, float *pqq,
                   int *npqq, int *file_size, int *error);
 void getdata1(FILE *file, int *ipart, int *error) ;
-void getslicefiledirection(int *is1, int *is2, int *iis1, int *iis2, int *js1,
-                           int *js2, int *ks1, int *ks2, int *idir, int *joff,
+void getslicefiledirection(int is1, int *is2, int *iis1, int *iis2, int js1,
+                           int *js2, int ks1, int *ks2, int *idir, int *joff,
                            int *koff, int *volslice);
 void writeslicedata(const char *slicefilename, int is1, int is2, int js1,
                     int js2, int ks1, int ks2, float *qdata, float *times,

--- a/Source/smokeview/IOzone.c
+++ b/Source/smokeview/IOzone.c
@@ -842,7 +842,7 @@ void GetSliceTempBounds(void){
 
     slicei = sliceinfo + i;
     if(strcmp(slicei->label.shortlabel, "TEMP")!=0)continue;
-    GetSliceSizes(slicei, slicei->file, ALL_FRAMES, &slicei->nslicei, &slicei->nslicej, &slicei->nslicek, &slicei->ntimes, tload_step, &error,
+    getslicesizes(slicei->file, ALL_FRAMES, &slicei->nslicei, &slicei->nslicej, &slicei->nslicek, &slicei->ntimes, tload_step, &error,
                   use_tload_begin, use_tload_end, tload_begin, tload_end, &headersize, &framesize);
     return_val = NewResizeMemory(slicei->qslicedata, sizeof(float)*(slicei->nslicei+1)*(slicei->nslicej+1)*(slicei->nslicek+1)*slicei->ntimes);
     if(return_val!=0)return_val = NewResizeMemory(slicei->times, sizeof(float)*slicei->ntimes);

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -16,6 +16,7 @@
 #include "IOvolsmoke.h"
 #include "stdio_buffer.h"
 #include "glui_motion.h"
+#include "getdata.h"
 
 #define BREAK break
 #define BREAK2 \
@@ -5899,7 +5900,7 @@ int ParseSLCFProcess(int option, bufferstreamdata *stream, char *buffer, int *nn
   if(read_slice_header==1){
     int error;
 
-    GetSliceFileHeader(sd->file, &ii1, &ii2, &jj1, &jj2, &kk1, &kk2, &error);
+    getsliceheader(sd->file, &ii1, &ii2, &jj1, &jj2, &kk1, &kk2, &error);
   }
   if(cellcenter==1){
     ii1 = MAX(ii1, 1);

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -246,8 +246,6 @@ EXTERNCPP FILE_SIZE GetSliceData(slicedata *sd, const char *slicefilename, int t
   float *qminptr, float *qmaxptr, float *qdataptr, float *timesptr, int ntimes_old_arg, int *ntimesptr,
   int tload_step_arg, int tload_beg_arg, int settmax_s_arg, float tmin_s_arg, float tmax_s_arg
 );
-EXTERNCPP void GetSliceSizes(slicedata *sd, const char *slicefilenameptr, int time_frame, int *nsliceiptr, int *nslicejptr, int *nslicekptr, int *ntimesptr, int tload_step_arg,
-  int *errorptr, int tload_beg_arg, int settmax_s_arg, float tmin_s_arg, float tmax_s_arg, int *headersizeptr, int *framesizeptr);
 EXTERNCPP void PrintPartLoadSummary(int option, int type);
 EXTERNCPP void CreatePartSizeFile(partdata *parti);
 EXTERNCPP void GetAllPartBounds(void);

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -166,7 +166,6 @@ EXTERNCPP void RefreshGluiDialogs(void);
 #endif
 EXTERNCPP void SetMainWindow(void);
 EXTERNCPP void UpdatePartType(void);
-EXTERNCPP void GetSliceFileHeader(char *file, int *ip1, int *ip2, int *jp1, int *jp2, int *kp1, int *kp2, int *error);
 EXTERNCPP int TimeAverageData(float *data_out, float *data_in, int ndata, int data_per_timestep, float *times_local, int ntimes_local, float average_time);
 bufferstreamdata *GetSMVBuffer(char *file, char *file2);
 EXTERNCPP void UpdateBlockType(void);


### PR DESCRIPTION
Particularly now that it is in shared, there are a number of functions that are both in `getdata.c` and (for example) `IOslice.c`.

This PR removes some duplicates. I've kept the ones in `getdata.c` as they are easier to test as they are more separated from global variables.