### PR TITLE
lua: improve font size handling in lua scripts

### DIFF
--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -111,6 +111,8 @@ int set_slice_bounds(const char *slice_type, int set_valmin, float valmin,
   slicebounds[slice_type_index].dlg_valmin = valmin;
   slicebounds[slice_type_index].dlg_valmax = valmax;
   int error = 0;
+  SetMinMax(BOUND_SLICE, slicebounds[slice_type_index].shortlabel, set_valmin,
+            valmin, set_valmax, valmax);
   // Update the colors given the bounds set above
   UpdateAllSliceColors(slice_type_index, &error);
   return 0;
@@ -2677,7 +2679,7 @@ int set_eyez(float v) {
 } // EYEZ
 
 int set_fontsize(int v) {
-  fontindex = v;
+  FontMenu(v);
   return 0;
 } // FONTSIZE
 
@@ -2776,6 +2778,15 @@ int set_scaledfont(int height2d, float height2dwidth, int thickness2d,
   thickness3d = scaled_font3d_thickness;
   return 0;
 } // SCALEDFONT
+
+int get_scaledfont_height2d() {
+  return scaled_font2d_height;
+}
+
+int set_scaledfont_height2d(int height2d) {
+  scaled_font2d_height = height2d;
+  return 0;
+}
 
 int set_showalltextures(int v) {
   showall_textures = v;

--- a/Source/smokeview/c_api.h
+++ b/Source/smokeview/c_api.h
@@ -389,6 +389,8 @@ int set_sbatstart(int v);                               // SBATSTART
 int set_scaledfont(int height2d, float height2dwidth, int thickness2d,
                    int height3d, float height3dwidth,
                    int thickness3d); // SCALEDFONT
+int get_scaledfont_height2d();
+int set_scaledfont_height2d(int height2d);
 int set_showalltextures(int v);      // SHOWALLTEXTURES
 int set_showaxislabels(int v);       // SHOWAXISLABELS
 int set_showblocklabel(int v);       // SHOWBLOCKLABEL

--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -3626,6 +3626,7 @@ int lua_set_outlinemode(lua_State *L) {
   int outline = lua_tonumber(L, 2);
   int return_code = set_outlinemode(highlight, outline);
   lua_pushnumber(L, return_code);
+  ;
   return 1;
 }
 
@@ -3652,6 +3653,33 @@ int lua_set_scaledfont(lua_State *L) {
   int thickness3d = lua_tonumber(L, 6);
   int return_code = set_scaledfont(height2d, height2dwidth, thickness2d,
                                    height3d, height3dwidth, thickness3d);
+  lua_pushnumber(L, return_code);
+  return 1;
+}
+
+int lua_get_fontsize(lua_State *L) {
+  switch (fontindex) {
+  case SMALL_FONT:
+    lua_pushstring(L, "small");
+    return 1;
+    break;
+  case LARGE_FONT:
+    lua_pushstring(L, "large");
+    return 1;
+    break;
+  case SCALED_FONT:
+    lua_pushnumber(L, scaled_font2d_height);
+    return 1;
+    break;
+  default:
+    return luaL_error(L, "font size is invalid");
+    break;
+  }
+}
+
+int lua_set_scaledfont_height2d(lua_State *L) {
+  int height2d = lua_tonumber(L, 1);
+  int return_code = set_scaledfont_height2d(height2d);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -5328,6 +5356,7 @@ static luaL_Reg const smvlib[] = {
     {"set_eyex", lua_set_eyex},
     {"set_eyey", lua_set_eyey},
     {"set_eyez", lua_set_eyez},
+    {"get_fontsize", lua_get_fontsize},
     {"set_fontsize", lua_set_fontsize},
     {"set_frameratevalue", lua_set_frameratevalue},
     {"set_showfaces_solid", lua_set_showfaces_solid},
@@ -5345,6 +5374,7 @@ static luaL_Reg const smvlib[] = {
     {"set_p3dsurfacetype", lua_set_p3dsurfacetype},
     {"set_p3dsurfacesmooth", lua_set_p3dsurfacesmooth},
     {"set_scaledfont", lua_set_scaledfont},
+    {"set_scaledfont_height2d", lua_set_scaledfont_height2d},
     {"set_showalltextures", lua_set_showalltextures},
     {"set_showaxislabels", lua_set_showaxislabels},
     {"set_showblocklabel", lua_set_showblocklabel},

--- a/Source/smvluacore/view.lua
+++ b/Source/smvluacore/view.lua
@@ -1,5 +1,6 @@
 --- @module 'view'
-local view = { colorbar = {}, blockages = {}, color = {}, titlebox = {}, surfaces = {}, devices = {}, outline = {} }
+local view = { colorbar = {}, font = {}, blockages = {}, color = {}, titlebox = {}, surfaces = {}, devices = {},
+    outline = {} }
 view.camera = require("camera")
 local _view = {
     -- colorbar = {
@@ -107,8 +108,8 @@ local view_mt = {
     __index = function(t, k)
         if type(_view[k]) == "function" then
             return _view[k]
-        elseif k == "render" or k == "bounds" or k == "window" then
-                return _view[k]
+        elseif k == "render" or k == "bounds" or k == "window" or k == "font" then
+            return _view[k]
         else
             return _view[k].get()
         end
@@ -197,6 +198,42 @@ local colorbar_mt = {
     end
 }
 setmetatable(view.colorbar, colorbar_mt)
+
+
+local _font = {
+    size = {
+        get = function()
+            return smvlib.get_fontsize()
+        end,
+        set = function(v)
+            if v == "small" then
+                return smvlib.set_fontsize(0)
+            elseif v == "large" then
+                return smvlib.set_fontsize(1)
+            elseif type(v) == "number" then
+                smvlib.set_scaledfont_height2d(v)
+                return smvlib.set_fontsize(2)
+            else
+                error("invalid font size")
+            end
+        end
+    }
+}
+local font_mt = {
+    -- get method
+    __index = function(t, k)
+        if type(_font[k]) == "function" then
+            return _font[k]
+        else
+            return _font[k].get()
+        end
+    end,
+    -- set method
+    __newindex = function(t, k, v)
+        _font[k].set(v)
+    end
+}
+setmetatable(view.font, font_mt)
 
 local _titlebox = {
     add_line = function(line)


### PR DESCRIPTION
This PR improves the API around font size handling in lua scripts.

```lua
view.font.size = "small"
view.font.size = "large"
view.font.size = 32
view.font.size = 18
print("Font Size:", view.font.size)
```