### PR TITLE
lua: refactor to match smv style

### DIFF
--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -46,7 +46,7 @@ void UnloadBoundaryMenu(int value);
 /// slicebounds array.
 /// @param slice_type A string describing the slice quantity.
 /// @return If successful, the index > 0. If not found -1.
-int get_slice_bound_index(const char *slice_type) {
+int GetSliceBoundIndex(const char *slice_type) {
   for (int i = 0; i < nslicebounds; i++) {
     if (strcmp(slicebounds[i].shortlabel, slice_type) == 0) {
       return i;
@@ -60,8 +60,8 @@ int get_slice_bound_index(const char *slice_type) {
 /// @param set
 /// @param value
 /// @return Non-zero on error
-int set_slice_bound_min(const char *slice_type, int set, float value) {
-  int slice_type_index = get_slice_bound_index(slice_type);
+int SetSliceBoundMin(const char *slice_type, int set, float value) {
+  int slice_type_index = GetSliceBoundIndex(slice_type);
   if (slice_type_index < 0) {
     // Slice type index could not be found.
     return 1;
@@ -80,8 +80,8 @@ int set_slice_bound_min(const char *slice_type, int set, float value) {
 /// @param[in] set
 /// @param[in] value
 /// @return
-int set_slice_bound_max(const char *slice_type, int set, float value) {
-  int slice_type_index = get_slice_bound_index(slice_type);
+int SetSliceBoundMax(const char *slice_type, int set, float value) {
+  int slice_type_index = GetSliceBoundIndex(slice_type);
   if (slice_type_index < 0) {
     // Slice type index could not be found.
     return 1;
@@ -102,9 +102,9 @@ int set_slice_bound_max(const char *slice_type, int set, float value) {
 /// @param[in] set_valmax
 /// @param[in] valmax
 /// @return Non-zero on error
-int set_slice_bounds(const char *slice_type, int set_valmin, float valmin,
-                     int set_valmax, float valmax) {
-  int slice_type_index = get_slice_bound_index(slice_type);
+int CApiSetSliceBounds(const char *slice_type, int set_valmin, float valmin,
+                   int set_valmax, float valmax) {
+  int slice_type_index = GetSliceBoundIndex(slice_type);
   if (slice_type_index < 0) {
     // Slice type index could not be found.
     return 1;
@@ -115,7 +115,8 @@ int set_slice_bounds(const char *slice_type, int set_valmin, float valmin,
   slicebounds[slice_type_index].dlg_valmin = valmin;
   slicebounds[slice_type_index].dlg_valmax = valmax;
   int error = 0;
-  SetMinMax(BOUND_SLICE, slicebounds[slice_type_index].shortlabel, set_valmin, valmin, set_valmax, valmax);
+  SetMinMax(BOUND_SLICE, slicebounds[slice_type_index].shortlabel, set_valmin,
+            valmin, set_valmax, valmax);
   // Update the colors given the bounds set above
   UpdateAllSliceColors(slice_type_index, &error);
   return 0;
@@ -126,8 +127,8 @@ int set_slice_bounds(const char *slice_type, int set_valmin, float valmin,
 /// @param[out] A simple_bounds struct containing the min and max bounds being
 /// used.
 /// @return Non-zero on error
-ERROR_CODE get_slice_bounds(const char *slice_type, simple_bounds *bounds) {
-  int slice_type_index = get_slice_bound_index(slice_type);
+ERROR_CODE GetSliceBounds(const char *slice_type, simple_bounds *bounds) {
+  int slice_type_index = GetSliceBoundIndex(slice_type);
   if (slice_type_index < 0) {
     // Slice type index could not be found.
     return ERR_NOK;
@@ -145,12 +146,12 @@ ERROR_CODE get_slice_bounds(const char *slice_type, simple_bounds *bounds) {
 /// elements that have yet to be factored out.
 /// @param[in] input_filename
 /// @return Non-zero on error
-int loadsmvall(const char *input_filename) {
+int Loadsmvall(const char *input_filename) {
   int return_code;
   // fdsprefix and input_filename_ext are global and defined in smokeviewvars.h
   // TODO: move these into the model information namespace
-  parse_smv_filepath(input_filename, fdsprefix, input_filename_ext);
-  return_code = loadsmv(fdsprefix, input_filename_ext);
+  ParseSmvFilepath(input_filename, fdsprefix, input_filename_ext);
+  return_code = Loadsmv(fdsprefix, input_filename_ext);
   if (return_code == 0 && update_bounds == 1) return_code = Update_Bounds();
   if (return_code != 0) return 1;
   // if(convert_ini==1){
@@ -166,7 +167,7 @@ int loadsmvall(const char *input_filename) {
 /// @param[out] fdsprefix
 /// @param[out] input_filename_ext
 /// @return
-int parse_smv_filepath(const char *smv_filepath, char *fdsprefix,
+int ParseSmvFilepath(const char *smv_filepath, char *fdsprefix,
                        char *input_filename_ext) {
   int len_casename;
   strcpy(input_filename_ext, "");
@@ -201,7 +202,7 @@ int parse_smv_filepath(const char *smv_filepath, char *fdsprefix,
   return 0;
 }
 
-int loadsmv(char *input_filename, char *input_filename_ext) {
+int Loadsmv(char *input_filename, char *input_filename_ext) {
   int return_code;
   char *input_file;
 
@@ -221,7 +222,8 @@ int loadsmv(char *input_filename, char *input_filename_ext) {
     trainer_active = 1;
     if (strcmp(input_filename_ext, ".svd") == 0) {
       input_file = trainer_filename;
-    } else if (strcmp(input_filename_ext, ".smt") == 0) {
+    }
+    else if (strcmp(input_filename_ext, ".smt") == 0) {
       input_file = test_filename;
     }
   }
@@ -307,7 +309,7 @@ int loadsmv(char *input_filename, char *input_filename_ext) {
   return 0;
 }
 
-int loadfile(const char *filename) {
+int Loadfile(const char *filename) {
   int errorcode = 0;
   if (filename == NULL) {
     // Return an error if passed a null pointer.
@@ -327,7 +329,8 @@ int loadfile(const char *filename) {
       if (i < nsliceinfo - nfedinfo) {
         ReadSlice(sd->file, i, ALL_FRAMES, NULL, LOAD, SET_SLICECOLOR,
                   &errorcode);
-      } else {
+      }
+      else {
         ReadFed(i, ALL_FRAMES, NULL, LOAD, FED_SLICE, &errorcode);
       }
       return errorcode;
@@ -399,14 +402,14 @@ int loadfile(const char *filename) {
   return 0;
 }
 
-void loadinifile(const char *filepath) {
+void Loadinifile(const char *filepath) {
   windowresized = 0;
   char f[1048];
   strcpy(f, filepath);
   ReadIni(f);
 }
 
-int loadvfile(const char *filepath) {
+int Loadvfile(const char *filepath) {
   FREEMEMORY(loaded_file);
   for (size_t i = 0; i < nvsliceinfo; i++) {
     slicedata *val;
@@ -428,7 +431,7 @@ int loadvfile(const char *filepath) {
   return 1;
 }
 
-void loadboundaryfile(const char *filepath) {
+void Loadboundaryfile(const char *filepath) {
   int errorcode;
   int count = 0;
 
@@ -465,7 +468,7 @@ void loadboundaryfile(const char *filepath) {
 /// @param right
 /// @param bottom
 /// @param top
-void renderclip(int flag, int left, int right, int bottom, int top) {
+void Renderclip(int flag, int left, int right, int bottom, int top) {
   clip_rendered_scene = flag;
   render_clip_left = left;
   render_clip_right = right;
@@ -473,7 +476,7 @@ void renderclip(int flag, int left, int right, int bottom, int top) {
   render_clip_top = top;
 }
 
-ERROR_CODE render(const char *filename) {
+ERROR_CODE CApiRender(const char *filename) {
   // runluascript=0;
   DisplayCB();
   // runluascript=1;
@@ -491,9 +494,9 @@ ERROR_CODE render(const char *filename) {
 /// @param screenH
 /// @param basename
 /// @return
-char *form_filename(int view_mode, char *renderfile_name, char *renderfile_dir,
-                    char *renderfile_path, int woffset, int hoffset,
-                    int screenH, const char *basename) {
+char *FormFilename(int view_mode, char *renderfile_name, char *renderfile_dir,
+                   char *renderfile_path, int woffset, int hoffset, int screenH,
+                   const char *basename) {
   char *renderfile_ext;
   char *view_suffix;
 
@@ -561,7 +564,8 @@ char *form_filename(int view_mode, char *renderfile_name, char *renderfile_dir,
 
     snprintf(renderfile_name, 1024, "%s%s%s", chidfilebase, view_suffix,
              renderfile_ext);
-  } else {
+  }
+  else {
     snprintf(renderfile_name, 1024, "%s%s", basename, renderfile_ext);
   }
   return renderfile_name;
@@ -584,12 +588,13 @@ int RenderFrameLua(int view_mode, const char *basename) {
                               // rendered
   char renderfile_path[2048]; // the full path of the rendered image
   int woffset = 0, hoffset = 0;
-  int screenH;
+  int screen_h;
   int return_code;
 
   if (script_dir_path != NULL) {
     strcpy(renderfile_dir, script_dir_path);
-  } else {
+  }
+  else {
     strcpy(renderfile_dir, ".");
   }
 
@@ -598,16 +603,16 @@ int RenderFrameLua(int view_mode, const char *basename) {
   SetThreadExecutionState(ES_DISPLAY_REQUIRED);
 #endif
 
-  screenH = screenHeight;
+  screen_h = screenHeight;
   // we should not be rendering under these conditions
   if (view_mode == VIEW_LEFT && stereotype == STEREO_RB) return 0;
   // construct filename for image to be rendered
-  form_filename(view_mode, renderfile_name, renderfile_dir, renderfile_path,
-                woffset, hoffset, screenH, basename);
+  FormFilename(view_mode, renderfile_name, renderfile_dir, renderfile_path,
+               woffset, hoffset, screen_h, basename);
   // render image
   return_code =
       SmokeviewImage2File(renderfile_dir, renderfile_name, render_filetype,
-                          woffset, screenWidth, hoffset, screenH);
+                          woffset, screenWidth, hoffset, screen_h);
   if (RenderTime == 1 && output_slicedata == 1) {
     OutputSliceData();
   }
@@ -616,7 +621,7 @@ int RenderFrameLua(int view_mode, const char *basename) {
 
 int RenderFrameLuaVar(int view_mode, gdImagePtr *RENDERimage) {
   int woffset = 0, hoffset = 0;
-  int screenH;
+  int screen_h;
   int return_code;
 
 #ifdef WIN32
@@ -624,19 +629,19 @@ int RenderFrameLuaVar(int view_mode, gdImagePtr *RENDERimage) {
   SetThreadExecutionState(ES_DISPLAY_REQUIRED);
 #endif
 
-  screenH = screenHeight;
+  screen_h = screenHeight;
   // we should not be rendering under these conditions
   if (view_mode == VIEW_LEFT && stereotype == STEREO_RB) return 0;
   // render image
   return_code = SVimage2var(render_filetype, woffset, screenWidth, hoffset,
-                            screenH, RENDERimage);
+                            screen_h, RENDERimage);
   if (RenderTime == 1 && output_slicedata == 1) {
     OutputSliceData();
   }
   return return_code;
 }
 
-void settourkeyframe(float keyframe_time) {
+void Settourkeyframe(float keyframe_time) {
   keyframe *keyj, *minkey = NULL;
   tourdata *touri;
   float minkeytime = 1000000000.0;
@@ -665,7 +670,7 @@ void settourkeyframe(float keyframe_time) {
   }
 }
 
-void gsliceview(int data, int show_triangles, int show_triangulation,
+void Gsliceview(int data, int show_triangles, int show_triangulation,
                 int show_normal) {
   vis_gslice_data = data;
   show_gslice_triangles = show_triangles;
@@ -674,20 +679,20 @@ void gsliceview(int data, int show_triangles, int show_triangulation,
   update_gslice = 1;
 }
 
-void gslicepos(float x, float y, float z) {
+void Gslicepos(float x, float y, float z) {
   gslice_xyz[0] = x;
   gslice_xyz[1] = y;
   gslice_xyz[2] = z;
   update_gslice = 1;
 }
 
-void gsliceorien(float az, float elev) {
+void Gsliceorien(float az, float elev) {
   gslice_normal_azelev[0] = az;
   gslice_normal_azelev[1] = elev;
   update_gslice = 1;
 }
 
-void settourview(int edittourArg, int mode, int show_tourlocusArg,
+void Settourview(int edittourArg, int mode, int show_tourlocusArg,
                  float tour_global_tensionArg) {
   edittour = edittourArg;
   show_avatar = show_tourlocusArg;
@@ -712,21 +717,21 @@ void settourview(int edittourArg, int mode, int show_tourlocusArg,
 
 /// @brief Get the current frame number.
 /// @return Time value in seconds.
-int getframe() {
+int Getframe() {
   int framenumber = itimes;
   return framenumber;
 }
 
 /// @brief Get the time value of the current frame.
 /// @return
-float gettime() { return global_times[itimes]; }
+float Gettime() { return global_times[itimes]; }
 
 /// @brief Set the currrent time.
 ///
 /// Switch to the frame with the closest time value to @p timeval.
 /// @param timeval Time in seconds
 /// @return Non-zero on error
-int settime(float timeval) {
+int Settime(float timeval) {
   if (global_times != NULL && nglobal_times > 0) {
     if (timeval < global_times[0]) timeval = global_times[0];
     if (timeval > global_times[nglobal_times - 1] - 0.0001) {
@@ -765,14 +770,15 @@ int settime(float timeval) {
     UpdateFrameNumber(0);
     UpdateTimeLabels();
     return 0;
-  } else {
+  }
+  else {
     return 1;
   }
 }
 
 /// @brief Show slices in blockages.
 /// @param setting Boolean
-void set_slice_in_obst(int setting) {
+void SetSliceInObst(int setting) {
   show_slice_in_obst = setting;
   // UpdateSliceFilenum();
   // plotstate=GetPlotState(DYNAMIC_PLOTS);
@@ -783,21 +789,21 @@ void set_slice_in_obst(int setting) {
 
 /// @brief Check if slices are being shown in obstructions.
 /// @return
-int get_slice_in_obst() { return show_slice_in_obst; }
+int GetSliceInObst() { return show_slice_in_obst; }
 
 /// @brief Set the colorbar to one named @p name
 /// @param name
 /// @return
-ERROR_CODE set_named_colorbar(const char *name) {
+ERROR_CODE SetNamedColorbar(const char *name) {
   size_t index = 0;
-  if (get_named_colorbar(name, &index)) {
+  if (GetNamedColorbar(name, &index)) {
     return ERR_NOK;
   }
-  set_colorbar(index);
+  SetColorbar(index);
   return ERR_OK;
 }
 
-ERROR_CODE get_named_colorbar(const char *name, size_t *index) {
+ERROR_CODE GetNamedColorbar(const char *name, size_t *index) {
   for (size_t i = 0; i < ncolorbars; i++) {
     if (strcmp(colorbarinfo[i].menu_label, name) == 0) {
       *index = i;
@@ -809,7 +815,7 @@ ERROR_CODE get_named_colorbar(const char *name, size_t *index) {
 
 /// @brief Set the colorbar to the given colorbar index.
 /// @param value
-void set_colorbar(size_t value) {
+void SetColorbar(size_t value) {
   colorbartype = value;
   iso_colorbar_index = value;
   iso_colorbar = colorbarinfo + iso_colorbar_index;
@@ -819,7 +825,8 @@ void set_colorbar(size_t value) {
   UpdateColorbarType();
   if (colorbartype == bw_colorbar_index && bw_colorbar_index >= 0) {
     setbwdata = 1;
-  } else {
+  }
+  else {
     setbwdata = 0;
   }
   IsoBoundCB(ISO_COLORS);
@@ -829,95 +836,101 @@ void set_colorbar(size_t value) {
   }
 }
 
-void set_colorbar_visibility_vertical(int setting) {
+void SetColorbarVisibilityVertical(int setting) {
   visColorbarVertical = setting;
   if (visColorbarVertical == 1 && visColorbarHorizontal == 0) {
     vis_colorbar = 1;
-  } else if (visColorbarVertical == 0 && visColorbarHorizontal == 1) {
+  }
+  else if (visColorbarVertical == 0 && visColorbarHorizontal == 1) {
     vis_colorbar = 2;
-  } else {
+  }
+  else {
     vis_colorbar = 0;
   }
 }
 
-int get_colorbar_visibility_vertical() { return visColorbarVertical; }
+int GetColorbarVisibilityVertical() { return visColorbarVertical; }
 
-void toggle_colorbar_visibility_vertical() {
+void ToggleColorbarVisibilityVertical() {
   visColorbarVertical = 1 - visColorbarVertical;
   if (visColorbarVertical == 1 && visColorbarHorizontal == 0) {
     vis_colorbar = 1;
-  } else if (visColorbarVertical == 0 && visColorbarHorizontal == 1) {
+  }
+  else if (visColorbarVertical == 0 && visColorbarHorizontal == 1) {
     vis_colorbar = 2;
-  } else {
+  }
+  else {
     vis_colorbar = 0;
   }
 }
 
-void set_colorbar_visibility_horizontal(int setting) {
+void SetColorbarVisibilityHorizontal(int setting) {
   visColorbarHorizontal = setting;
   if (visColorbarVertical == 1 && visColorbarHorizontal == 0) {
     vis_colorbar = 1;
-  } else if (visColorbarVertical == 0 && visColorbarHorizontal == 1) {
+  }
+  else if (visColorbarVertical == 0 && visColorbarHorizontal == 1) {
     vis_colorbar = 2;
-  } else {
+  }
+  else {
     vis_colorbar = 0;
   }
 }
 
-int get_colorbar_visibility_horizontal() { return visColorbarHorizontal; }
+int GetColorbarVisibilityHorizontal() { return visColorbarHorizontal; }
 
-void toggle_colorbar_visibility_horizontal() {
+void ToggleColorbarVisibilityHorizontal() {
   visColorbarHorizontal = 1 - visColorbarHorizontal;
   if (visColorbarVertical == 1 && visColorbarHorizontal == 0) {
     vis_colorbar = 1;
-  } else if (visColorbarVertical == 0 && visColorbarHorizontal == 1) {
+  }
+  else if (visColorbarVertical == 0 && visColorbarHorizontal == 1) {
     vis_colorbar = 2;
-  } else {
+  }
+  else {
     vis_colorbar = 0;
   }
 }
 
-void set_colorbar_visibility(int setting) {
-  set_colorbar_visibility_vertical(setting);
+void SetColorbarVisibility(int setting) {
+  SetColorbarVisibilityVertical(setting);
 }
 
-int get_colorbar_visibility() { return get_colorbar_visibility_vertical(); }
+int GetColorbarVisibility() { return GetColorbarVisibilityVertical(); }
 
-void toggle_colorbar_visibility() { toggle_colorbar_visibility_vertical(); }
+void ToggleColorbarVisibility() { ToggleColorbarVisibilityVertical(); }
 
-void set_timebar_visibility(int setting) { visTimebar = setting; }
+void SetTimebarVisibility(int setting) { visTimebar = setting; }
 
-int get_timebar_visibility() { return visTimebar; }
+int GetTimebarVisibility() { return visTimebar; }
 
-void toggle_timebar_visibility() { visTimebar = 1 - visTimebar; }
+void ToggleTimebarVisibility() { visTimebar = 1 - visTimebar; }
 
 /// @brief Set whether the title of the simulation is visible.
 /// @param setting Boolean value.
-void set_title_visibility(int setting) { vis_title_fds = setting; }
+void SetTitleVisibility(int setting) { vis_title_fds = setting; }
 
 /// @brief Check whether the title of the simulation is visible.
 /// @return
-int get_title_visibility() { return vis_title_fds; }
+int GetTitleVisibility() { return vis_title_fds; }
 
-void toggle_title_visibility() { vis_title_fds = 1 - vis_title_fds; }
+void ToggleTitleVisibility() { vis_title_fds = 1 - vis_title_fds; }
 
-void set_smv_version_visibility(int setting) {
-  vis_title_smv_version = setting;
-}
+void SetSmvVersionVisibility(int setting) { vis_title_smv_version = setting; }
 
-int get_smv_version_visibility() { return vis_title_smv_version; }
+int GetSmvVersionVisibility() { return vis_title_smv_version; }
 
-void toggle_smv_version_visibility() {
+void ToggleSmvVersionVisibility() {
   vis_title_smv_version = 1 - vis_title_smv_version;
 }
 
-void set_chid_visibility(int setting) { vis_title_CHID = setting; }
+void SetChidVisibility(int setting) { vis_title_CHID = setting; }
 
-int get_chid_visibility() { return vis_title_CHID; }
+int GetChidVisibility() { return vis_title_CHID; }
 
-void toggle_chid_visibility() { vis_title_CHID = 1 - vis_title_CHID; }
+void ToggleChidVisibility() { vis_title_CHID = 1 - vis_title_CHID; }
 
-void blockages_show_all() {
+void BlockagesShowAll() {
   if (isZoneFireModel) visFrame = 1;
   /*
   visFloor=1;
@@ -931,16 +944,16 @@ void blockages_show_all() {
 
 void ImmersedMenu(int value);
 void BlockageMenu(int value);
-void blockages_hide_all() { BlockageMenu(visBLOCKHide); }
+void BlockagesHideAll() { BlockageMenu(visBLOCKHide); }
 // TODO: clarify behaviour under isZoneFireModel
-void outlines_hide() {
+void OutlinesHide() {
   if (isZoneFireModel == 0) visFrame = 1 - visFrame;
 }
-void outlines_show() {
+void OutlinesShow() {
   if (isZoneFireModel == 0) visFrame = 1 - visFrame;
 }
 
-void surfaces_hide_all() {
+void SurfacesHideAll() {
   visVents = 0;
   visOpenVents = 0;
   visDummyVents = 0;
@@ -948,7 +961,7 @@ void surfaces_hide_all() {
   visCircularVents = VENT_HIDE;
 }
 
-void devices_hide_all() {
+void DevicesHideAll() {
   for (size_t i = 0; i < nobject_defs; i++) {
     sv_object *objecti = object_defs[i];
     objecti->visible = 0;
@@ -956,20 +969,20 @@ void devices_hide_all() {
 }
 
 // axis visibility
-void set_axis_visibility(int setting) {
+void SetAxisVisibility(int setting) {
   visaxislabels = setting;
   UpdateVisAxisLabels();
 }
 
-int get_axis_visibility() { return visaxislabels; }
+int GetAxisVisibility() { return visaxislabels; }
 
-void toggle_axis_visibility() {
+void ToggleAxisVisibility() {
   visaxislabels = 1 - visaxislabels;
   UpdateVisAxisLabels();
 }
 
 // framelabel visibility
-void set_framelabel_visibility(int setting) {
+void SetFramelabelVisibility(int setting) {
   visFramelabel = setting;
   // The frame label should not be shown without the timebar
   // so show timebar if necessary.
@@ -982,9 +995,9 @@ void set_framelabel_visibility(int setting) {
   }
 }
 
-int get_framelabel_visibility() { return visFramelabel; }
+int GetFramelabelVisibility() { return visFramelabel; }
 
-void toggle_framelabel_visibility() {
+void ToggleFramelabelVisibility() {
   visFramelabel = 1 - visFramelabel;
   // The frame label should not be shown without the timebar
   // so show timebar if necessary.
@@ -997,34 +1010,34 @@ void toggle_framelabel_visibility() {
   }
 }
 
-void set_framerate_visibility(int setting) { visFramerate = setting; }
+void SetFramerateVisibility(int setting) { visFramerate = setting; }
 
-int get_framerate_visibility() { return visFramerate; }
+int GetFramerateVisibility() { return visFramerate; }
 
-void toggle_framerate_visibility() { visFramerate = 1 - visFramerate; }
+void ToggleFramerateVisibility() { visFramerate = 1 - visFramerate; }
 
 // grid locations visibility
-void set_gridloc_visibility(int setting) { visgridloc = setting; }
+void SetGridlocVisibility(int setting) { visgridloc = setting; }
 
-int get_gridloc_visibility() { return visgridloc; }
+int GetGridlocVisibility() { return visgridloc; }
 
-void toggle_gridloc_visibility() { visgridloc = 1 - visgridloc; }
+void ToggleGridlocVisibility() { visgridloc = 1 - visgridloc; }
 
 // HRRPUV cutoff visibility
-void set_hrrcutoff_visibility(int setting) { show_hrrcutoff_active = setting; }
+void SetHrrcutoffVisibility(int setting) { show_hrrcutoff_active = setting; }
 
-int get_hrrcutoff_visibility() { return show_hrrcutoff_active; }
+int GetHrrcutoffVisibility() { return show_hrrcutoff_active; }
 
-void toggle_hrrcutoff_visibility() {
+void ToggleHrrcutoffVisibility() {
   show_hrrcutoff_active = 1 - show_hrrcutoff_active;
 }
 
 // HRR label
-void set_hrrlabel_visibility(int setting) { vis_hrr_label = setting; }
+void SetHrrlabelVisibility(int setting) { vis_hrr_label = setting; }
 
-int get_hrrlabel_visibility() { return vis_hrr_label; }
+int GetHrrlabelVisibility() { return vis_hrr_label; }
 
-void toggle_hrrlabel_visibility() { vis_hrr_label = 1 - vis_hrr_label; }
+void ToggleHrrlabelVisibility() { vis_hrr_label = 1 - vis_hrr_label; }
 
 // memory load
 #ifdef pp_memstatus
@@ -1036,85 +1049,85 @@ void toggle_memload_visibility() { visAvailmemory = 1 - visAvailmemory; }
 #endif
 
 // mesh label
-void set_meshlabel_visibility(int setting) { visMeshlabel = setting; }
+void SetMeshlabelVisibility(int setting) { visMeshlabel = setting; }
 
-int get_meshlabel_visibility() { return visMeshlabel; }
+int GetMeshlabelVisibility() { return visMeshlabel; }
 
-void toggle_meshlabel_visibility() { visMeshlabel = 1 - visMeshlabel; }
+void ToggleMeshlabelVisibility() { visMeshlabel = 1 - visMeshlabel; }
 
 // slice average
-void set_slice_average_visibility(int setting) { vis_slice_average = setting; }
+void SetSliceAverageVisibility(int setting) { vis_slice_average = setting; }
 
-int get_slice_average_visibility() { return vis_slice_average; }
+int GetSliceAverageVisibility() { return vis_slice_average; }
 
-void toggle_slice_average_visibility() {
+void ToggleSliceAverageVisibility() {
   vis_slice_average = 1 - vis_slice_average;
 }
 
 // time
-void set_time_visibility(int setting) { visTimelabel = setting; }
+void SetTimeVisibility(int setting) { visTimelabel = setting; }
 
-int get_time_visibility() { return visTimelabel; }
+int GetTimeVisibility() { return visTimelabel; }
 
-void toggle_time_visibility() { visTimelabel = 1 - visTimelabel; }
+void ToggleTimeVisibility() { visTimelabel = 1 - visTimelabel; }
 
 // user settable ticks
-void set_user_ticks_visibility(int setting) { visUSERticks = setting; }
+void SetUserTicksVisibility(int setting) { visUSERticks = setting; }
 
-int get_user_ticks_visibility() { return visUSERticks; }
+int GetUserTicksVisibility() { return visUSERticks; }
 
-void toggle_user_ticks_visibility() { visUSERticks = 1 - visUSERticks; }
+void ToggleUserTicksVisibility() { visUSERticks = 1 - visUSERticks; }
 
 // version info
-void set_version_info_visibility(int setting) { vis_title_gversion = setting; }
+void SetVersionInfoVisibility(int setting) { vis_title_gversion = setting; }
 
-int get_version_info_visibility() { return vis_title_gversion; }
+int GetVersionInfoVisibility() { return vis_title_gversion; }
 
-void toggle_version_info_visibility() {
+void ToggleVersionInfoVisibility() {
   vis_title_gversion = 1 - vis_title_gversion;
 }
 
-void set_all_label_visibility(int setting) {
-  set_colorbar_visibility(setting);
-  set_timebar_visibility(setting);
-  set_title_visibility(setting);
-  set_axis_visibility(setting);
-  set_framelabel_visibility(setting);
-  set_framerate_visibility(setting);
-  set_gridloc_visibility(setting);
-  set_hrrcutoff_visibility(setting);
-  set_hrrlabel_visibility(setting);
+void SetAllLabelVisibility(int setting) {
+  SetColorbarVisibility(setting);
+  SetTimebarVisibility(setting);
+  SetTitleVisibility(setting);
+  SetAxisVisibility(setting);
+  SetFramelabelVisibility(setting);
+  SetFramerateVisibility(setting);
+  SetGridlocVisibility(setting);
+  SetHrrcutoffVisibility(setting);
+  SetHrrlabelVisibility(setting);
 #ifdef pp_memstatus
   set_memload_visibility(setting);
 #endif
-  set_meshlabel_visibility(setting);
-  set_slice_average_visibility(setting);
-  set_time_visibility(setting);
-  set_user_ticks_visibility(setting);
-  set_version_info_visibility(setting);
+  SetMeshlabelVisibility(setting);
+  SetSliceAverageVisibility(setting);
+  SetTimeVisibility(setting);
+  SetUserTicksVisibility(setting);
+  SetVersionInfoVisibility(setting);
 }
 
 // Display Units
 // time
-void set_timehms(int setting) {
+void SetTimehms(int setting) {
   vishmsTimelabel = 1 - vishmsTimelabel;
   SetLabelControls();
 }
 
-int get_timehms() { return vishmsTimelabel; }
+int GetTimehms() { return vishmsTimelabel; }
 
-void toggle_timehms() {
+void ToggleTimehms() {
   vishmsTimelabel = 1 - vishmsTimelabel;
   SetLabelControls();
 }
 
-void set_units(int unitclass, int unit_index) {
+void SetUnits(int unitclass, int unit_index) {
   unitclasses[unitclass].unit_index = unit_index;
   updatemenu = 1;
   GLUTPOSTREDISPLAY;
 }
 
-void set_units_default() {
+void SetUnitsDefault() {
   for (size_t i = 0; i < nunitclasses; i++) {
     unitclasses[i].unit_index = 0;
   }
@@ -1122,7 +1135,7 @@ void set_units_default() {
   GLUTPOSTREDISPLAY;
 }
 
-void set_unitclass_default(int unitclass) {
+void SetUnitclassDefault(int unitclass) {
   unitclasses[unitclass].unit_index = 0;
   updatemenu = 1;
   GLUTPOSTREDISPLAY;
@@ -1140,7 +1153,7 @@ void set_unitclass_default(int unitclass) {
 /// - 3 - Outline added
 /// - 4 - Hidden
 /// @return
-int blockage_view_method(int setting) {
+int BlockageViewMethod(int setting) {
   int value;
   switch (setting) {
   case 0:
@@ -1174,7 +1187,7 @@ int blockage_view_method(int setting) {
 /// - 0 - Use blockage
 /// - 1 - Use foreground
 /// @return Non-zero on error
-int blockage_outline_color(int setting) {
+int BlockageOutlineColor(int setting) {
   switch (setting) {
   case 0:
     outline_color_flag = 0;
@@ -1198,7 +1211,7 @@ int blockage_outline_color(int setting) {
 ///   - 1 - exact - As specified.
 ///   - 2 - cad - Using CAD geometry.
 /// @return
-int blockage_locations(int setting) {
+int BlockageLocations(int setting) {
   switch (setting) {
   case 0:
     blocklocation = BLOCKlocation_grid;
@@ -1215,7 +1228,7 @@ int blockage_locations(int setting) {
   return 0;
 }
 
-void setframe(int framenumber) {
+void Setframe(int framenumber) {
   itimes = framenumber;
   script_itime = itimes;
   stept = 0;
@@ -1228,14 +1241,15 @@ void setframe(int framenumber) {
 /// files for all meshes or for one particular mesh. Use meshnumber = -1 for all
 /// meshes.
 /// @param meshnumber
-void loadvolsmoke(int meshnumber) {
+void Loadvolsmoke(int meshnumber) {
   int imesh;
 
   imesh = meshnumber;
   if (imesh == -1) {
     read_vol_mesh = VOL_READALL;
     ReadVolsmokeAllFramesAllMeshes2(NULL);
-  } else if (imesh >= 0 && imesh < nmeshes) {
+  }
+  else if (imesh >= 0 && imesh < nmeshes) {
     meshdata *meshi;
     volrenderdata *vr;
 
@@ -1250,7 +1264,7 @@ void loadvolsmoke(int meshnumber) {
 /// @param meshnumber
 /// @param framenumber
 /// @param flag
-void loadvolsmokeframe(int meshnumber, int framenumber, int flag) {
+void Loadvolsmokeframe(int meshnumber, int framenumber, int flag) {
   int framenum, index;
   int first = 1;
   int i;
@@ -1292,7 +1306,7 @@ void loadvolsmokeframe(int meshnumber, int framenumber, int flag) {
   if (flag == 1) script_render = 1; // called when only rendering a single frame
 }
 
-void load3dsmoke(const char *smoke_type) {
+void Load3dsmoke(const char *smoke_type) {
   int errorcode;
   int count = 0;
   int lastsmoke;
@@ -1346,42 +1360,45 @@ void load3dsmoke(const char *smoke_type) {
   updatemenu = 1;
 }
 
-int set_rendertype(const char *type) {
+int SetRendertype(const char *type) {
   if (STRCMP(type, "JPG") == 0 || STRCMP(type, "JPEG") == 0) {
     render_filetype = JPEG;
     return 0;
-  } else if (STRCMP(type, "PNG") == 0) {
+  }
+  else if (STRCMP(type, "PNG") == 0) {
     render_filetype = PNG;
     return 0;
-  } else {
+  }
+  else {
     return 1;
   }
   UpdateRenderType(render_filetype);
 }
 
-int get_rendertype() { return render_filetype; }
+int GetRendertype() { return render_filetype; }
 
-void set_movietype(const char *type) {
+void SetMovietype(const char *type) {
   if (STRCMP(type, "WMV") == 0) {
     UpdateMovieType(WMV);
   }
   if (STRCMP(type, "MP4") == 0) {
     UpdateMovieType(MP4);
-  } else {
+  }
+  else {
     UpdateMovieType(AVI);
   }
 }
 
-int get_movietype() { return movie_filetype; }
+int GetMovietype() { return movie_filetype; }
 
-void makemovie(const char *name, const char *base, float framerate) {
+void Makemovie(const char *name, const char *base, float framerate) {
   strcpy(movie_name, name);
   strcpy(render_file_base, base);
   movie_framerate = framerate;
   RenderCB(MAKE_MOVIE);
 }
 
-int loadtour(const char *tourname) {
+int Loadtour(const char *tourname) {
   int count = 0;
   int errorcode = 0;
 
@@ -1407,7 +1424,7 @@ int loadtour(const char *tourname) {
   return errorcode;
 }
 
-void loadparticles(const char *name) {
+void Loadparticles(const char *name) {
   int errorcode;
   int count = 0;
 
@@ -1440,7 +1457,7 @@ void loadparticles(const char *name) {
   updatemenu = 1;
 }
 
-void partclasscolor(const char *color) {
+void Partclasscolor(const char *color) {
   int count = 0;
 
   for (size_t i = 0; i < npart5prop; i++) {
@@ -1458,7 +1475,7 @@ void partclasscolor(const char *color) {
             color);
 }
 
-void partclasstype(const char *part_type) {
+void Partclasstype(const char *part_type) {
   int count = 0;
 
   for (size_t i = 0; i < npart5prop; i++) {
@@ -1486,7 +1503,7 @@ void partclasstype(const char *part_type) {
             part_type);
 }
 
-void plot3dprops(int variable_index, int showvector, int vector_length_index,
+void Plot3dprops(int variable_index, int showvector, int vector_length_index,
                  int display_type, float vector_length) {
   int p_index;
 
@@ -1583,7 +1600,7 @@ void ShowPlot3dData(int meshnumber, int plane_orientation, int display,
   // GLUTPOSTREDISPLAY;
 }
 
-void loadplot3d(int meshnumber, float time_local) {
+void Loadplot3d(int meshnumber, float time_local) {
   size_t count = 0;
   int blocknum = meshnumber - 1;
 
@@ -1604,7 +1621,7 @@ void loadplot3d(int meshnumber, float time_local) {
   // UpdateMenu();
 }
 
-void loadiso(const char *type) {
+void Loadiso(const char *type) {
   int count = 0;
 
   FREEMEMORY(loaded_file);
@@ -1637,12 +1654,12 @@ void loadiso(const char *type) {
   updatemenu = 1;
 }
 
-FILE_SIZE loadsliceindex(size_t index, int *errorcode) {
+FILE_SIZE Loadsliceindex(size_t index, int *errorcode) {
   return ReadSlice(sliceinfo[index].file, (int)index, ALL_FRAMES, NULL, LOAD,
                    SET_SLICECOLOR, errorcode);
 }
 
-void loadslice(const char *type, int axis, float distance) {
+void Loadslice(const char *type, int axis, float distance) {
   int count = 0;
   for (int i = 0; i < nmultisliceinfo; i++) {
     multislicedata *mslicei;
@@ -1672,7 +1689,7 @@ void loadslice(const char *type, int axis, float distance) {
             type);
 }
 
-void loadvslice(const char *type, int axis, float distance) {
+void Loadvslice(const char *type, int axis, float distance) {
   float delta_orig;
   int count = 0;
   for (int i = 0; i < nmultivsliceinfo; i++) {
@@ -1702,7 +1719,7 @@ void loadvslice(const char *type, int axis, float distance) {
             type);
 }
 
-void unloadslice(int value) {
+void Unloadslice(int value) {
   int errorcode;
 
   updatemenu = 1;
@@ -1713,25 +1730,28 @@ void unloadslice(int value) {
     slicei = sliceinfo + value;
 
     if (slicei->slice_filetype == SLICE_GEOM) {
-      ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL,
-                   0, &errorcode);
-    } else {
+      ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0,
+                   &errorcode);
+    }
+    else {
       ReadSlice("", value, ALL_FRAMES, NULL, UNLOAD, SET_SLICECOLOR,
                 &errorcode);
     }
   }
   if (value <= -3) {
     UnloadBoundaryMenu(-3 - value);
-  } else {
+  }
+  else {
     if (value == UNLOAD_ALL) {
       for (size_t i = 0; i < nsliceinfo; i++) {
         slicedata *slicei;
 
         slicei = sliceinfo + i;
         if (slicei->slice_filetype == SLICE_GEOM) {
-          ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL,
-                       0, &errorcode);
-        } else {
+          ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0,
+                       &errorcode);
+        }
+        else {
           ReadSlice("", i, ALL_FRAMES, NULL, UNLOAD, DEFER_SLICECOLOR,
                     &errorcode);
         }
@@ -1745,7 +1765,8 @@ void unloadslice(int value) {
           UnloadBoundaryMenu(i);
         }
       }
-    } else if (value == UNLOAD_LAST) {
+    }
+    else if (value == UNLOAD_LAST) {
       int unload_index;
 
       unload_index = LastSliceLoadstack();
@@ -1754,9 +1775,10 @@ void unloadslice(int value) {
 
         slicei = sliceinfo + unload_index;
         if (slicei->slice_filetype == SLICE_GEOM) {
-          ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL,
-                       0, &errorcode);
-        } else {
+          ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0,
+                       &errorcode);
+        }
+        else {
           ReadSlice("", unload_index, ALL_FRAMES, NULL, UNLOAD, SET_SLICECOLOR,
                     &errorcode);
         }
@@ -1766,7 +1788,7 @@ void unloadslice(int value) {
 }
 
 /// @brief Unload all the currently loaded data.
-int unloadall() {
+int Unloadall() {
   int errorcode = 0;
 
   if (scriptoutstream != NULL) {
@@ -1784,9 +1806,10 @@ int unloadall() {
     slicei = sliceinfo + i;
     if (slicei->loaded == 1) {
       if (slicei->slice_filetype == SLICE_GEOM) {
-        ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL,
-                     0, &errorcode);
-      } else {
+        ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0,
+                     &errorcode);
+      }
+      else {
         ReadSlice(slicei->file, i, ALL_FRAMES, NULL, UNLOAD, DEFER_SLICECOLOR,
                   &errorcode);
       }
@@ -1818,12 +1841,12 @@ int unloadall() {
   return errorcode;
 }
 
-void unloadtour() { TourMenu(MENU_TOUR_MANUAL); }
+void Unloadtour() { TourMenu(MENU_TOUR_MANUAL); }
 
 /// @brief Exit smokeview.
-void exit_smokeview() { exit(EXIT_SUCCESS); }
+void ExitSmokeview() { exit(EXIT_SUCCESS); }
 
-int setviewpoint(const char *viewpoint) {
+int Setviewpoint(const char *viewpoint) {
   int count = 0;
   int errorcode = 0;
   for (cameradata *ca = camera_list_first.next; ca->next != NULL;
@@ -1851,37 +1874,43 @@ int setviewpoint(const char *viewpoint) {
 /// - "ZMIN"
 /// - "ZMAX"
 /// @return
-int set_ortho_preset(const char *viewpoint) {
+int SetOrthoPreset(const char *viewpoint) {
   int command;
   if (STRCMP(viewpoint, "XMIN") == 0) {
     command = SCRIPT_VIEWXMIN;
-  } else if (STRCMP(viewpoint, "XMAX") == 0) {
+  }
+  else if (STRCMP(viewpoint, "XMAX") == 0) {
     command = SCRIPT_VIEWXMAX;
-  } else if (STRCMP(viewpoint, "YMIN") == 0) {
+  }
+  else if (STRCMP(viewpoint, "YMIN") == 0) {
     command = SCRIPT_VIEWYMIN;
-  } else if (STRCMP(viewpoint, "YMAX") == 0) {
+  }
+  else if (STRCMP(viewpoint, "YMAX") == 0) {
     command = SCRIPT_VIEWYMAX;
-  } else if (STRCMP(viewpoint, "ZMIN") == 0) {
+  }
+  else if (STRCMP(viewpoint, "ZMIN") == 0) {
     command = SCRIPT_VIEWZMIN;
-  } else if (STRCMP(viewpoint, "ZMAX") == 0) {
+  }
+  else if (STRCMP(viewpoint, "ZMAX") == 0) {
     command = SCRIPT_VIEWZMAX;
-  } else {
+  }
+  else {
     return 1;
   }
   ScriptViewXYZMINMAXOrtho(command);
   return 0;
 }
 
-int get_clipping_mode() { return clip_mode; }
+int GetClippingMode() { return clip_mode; }
 
-void set_clipping_mode(int mode) {
+void SetClippingMode(int mode) {
   clip_mode = mode;
   updatefacelists = 1;
   UpdateGluiClip();
   UpdateClipAll();
 }
 
-void set_sceneclip_x(int clipMin, float min, int clipMax, float max) {
+void SetSceneclipX(int clipMin, float min, int clipMax, float max) {
   clipinfo.clip_xmin = clipMin;
   clipinfo.xmin = min;
 
@@ -1892,7 +1921,7 @@ void set_sceneclip_x(int clipMin, float min, int clipMax, float max) {
   UpdateClipAll();
 }
 
-void set_sceneclip_x_min(int flag, float value) {
+void SetSceneclipXMin(int flag, float value) {
   clipinfo.clip_xmin = flag;
   clipinfo.xmin = value;
   updatefacelists = 1;
@@ -1900,7 +1929,7 @@ void set_sceneclip_x_min(int flag, float value) {
   UpdateClipAll();
 }
 
-void set_sceneclip_x_max(int flag, float value) {
+void SetSceneclipXMax(int flag, float value) {
   clipinfo.clip_xmax = flag;
   clipinfo.xmax = value;
   updatefacelists = 1;
@@ -1908,7 +1937,7 @@ void set_sceneclip_x_max(int flag, float value) {
   UpdateClipAll();
 }
 
-void set_sceneclip_y(int clipMin, float min, int clipMax, float max) {
+void SetSceneclipY(int clipMin, float min, int clipMax, float max) {
   clipinfo.clip_ymin = clipMin;
   clipinfo.ymin = min;
 
@@ -1919,7 +1948,7 @@ void set_sceneclip_y(int clipMin, float min, int clipMax, float max) {
   UpdateClipAll();
 }
 
-void set_sceneclip_y_min(int flag, float value) {
+void SetSceneclipYMin(int flag, float value) {
   clipinfo.clip_ymin = flag;
   clipinfo.ymin = value;
   updatefacelists = 1;
@@ -1927,7 +1956,7 @@ void set_sceneclip_y_min(int flag, float value) {
   UpdateClipAll();
 }
 
-void set_sceneclip_y_max(int flag, float value) {
+void SetSceneclipYMax(int flag, float value) {
   clipinfo.clip_ymax = flag;
   clipinfo.ymax = value;
   updatefacelists = 1;
@@ -1935,7 +1964,7 @@ void set_sceneclip_y_max(int flag, float value) {
   UpdateClipAll();
 }
 
-void set_sceneclip_z(int clipMin, float min, int clipMax, float max) {
+void SetSceneclipZ(int clipMin, float min, int clipMax, float max) {
   clipinfo.clip_zmin = clipMin;
   clipinfo.zmin = min;
 
@@ -1946,7 +1975,7 @@ void set_sceneclip_z(int clipMin, float min, int clipMax, float max) {
   UpdateClipAll();
 }
 
-void set_sceneclip_z_min(int flag, float value) {
+void SetSceneclipZMin(int flag, float value) {
   clipinfo.clip_zmin = flag;
   clipinfo.zmin = value;
   updatefacelists = 1;
@@ -1954,7 +1983,7 @@ void set_sceneclip_z_min(int flag, float value) {
   UpdateClipAll();
 }
 
-void set_sceneclip_z_max(int flag, float value) {
+void SetSceneclipZMax(int flag, float value) {
   clipinfo.clip_zmax = flag;
   clipinfo.zmax = value;
   updatefacelists = 1;
@@ -1962,7 +1991,7 @@ void set_sceneclip_z_max(int flag, float value) {
   UpdateClipAll();
 }
 
-int setrenderdir(const char *dir) {
+int Setrenderdir(const char *dir) {
   // TODO: as lua gives us consts, but most smv code uses non-const, we
   // must make a non-const copy
   int l = strlen(dir);
@@ -1986,12 +2015,14 @@ int setrenderdir(const char *dir) {
               "directory: %s\n",
               dir_path_temp);
       return 1;
-    } else {
+    }
+    else {
       free(script_dir_path);
       script_dir_path = dir_path_temp;
       return 0;
     }
-  } else {
+  }
+  else {
     // TODO: why would we ever want to set the render directory to NULL
     script_dir_path = NULL;
     FREEMEMORY(dir_path_temp);
@@ -1999,11 +2030,11 @@ int setrenderdir(const char *dir) {
   }
 }
 
-void setcolorbarindex(int chosen_index) { UpdateRGBColors(chosen_index); }
+void Setcolorbarindex(int chosen_index) { UpdateRGBColors(chosen_index); }
 
-int getcolorbarindex() { return global_colorbar_index; }
+int Getcolorbarindex() { return global_colorbar_index; }
 
-void setwindowsize(int width, int height) {
+void Setwindowsize(int width, int height) {
   glutReshapeWindow(width, height);
   ResizeWindow(width, height);
   ReshapeCB(width, height);
@@ -2015,13 +2046,13 @@ void setwindowsize(int width, int height) {
 /// - #GRID_NOPROBE
 /// - #GRID_PROBE
 /// - #NOGRID_PROBE
-void setgridvisibility(int selection) {
+void Setgridvisibility(int selection) {
   visGrid = selection;
   // selection may be one of:
   if (visGrid == GRID_PROBE || visGrid == NOGRID_PROBE) visgridloc = 1;
 }
 
-void setgridparms(int x_vis, int y_vis, int z_vis, int x_plot, int y_plot,
+void Setgridparms(int x_vis, int y_vis, int z_vis, int x_plot, int y_plot,
                   int z_plot) {
   visx_all = x_vis;
   visy_all = y_vis;
@@ -2039,7 +2070,7 @@ void setgridparms(int x_vis, int y_vis, int z_vis, int x_plot, int y_plot,
 /// @brief Set the firection of the colorbar.
 /// @param flip Boolean. If true, the colorbar runs in the opposite direction
 /// than default.
-void setcolorbarflip(int flip) {
+void Setcolorbarflip(int flip) {
   colorbar_flip = flip;
   UpdateColorbarFlip();
   UpdateRGBColors(COLORBAR_INDEX_NONE);
@@ -2047,11 +2078,11 @@ void setcolorbarflip(int flip) {
 
 /// @brief Get whether the direction of the colorbar is flipped.
 /// @return
-int getcolorbarflip() { return colorbar_flip; }
+int Getcolorbarflip() { return colorbar_flip; }
 
 // Camera API
 // These function live-modify the current view by modifying "camera_current".
-void camera_set_rotation_type(int rotation_typev) {
+void CameraSetRotationType(int rotation_typev) {
   rotation_type = rotation_typev;
   camera_current->rotation_type = rotation_typev;
   RotationTypeCB(rotation_type);
@@ -2059,71 +2090,71 @@ void camera_set_rotation_type(int rotation_typev) {
   HandleRotationType(ROTATION_2AXIS);
 }
 
-int camera_get_rotation_type() { return camera_current->rotation_type; }
+int CameraGetRotationType() { return camera_current->rotation_type; }
 
 // TODO: How does the rotation index work.
-void camera_set_rotation_index(int rotation_index) {
+void CameraSetRotationIndex(int rotation_index) {
   camera_current->rotation_index = rotation_index;
 }
 
-int camera_get_rotation_index() { return camera_current->rotation_index; }
+int CameraGetRotationIndex() { return camera_current->rotation_index; }
 
-void camera_set_viewdir(float xcen, float ycen, float zcen) {
+void CameraSetViewdir(float xcen, float ycen, float zcen) {
   camera_current->xcen = xcen;
   camera_current->ycen = ycen;
   camera_current->zcen = zcen;
 }
 
 // xcen
-void camera_set_xcen(float xcen) { camera_current->xcen = xcen; }
-float camera_get_xcen() { return camera_current->xcen; }
+void CameraSetXcen(float xcen) { camera_current->xcen = xcen; }
+float CameraGetXcen() { return camera_current->xcen; }
 
 // ycen
-void camera_set_ycen(float ycen) { camera_current->ycen = ycen; }
-float camera_get_ycen() { return camera_current->ycen; }
+void CameraSetYcen(float ycen) { camera_current->ycen = ycen; }
+float CameraGetYcen() { return camera_current->ycen; }
 
 // zcen
-void camera_set_zcen(float zcen) { camera_current->zcen = zcen; }
-float camera_get_zcen() { return camera_current->zcen; }
+void CameraSetZcen(float zcen) { camera_current->zcen = zcen; }
+float CameraGetZcen() { return camera_current->zcen; }
 
 // eyex
-void camera_mod_eyex(float delta) {
+void CameraModEyex(float delta) {
   camera_current->eye[0] = camera_current->eye[0] + delta;
 }
-void camera_set_eyex(float eyex) { camera_current->eye[0] = eyex; }
+void CameraSetEyex(float eyex) { camera_current->eye[0] = eyex; }
 
-float camera_get_eyex() { return camera_current->eye[0]; }
+float CameraGetEyex() { return camera_current->eye[0]; }
 
 // eyey
-void camera_mod_eyey(float delta) {
+void CameraModEyey(float delta) {
   camera_current->eye[1] = camera_current->eye[1] + delta;
 }
-void camera_set_eyey(float eyey) { camera_current->eye[1] = eyey; }
-float camera_get_eyey() { return camera_current->eye[1]; }
+void CameraSetEyey(float eyey) { camera_current->eye[1] = eyey; }
+float CameraGetEyey() { return camera_current->eye[1]; }
 
 // eyez
-void camera_mod_eyez(float delta) {
+void CameraModEyez(float delta) {
   camera_current->eye[2] = camera_current->eye[2] + delta;
 }
-void camera_set_eyez(float eyez) { camera_current->eye[2] = eyez; }
-float camera_get_eyez() { return camera_current->eye[2]; }
+void CameraSetEyez(float eyez) { camera_current->eye[2] = eyez; }
+float CameraGetEyez() { return camera_current->eye[2]; }
 
 // azimuth
-void camera_mod_az(float delta) {
+void CameraModAz(float delta) {
   camera_current->az_elev[0] = camera_current->az_elev[0] + delta;
 }
-void camera_set_az(float az) { camera_current->az_elev[0] = az; }
-float camera_get_az() { return camera_current->az_elev[0]; }
+void CameraSetAz(float az) { camera_current->az_elev[0] = az; }
+float CameraGetAz() { return camera_current->az_elev[0]; }
 
 // elevation
-void camera_mod_elev(float delta) {
+void CameraModElev(float delta) {
   camera_current->az_elev[1] = camera_current->az_elev[1] + delta;
 }
-void camera_set_elev(float elev) { camera_current->az_elev[1] = elev; }
-float camera_get_elev() { return camera_current->az_elev[1]; }
+void CameraSetElev(float elev) { camera_current->az_elev[1] = elev; }
+float CameraGetElev() { return camera_current->az_elev[1]; }
 
 void MoveScene(int xm, int ym);
-int camera_zoom_to_fit() {
+int CameraZoomToFit() {
   float offset = (zbar - ybar) / 2.0;
   camera_current->eye[1] += offset * 2;
   eye_xyz0[1] = camera_current->eye[1];
@@ -2133,10 +2164,10 @@ int camera_zoom_to_fit() {
 }
 
 // projection_type
-void camera_toggle_projection_type() {
+void CameraToggleProjectionType() {
   camera_current->projection_type = 1 - camera_current->projection_type;
 }
-int camera_set_projection_type(int pt) {
+int CameraSetProjectionType(int pt) {
   camera_current->projection_type = pt;
   projection_type = pt;
   ZoomMenu(UPDATE_PROJECTION);
@@ -2145,18 +2176,18 @@ int camera_set_projection_type(int pt) {
   // 0 is perspective
   return 0;
 }
-int camera_get_projection_type() { return camera_current->projection_type; }
+int CameraGetProjectionType() { return camera_current->projection_type; }
 
 // .ini config options
 // *** COLOR/LIGHTING ***
-int set_ambientlight(float r, float g, float b) {
+int SetAmbientlight(float r, float g, float b) {
   ambientlight[0] = r;
   ambientlight[1] = g;
   ambientlight[2] = b;
   return 0;
 } // AMBIENTLIGHT
 
-int set_backgroundcolor(float r, float g, float b) {
+int SetBackgroundcolor(float r, float g, float b) {
   backgroundbasecolor[0] = r;
   backgroundbasecolor[1] = g;
   backgroundbasecolor[2] = b;
@@ -2165,26 +2196,26 @@ int set_backgroundcolor(float r, float g, float b) {
   return 0;
 } // BACKGROUNDCOLOR
 
-int set_blockcolor(float r, float g, float b) {
+int SetBlockcolor(float r, float g, float b) {
   block_ambient2[0] = r;
   block_ambient2[1] = g;
   block_ambient2[2] = b;
   return 0;
 } // BLOCKCOLOR
 
-int set_blockshininess(float v) {
+int SetBlockshininess(float v) {
   block_shininess = v;
   return 0;
 } // BLOCKSHININESS
 
-int set_blockspecular(float r, float g, float b) {
+int SetBlockspecular(float r, float g, float b) {
   block_specular2[0] = r;
   block_specular2[1] = g;
   block_specular2[2] = b;
   return 0;
 } // BLOCKSPECULAR
 
-int set_boundcolor(float r, float g, float b) {
+int SetBoundcolor(float r, float g, float b) {
   boundcolor[0] = r;
   boundcolor[1] = g;
   boundcolor[2] = b;
@@ -2199,7 +2230,7 @@ int set_boundcolor(float r, float g, float b) {
 //   return usetexturebar;
 // }
 
-int set_colorbar_colors(int ncolors, float *colors) {
+int SetColorbarColors(int ncolors, float *colors) {
 
   float *rgb_ini_copy;
   float *rgb_ini_copy_p;
@@ -2224,7 +2255,7 @@ int set_colorbar_colors(int ncolors, float *colors) {
   return 0;
 }
 
-int set_color2bar_colors(int ncolors, float *colors) {
+int SetColor2barColors(int ncolors, float *colors) {
   float *rgb_ini_copy;
   float *rgb_ini_copy_p;
   CheckMemory;
@@ -2248,14 +2279,14 @@ int set_color2bar_colors(int ncolors, float *colors) {
   return 0;
 }
 
-int set_diffuselight(float r, float g, float b) {
+int SetDiffuselight(float r, float g, float b) {
   diffuselight[0] = r;
   diffuselight[1] = g;
   diffuselight[2] = b;
   return 0;
 } // DIFFUSELIGHT
 
-int set_directioncolor(float r, float g, float b) {
+int SetDirectioncolor(float r, float g, float b) {
   direction_color[0] = r;
   direction_color[1] = g;
   direction_color[2] = b;
@@ -2267,37 +2298,37 @@ int set_directioncolor(float r, float g, float b) {
 /// By default they are flipped.
 /// @param v
 /// @return
-int set_flip(int v) {
+int SetFlip(int v) {
   background_flip = v;
   return 0;
 } // FLIP
 
-int get_flip() { return background_flip; }
+int GetFlip() { return background_flip; }
 
-int set_foregroundcolor(float r, float g, float b) {
+int SetForegroundcolor(float r, float g, float b) {
   foregroundbasecolor[0] = r;
   foregroundbasecolor[1] = g;
   foregroundbasecolor[2] = b;
   return 0;
 } // FOREGROUNDCOLOR
 
-int set_heatoffcolor(float r, float g, float b) {
+int SetHeatoffcolor(float r, float g, float b) {
   heatoffcolor[0] = r;
   heatoffcolor[1] = g;
   heatoffcolor[2] = b;
   return 0;
 } // HEATOFFCOLOR
 
-int set_heatoncolor(float r, float g, float b) {
+int SetHeatoncolor(float r, float g, float b) {
   heatoncolor[0] = r;
   heatoncolor[1] = g;
   heatoncolor[2] = b;
   return 0;
 } // HEATONCOLOR
 
-int set_isocolors(float shininess, float transparency, int transparency_option,
-                  int opacity_change, float specular[3], int n_colors,
-                  float colors[][4]) {
+int SetIsocolors(float shininess, float transparency, int transparency_option,
+                 int opacity_change, float specular[3], int n_colors,
+                 float colors[][4]) {
   iso_shininess = shininess;
   iso_transparency = transparency;
   iso_transparency_option = transparency_option;
@@ -2319,7 +2350,7 @@ int set_isocolors(float shininess, float transparency, int transparency_option,
   return 0;
 } // ISOCOLORS
 
-int set_colortable(int ncolors, int colors[][4], char **names) {
+int SetColortable(int ncolors, int colors[][4], char **names) {
   int nctableinfo;
 
   colortabledata *ctableinfo = NULL;
@@ -2346,7 +2377,7 @@ int set_colortable(int ncolors, int colors[][4], char **names) {
   return 0;
 } // COLORTABLE
 
-int set_lightpos0(float a, float b, float c, float d) {
+int SetLightpos0(float a, float b, float c, float d) {
   light_position0[0] = a;
   light_position0[1] = a;
   light_position0[2] = a;
@@ -2354,7 +2385,7 @@ int set_lightpos0(float a, float b, float c, float d) {
   return 0;
 } // LIGHTPOS0
 
-int set_lightpos1(float a, float b, float c, float d) {
+int SetLightpos1(float a, float b, float c, float d) {
   light_position1[0] = a;
   light_position1[1] = a;
   light_position1[2] = a;
@@ -2362,55 +2393,55 @@ int set_lightpos1(float a, float b, float c, float d) {
   return 0;
 } // LIGHTPOS1
 
-int set_sensorcolor(float r, float g, float b) {
+int SetSensorcolor(float r, float g, float b) {
   sensorcolor[0] = r;
   sensorcolor[1] = g;
   sensorcolor[2] = b;
   return 0;
 } // SENSORCOLOR
 
-int set_sensornormcolor(float r, float g, float b) {
+int SetSensornormcolor(float r, float g, float b) {
   sensornormcolor[0] = r;
   sensornormcolor[1] = g;
   sensornormcolor[2] = b;
   return 0;
 } // SENSORNORMCOLOR
 
-int set_bw(int geo_setting, int data_setting) {
+int SetBw(int geo_setting, int data_setting) {
   setbw = geo_setting;
   setbwdata = data_setting;
   return 0;
 } // SETBW
 
-int set_sprinkleroffcolor(float r, float g, float b) {
+int SetSprinkleroffcolor(float r, float g, float b) {
   sprinkoffcolor[0] = r;
   sprinkoffcolor[1] = g;
   sprinkoffcolor[2] = b;
   return 0;
 } // SPRINKOFFCOLOR
 
-int set_sprinkleroncolor(float r, float g, float b) {
+int SetSprinkleroncolor(float r, float g, float b) {
   sprinkoncolor[0] = r;
   sprinkoncolor[1] = g;
   sprinkoncolor[2] = b;
   return 0;
 } // SPRINKONCOLOR
 
-int set_staticpartcolor(float r, float g, float b) {
+int SetStaticpartcolor(float r, float g, float b) {
   static_color[0] = r;
   static_color[1] = g;
   static_color[2] = b;
   return 0;
 } // STATICPARTCOLOR
 
-int set_timebarcolor(float r, float g, float b) {
+int SetTimebarcolor(float r, float g, float b) {
   timebarcolor[0] = r;
   timebarcolor[1] = g;
   timebarcolor[2] = b;
   return 0;
 } // TIMEBARCOLOR
 
-int set_ventcolor(float r, float g, float b) {
+int SetVentcolor(float r, float g, float b) {
   ventcolor[0] = r;
   ventcolor[1] = g;
   ventcolor[2] = b;
@@ -2418,156 +2449,157 @@ int set_ventcolor(float r, float g, float b) {
 } // VENTCOLOR
 
 // --    *** SIZES/OFFSETS ***
-int set_gridlinewidth(float v) {
+int SetGridlinewidth(float v) {
   gridlinewidth = v;
   return 0;
 } // GRIDLINEWIDTH
 
-int set_isolinewidth(float v) {
+int SetIsolinewidth(float v) {
   isolinewidth = v;
   return 0;
 } // ISOLINEWIDTH
 
-int set_isopointsize(float v) {
+int SetIsopointsize(float v) {
   isopointsize = v;
   return 0;
 } // ISOPOINTSIZE
 
-int set_linewidth(float v) {
+int SetLinewidth(float v) {
   linewidth = v;
   return 0;
 } // LINEWIDTH
 
-int set_partpointsize(float v) {
+int SetPartpointsize(float v) {
   partpointsize = v;
   return 0;
 } // PARTPOINTSIZE
 
-int set_plot3dlinewidth(float v) {
+int SetPlot3dlinewidth(float v) {
   plot3dlinewidth = v;
   return 0;
 } // PLOT3DLINEWIDTH
 
-int set_plot3dpointsize(float v) {
+int SetPlot3dpointsize(float v) {
   plot3dpointsize = v;
   return 0;
 } // PLOT3DPOINTSIZE
 
-int set_sensorabssize(float v) {
+int SetSensorabssize(float v) {
   sensorabssize = v;
   return 0;
 } // SENSORABSSIZE
 
-int set_sensorrelsize(float v) {
+int SetSensorrelsize(float v) {
   sensorrelsize = v;
   return 0;
 } // SENSORRELSIZE
 
-int set_sliceoffset(float v) {
+int SetSliceoffset(float v) {
   sliceoffset_factor = v;
   return 0;
 } // SLICEOFFSET
 
-int set_smoothlines(int v) {
+int SetSmoothlines(int v) {
   antialiasflag = v;
   return 0;
 } // SMOOTHLINES
 
-int set_spheresegs(int v) {
+int SetSpheresegs(int v) {
   device_sphere_segments = v;
   return 0;
 } // SPHERESEGS
 
-int set_sprinklerabssize(float v) {
+int SetSprinklerabssize(float v) {
   sprinklerabssize = v;
   return 0;
 } // SPRINKLERABSSIZE
 
-int set_streaklinewidth(float v) {
+int SetStreaklinewidth(float v) {
   streaklinewidth = v;
   return 0;
 } // STREAKLINEWIDTH
 
-int set_ticklinewidth(float v) {
+int SetTicklinewidth(float v) {
   ticklinewidth = v;
   return 0;
 } // TICKLINEWIDTH
 
-int set_usenewdrawface(int v) {
+int SetUsenewdrawface(int v) {
   use_new_drawface = v;
   return 0;
 } // USENEWDRAWFACE
 
-int set_veclength(float vf, int vec_uniform_length_in,
-                  int vec_uniform_spacing_in) {
+int SetVeclength(float vf, int vec_uniform_length_in,
+                 int vec_uniform_spacing_in) {
   vecfactor = vf;
   vec_uniform_spacing = vec_uniform_spacing_in;
   vec_uniform_length = vec_uniform_length_in;
   return 0;
 } // VECLENGTH
 
-int set_vectorlinewidth(float a, float b) {
+int SetVectorlinewidth(float a, float b) {
   vectorlinewidth = a;
   slice_line_contour_width = b;
   return 0;
 } // VECTORLINEWIDTH
 
-int set_vectorpointsize(float v) {
+int SetVectorpointsize(float v) {
   vectorpointsize = v;
   return 0;
 } // VECTORPOINTSIZE
 
-int set_ventlinewidth(float v) {
+int SetVentlinewidth(float v) {
   ventlinewidth = v;
   return 0;
 } // VENTLINEWIDTH
 
-int set_ventoffset(float v) {
+int SetVentoffset(float v) {
   ventoffset_factor = v;
   return 0;
 } // VENTOFFSET
 
-int set_windowoffset(int v) {
+int SetWindowoffset(int v) {
   titlesafe_offsetBASE = v;
   return 0;
 } // WINDOWOFFSET
 
-int set_windowwidth(int v) {
+int SetWindowwidth(int v) {
   screenWidth = v;
   return 0;
 } // WINDOWWIDTH
 
-int set_windowheight(int v) {
+int SetWindowheight(int v) {
   screenHeight = v;
   return 0;
 } // WINDOWHEIGHT
 
 // --  *** DATA LOADING ***
-int set_boundzipstep(int v) {
+int SetBoundzipstep(int v) {
   tload_zipstep = v;
   return 0;
 } // BOUNDZIPSTEP
 
-int set_fed(int v) {
+int SetFed(int v) {
   regenerate_fed = v;
   return 0;
 } // FED
 
-int set_fedcolorbar(const char *name) {
+int SetFedcolorbar(const char *name) {
   if (strlen(name) > 0) {
     strcpy(default_fed_colorbar, name);
     return 0;
-  } else {
+  }
+  else {
     return 1;
   }
 } // FEDCOLORBAR
 
-int set_isozipstep(int v) {
+int SetIsozipstep(int v) {
   tload_zipstep = v;
   return 0;
 } // ISOZIPSTEP
 
-int set_nopart(int v) {
+int SetNopart(int v) {
   nopart = v;
   return 0;
 } // NOPART
@@ -2577,34 +2609,34 @@ int set_nopart(int v) {
 //   return 0;
 // } // PARTPOINTSTEP
 
-int set_showfedarea(int v) {
+int SetShowfedarea(int v) {
   show_fed_area = v;
   return 0;
 } // SHOWFEDAREA
 
-int set_sliceaverage(int flag, float interval, int vis) {
+int SetSliceaverage(int flag, float interval, int vis) {
   slice_average_flag = flag;
   slice_average_interval = interval;
   vis_slice_average = vis;
   return 0;
 } // SLICEAVERAGE
 
-int set_slicedataout(int v) {
+int SetSlicedataout(int v) {
   output_slicedata = v;
   return 0;
 } // SLICEDATAOUT
 
-int set_slicezipstep(int v) {
+int SetSlicezipstep(int v) {
   tload_zipstep = v;
   return 0;
 } // SLICEZIPSTEP
 
-int set_smoke3dzipstep(int v) {
+int SetSmoke3dzipstep(int v) {
   tload_zipstep = v;
   return 0;
 } // SMOKE3DZIPSTEP
 
-int set_userrotate(int index, int show_center, float x, float y, float z) {
+int SetUserrotate(int index, int show_center, float x, float y, float z) {
   glui_rotation_index = index;
   slice_average_interval = show_center;
   xcenCUSTOM = x;
@@ -2614,7 +2646,7 @@ int set_userrotate(int index, int show_center, float x, float y, float z) {
 } // USER_ROTATE
 
 // --  *** VIEW PARAMETERS ***
-int set_aperture(int v) {
+int SetAperture(int v) {
   apertureindex = v;
   return 0;
 } // APERTURE
@@ -2625,97 +2657,97 @@ int set_aperture(int v) {
 // } // AXISSMOOTH
 
 // provided above
-int set_blocklocation(int v) {
+int SetBlocklocation(int v) {
   blocklocation = v;
   return 0;
 } // BLOCKLOCATION
 
-int set_boundarytwoside(int v) {
+int SetBoundarytwoside(int v) {
   showpatch_both = v;
   return 0;
 } // BOUNDARYTWOSIDE
 
-int set_clip(float v_near, float v_far) {
+int SetClip(float v_near, float v_far) {
   nearclip = v_near;
   farclip = v_far;
   return 0;
 } // CLIP
 
-int set_contourtype(int v) {
+int SetContourtype(int v) {
   contour_type = v;
   return 0;
 } // CONTOURTYPE
 
-int set_cullfaces(int v) {
+int SetCullfaces(int v) {
   cullfaces = v;
   return 0;
 } // CULLFACES
 
-int set_texturelighting(int v) {
+int SetTexturelighting(int v) {
   enable_texture_lighting = v;
   return 0;
 } // ENABLETEXTURELIGHTING
 
-int set_eyeview(int v) {
+int SetEyeview(int v) {
   rotation_type = v;
   return 0;
 } // EYEVIEW
 
-int set_eyex(float v) {
+int SetEyex(float v) {
   eyexfactor = v;
   return 0;
 } // EYEX
 
-int set_eyey(float v) {
+int SetEyey(float v) {
   eyeyfactor = v;
   return 0;
 } // EYEY
 
-int set_eyez(float v) {
+int SetEyez(float v) {
   eyezfactor = v;
   return 0;
 } // EYEZ
 
-int set_fontsize(int v) {
+int SetFontsize(int v) {
   FontMenu(v);
   return 0;
 } // FONTSIZE
 
-int set_frameratevalue(int v) {
+int SetFrameratevalue(int v) {
   frameratevalue = v;
   return 0;
 } // FRAMERATEVALUE
 
 // int set_geomshow(int )
 // GEOMSHOW
-int set_showfaces_solid(int v) {
+int SetShowfacesSolid(int v) {
   frameratevalue = v;
   return 0;
 }
-int set_showfaces_outline(int v) {
+int SetShowfacesOutline(int v) {
   show_faces_outline = v;
   return 0;
 }
-int set_smoothgeomnormal(int v) {
+int SetSmoothgeomnormal(int v) {
   smooth_geom_normal = v;
   return 0;
 }
-int set_geomvertexag(int v) {
+int SetGeomvertexag(int v) {
   geom_vert_exag = v;
   return 0;
 }
 
-int set_gversion(int v) {
+int SetGversion(int v) {
   vis_title_gversion = v;
   return 0;
 } // GVERSION
 
-int set_isotran2(int v) {
+int SetIsotran2(int v) {
   transparent_state = v;
   return 0;
 } // ISOTRAN2
 
-int set_meshvis(int n, int vals[]) {
+int SetMeshvis(int n, int vals[]) {
   meshdata *meshi;
   for (size_t i = 0; i < n; i++) {
     if (i > nmeshes - 1) break;
@@ -2726,7 +2758,7 @@ int set_meshvis(int n, int vals[]) {
   return 0;
 } // MESHVIS
 
-int set_meshoffset(int meshnum, int value) {
+int SetMeshoffset(int meshnum, int value) {
   if (meshnum >= 0 && meshnum < nmeshes) {
     meshdata *meshi;
 
@@ -2737,7 +2769,7 @@ int set_meshoffset(int meshnum, int value) {
   return 1;
 } // MESHOFFSET
 
-int set_northangle(int vis, float x, float y, float z) {
+int SetNorthangle(int vis, float x, float y, float z) {
   vis_northangle = vis;
   northangle_position[0] = x;
   northangle_position[1] = y;
@@ -2745,29 +2777,29 @@ int set_northangle(int vis, float x, float y, float z) {
   return 0;
 } // NORTHANGLE
 
-int set_offsetslice(int v) {
+int SetOffsetslice(int v) {
   offset_slice = v;
   return 0;
 } // OFFSETSLICE
 
-int set_outlinemode(int a, int b) {
+int SetOutlinemode(int a, int b) {
   highlight_flag = a;
   outline_color_flag = b;
   return 0;
 } // OUTLINEMODE
 
-int set_p3dsurfacetype(int v) {
+int SetP3dsurfacetype(int v) {
   p3dsurfacetype = v;
   return 0;
 } // P3DSURFACETYPE
 
-int set_p3dsurfacesmooth(int v) {
+int SetP3dsurfacesmooth(int v) {
   p3dsurfacesmooth = v;
   return 0;
 } // P3DSURFACESMOOTH
 
-int set_scaledfont(int height2d, float height2dwidth, int thickness2d,
-                   int height3d, float height3dwidth, int thickness3d) {
+int SetScaledfont(int height2d, float height2dwidth, int thickness2d,
+                  int height3d, float height3dwidth, int thickness3d) {
   scaled_font2d_height = scaled_font2d_height;
   scaled_font2d_height2width = scaled_font2d_height2width;
   scaled_font3d_height = scaled_font3d_height;
@@ -2775,162 +2807,160 @@ int set_scaledfont(int height2d, float height2dwidth, int thickness2d,
   return 0;
 } // SCALEDFONT
 
-int get_scaledfont_height2d() {
-  return scaled_font2d_height;
-}
+int GetScaledfontHeight2d() { return scaled_font2d_height; }
 
-int set_scaledfont_height2d(int height2d) {
+int SetScaledfontHeight2d(int height2d) {
   scaled_font2d_height = height2d;
   return 0;
 }
 
-int set_showalltextures(int v) {
+int SetShowalltextures(int v) {
   showall_textures = v;
   return 0;
 } // SHOWALLTEXTURES
 
-int set_showaxislabels(int v) {
+int SetShowaxislabels(int v) {
   visaxislabels = v;
   return 0;
 } // SHOWAXISLABELS TODO: duplicate
 
-int set_showblocklabel(int v) {
+int SetShowblocklabel(int v) {
   visMeshlabel = v;
   return 0;
 } // SHOWBLOCKLABEL
 
-int set_showblocks(int v) {
+int SetShowblocks(int v) {
   visBlocks = v;
   return 0;
 } // SHOWBLOCKS
 
-int set_showcadandgrid(int v) {
+int SetShowcadandgrid(int v) {
   show_cad_and_grid = v;
   return 0;
 } // SHOWCADANDGRID
 
-int set_showcadopaque(int v) {
+int SetShowcadopaque(int v) {
   viscadopaque = v;
   return 0;
 } // SHOWCADOPAQUE
 
-int set_showceiling(int v) {
+int SetShowceiling(int v) {
   visCeiling = v;
   return 0;
 } // SHOWCEILING
 
-int set_showcolorbars(int v) {
+int SetShowcolorbars(int v) {
   visColorbarVertical = v;
   return 0;
 } // SHOWCOLORBARS
 
-int set_showcvents(int a, int b) {
+int SetShowcvents(int a, int b) {
   visCircularVents = a;
   circle_outline = b;
   return 0;
 } // SHOWCVENTS
 
-int set_showdummyvents(int v) {
+int SetShowdummyvents(int v) {
   visDummyVents = v;
   return 0;
 } // SHOWDUMMYVENTS
 
-int set_showfloor(int v) {
+int SetShowfloor(int v) {
   visFloor = v;
   return 0;
 } // SHOWFLOOR
 
-int set_showframe(int v) {
+int SetShowframe(int v) {
   visFrame = v;
   return 0;
 } // SHOWFRAME
 
-int set_showframelabel(int v) {
+int SetShowframelabel(int v) {
   visFramelabel = v;
   return 0;
 } // SHOWFRAMELABEL
 
-int set_showframerate(int v) {
+int SetShowframerate(int v) {
   visFramerate = v;
   return 0;
 } // SHOWFRAMERATE
 
-int set_showgrid(int v) {
+int SetShowgrid(int v) {
   visGrid = v;
   return 0;
 } // SHOWGRID
 
-int set_showgridloc(int v) {
+int SetShowgridloc(int v) {
   visgridloc = v;
   return 0;
 } // SHOWGRIDLOC
 
-int set_showhmstimelabel(int v) {
+int SetShowhmstimelabel(int v) {
   vishmsTimelabel = v;
   return 0;
 } // SHOWHMSTIMELABEL
 
-int set_showhrrcutoff(int v) {
+int SetShowhrrcutoff(int v) {
   vis_hrr_label = v;
   return 0;
 } // SHOWHRRCUTOFF
 
-int set_showiso(int v) {
+int SetShowiso(int v) {
   visAIso = v;
   return 0;
 } // SHOWISO
 
-int set_showisonormals(int v) {
+int SetShowisonormals(int v) {
   show_iso_normal = v;
   return 0;
 } // SHOWISONORMALS
 
-int set_showlabels(int v) {
+int SetShowlabels(int v) {
   visLabels = v;
   return 0;
 } // SHOWLABELS
 
 #ifdef pp_memstatus
-int set_showmemload(int v) {
+int SetShowmemload(int v) {
   visAvailmemory = v;
   return 0;
 } // SHOWMEMLOAD
 #endif
 
 // int set_shownormalwhensmooth(int v); // SHOWNORMALWHENSMOOTH
-int set_showopenvents(int a, int b) {
+int SetShowopenvents(int a, int b) {
   visOpenVents = a;
   visOpenVentsAsOutline = b;
   return 0;
 } // SHOWOPENVENTS
 
-int set_showothervents(int v) {
+int SetShowothervents(int v) {
   visOtherVents = v;
   return 0;
 } // SHOWOTHERVENTS
 
-int set_showsensors(int a, int b) {
+int SetShowsensors(int a, int b) {
   visSensor = a;
   visSensorNorm = b;
   return 0;
 } // SHOWSENSORS
 
-int set_showsliceinobst(int v) {
+int SetShowsliceinobst(int v) {
   show_slice_in_obst = v;
   return 0;
 } // SHOWSLICEINOBST
 
-int set_showsmokepart(int v) {
+int SetShowsmokepart(int v) {
   visSmokePart = v;
   return 0;
 } // SHOWSMOKEPART
 
-int set_showsprinkpart(int v) {
+int SetShowsprinkpart(int v) {
   visSprinkPart = v;
   return 0;
 } // SHOWSPRINKPART
 
-int set_showstreak(int show, int step, int showhead, int index) {
+int SetShowstreak(int show, int step, int showhead, int index) {
   streak5show = show;
   streak5step = step;
   showstreakhead = showhead;
@@ -2938,44 +2968,44 @@ int set_showstreak(int show, int step, int showhead, int index) {
   return 0;
 } // SHOWSTREAK
 
-int set_showterrain(int v) {
+int SetShowterrain(int v) {
   visTerrainType = v;
   return 0;
 } // SHOWTERRAIN
 
-int set_showthreshold(int a, int b, float c) {
+int SetShowthreshold(int a, int b, float c) {
   vis_threshold = a;
   vis_onlythreshold = b;
   temp_threshold = c;
   return 0;
 } // SHOWTHRESHOLD
 
-int set_showticks(int v) {
+int SetShowticks(int v) {
   visFDSticks = v;
   return 0;
 } // SHOWTICKS
 
-int set_showtimebar(int v) {
+int SetShowtimebar(int v) {
   visTimebar = v;
   return 0;
 } // SHOWTIMEBAR
 
-int set_showtimelabel(int v) {
+int SetShowtimelabel(int v) {
   visTimelabel = v;
   return 0;
 } // SHOWTIMELABEL
 
-int set_showtitle(int v) {
+int SetShowtitle(int v) {
   vis_title_fds = v;
   return 0;
 } // SHOWTITLE
 
-int set_showtracersalways(int v) {
+int SetShowtracersalways(int v) {
   show_tracers_always = v;
   return 0;
 } // SHOWTRACERSALWAYS
 
-int set_showtriangles(int a, int b, int c, int d, int e, int f) {
+int SetShowtriangles(int a, int b, int c, int d, int e, int f) {
   show_iso_shaded = a;
   show_iso_outline = b;
   show_iso_points = c;
@@ -2984,22 +3014,22 @@ int set_showtriangles(int a, int b, int c, int d, int e, int f) {
   return 0;
 } // SHOWTRIANGLES
 
-int set_showtransparent(int v) {
+int SetShowtransparent(int v) {
   visTransparentBlockage = v;
   return 0;
 } // SHOWTRANSPARENT
 
-int set_showtransparentvents(int v) {
+int SetShowtransparentvents(int v) {
   show_transparent_vents = v;
   return 0;
 } // SHOWTRANSPARENTVENTS
 
-int set_showtrianglecount(int v) {
+int SetShowtrianglecount(int v) {
   show_triangle_count = v;
   return 0;
 } // SHOWTRIANGLECOUNT
 
-int set_showventflow(int a, int b, int c, int d, int e) {
+int SetShowventflow(int a, int b, int c, int d, int e) {
   visVentHFlow = a;
   visventslab = b;
   visventprofile = c;
@@ -3008,17 +3038,17 @@ int set_showventflow(int a, int b, int c, int d, int e) {
   return 0;
 } // SHOWVENTFLOW
 
-int set_showvents(int v) {
+int SetShowvents(int v) {
   visVents = v;
   return 0;
 } // SHOWVENTS
 
-int set_showwalls(int v) {
+int SetShowwalls(int v) {
   visWalls = v;
   return 0;
 } // SHOWWALLS
 
-int set_skipembedslice(int v) {
+int SetSkipembedslice(int v) {
   skip_slice_in_embedded_mesh = v;
   return 0;
 } // SKIPEMBEDSLICE
@@ -3031,7 +3061,7 @@ int set_slicedup(int a, int b) {
 } // SLICEDUP
 #endif
 
-int set_smokesensors(int a, int b) {
+int SetSmokesensors(int a, int b) {
   show_smokesensors = a;
   test_smokesensors = b;
   return 0;
@@ -3055,18 +3085,18 @@ int set_startuplang(const char *lang) {
 } // STARTUPLANG
 #endif
 
-int set_stereo(int v) {
+int SetStereo(int v) {
   stereotype = v;
   return 0;
 } // STEREO
 
-int set_surfinc(int v) {
+int SetSurfinc(int v) {
   surfincrement = v;
   return 0;
 } // SURFINC
 
-int set_terrainparams(int r_min, int g_min, int b_min, int r_max, int g_max,
-                      int b_max, int v) {
+int SetTerrainparams(int r_min, int g_min, int b_min, int r_max, int g_max,
+                     int b_max, int v) {
   terrain_rgba_zmin[0] = r_min;
   terrain_rgba_zmin[1] = g_min;
   terrain_rgba_zmin[2] = b_min;
@@ -3077,28 +3107,28 @@ int set_terrainparams(int r_min, int g_min, int b_min, int r_max, int g_max,
   return 0;
 } // TERRAINPARMS
 
-int set_titlesafe(int v) {
+int SetTitlesafe(int v) {
   titlesafe_offset = v;
   return 0;
 } // TITLESAFE
 
-int set_trainermode(int v) {
+int SetTrainermode(int v) {
   trainer_mode = v;
   return 0;
 } // TRAINERMODE
 
-int set_trainerview(int v) {
+int SetTrainerview(int v) {
   trainerview = v;
   return 0;
 } // TRAINERVIEW
 
-int set_transparent(int use_flag, float level) {
+int SetTransparent(int use_flag, float level) {
   use_transparency_data = use_flag;
   transparent_level = level;
   return 0;
 } // TRANSPARENT
 
-int set_treeparms(int minsize, int visx, int visy, int visz) {
+int SetTreeparms(int minsize, int visx, int visy, int visz) {
   mintreesize = minsize;
   vis_xtree = visx;
   vis_ytree = visy;
@@ -3106,19 +3136,19 @@ int set_treeparms(int minsize, int visx, int visy, int visz) {
   return 0;
 } // TREEPARMS
 
-int set_twosidedvents(int internal, int external) {
+int SetTwosidedvents(int internal, int external) {
   show_bothsides_int = internal;
   show_bothsides_ext = external;
   return 0;
 } // TWOSIDEDVENTS
 
-int set_vectorskip(int v) {
+int SetVectorskip(int v) {
   vectorskip = v;
   return 0;
 } // VECTORSKIP
 
-int set_volsmoke(int a, int b, int c, int d, int e, float f, float g, float h,
-                 float i, float j, float k, float l) {
+int SetVolsmoke(int a, int b, int c, int d, int e, float f, float g, float h,
+                float i, float j, float k, float l) {
   glui_compress_volsmoke = a;
   use_multi_threading = b;
   load_at_rendertimes = c;
@@ -3134,19 +3164,19 @@ int set_volsmoke(int a, int b, int c, int d, int e, float f, float g, float h,
   return 0;
 } // VOLSMOKE
 
-int set_zoom(int a, float b) {
+int SetZoom(int a, float b) {
   zoomindex = a;
   zoom = b;
   return 0;
 } // ZOOM
 
 // *** MISC ***
-int set_cellcentertext(int v) {
+int SetCellcentertext(int v) {
   show_slice_values_all_regions = v;
   return 0;
 } // CELLCENTERTEXT
 
-int set_inputfile(const char *filename) {
+int SetInputfile(const char *filename) {
   size_t len;
   len = strlen(filename);
 
@@ -3157,7 +3187,7 @@ int set_inputfile(const char *filename) {
   return 0;
 } // INPUT_FILE
 
-int set_labelstartupview(const char *startupview) {
+int SetLabelstartupview(const char *startupview) {
   strcpy(viewpoint_label_startup, startupview);
   update_startup_view = 3;
   return 0;
@@ -3169,7 +3199,7 @@ int set_labelstartupview(const char *startupview) {
 //   return 0;
 // } // PIXELSKIP
 
-int set_renderclip(int use_flag, int left, int right, int bottom, int top) {
+int SetRenderclip(int use_flag, int left, int right, int bottom, int top) {
   clip_rendered_scene = use_flag;
   render_clip_left = left;
   render_clip_right = right;
@@ -3184,13 +3214,13 @@ int set_renderclip(int use_flag, int left, int right, int bottom, int top) {
 //   return 0;
 // } // RENDERFILELABEL
 
-int set_renderfiletype(int render, int movie) {
+int SetRenderfiletype(int render, int movie) {
   render_filetype = render;
   movie_filetype = movie;
   return 0;
 } // RENDERFILETYPE
 
-int set_skybox() {
+int SetSkybox() {
   // skyboxdata *skyi;
 
   // free_skybox();
@@ -3213,7 +3243,7 @@ int set_skybox() {
 //   return 0;
 // } // RENDEROPTION
 
-int set_unitclasses(int n, int indices[]) {
+int SetUnitclasses(int n, int indices[]) {
 
   for (size_t i = 0; i < n; i++) {
     if (i > nunitclasses - 1) continue;
@@ -3222,22 +3252,22 @@ int set_unitclasses(int n, int indices[]) {
   return 0;
 } // UNITCLASSES
 
-int set_zaxisangles(float a, float b, float c) {
+int SetZaxisangles(float a, float b, float c) {
   zaxis_angles[0] = a;
   zaxis_angles[1] = b;
   zaxis_angles[2] = c;
   return 0;
 }
 
-int set_colorbartype(int type, const char *label) {
+int SetColorbartype(int type, const char *label) {
   update_colorbartype = 1;
   colorbartype = type;
   strcpy(colorbarname, label);
   return 0;
 } // COLORBARTYPE
 
-int set_extremecolors(int rmin, int gmin, int bmin, int rmax, int gmax,
-                      int bmax) {
+int SetExtremecolors(int rmin, int gmin, int bmin, int rmax, int gmax,
+                     int bmax) {
   rgb_below_min[0] = CLAMP(rmin, 0, 255);
   rgb_below_min[1] = CLAMP(gmin, 0, 255);
   rgb_below_min[2] = CLAMP(bmin, 0, 255);
@@ -3248,20 +3278,20 @@ int set_extremecolors(int rmin, int gmin, int bmin, int rmax, int gmax,
   return 0;
 } // EXTREMECOLORS
 
-int set_firecolor(int r, int g, int b) {
+int SetFirecolor(int r, int g, int b) {
   fire_color_int255[0] = r;
   fire_color_int255[1] = g;
   fire_color_int255[2] = b;
   return 0;
 } // FIRECOLOR
 
-int set_firecolormap(int type, int index) {
+int SetFirecolormap(int type, int index) {
   fire_colormap_type = type;
   fire_colorbar_index = index;
   return 0;
 } // FIRECOLORMAP
 
-int set_firedepth(float v) {
+int SetFiredepth(float v) {
   fire_halfdepth = v;
   return 0;
 } // FIREDEPTH
@@ -3312,19 +3342,21 @@ int set_firedepth(float v) {
 //   return 0;
 // } // GCOLORBAR
 
-int set_showextremedata(int show_extremedata, int below, int above) {
+int SetShowextremedata(int show_extremedata, int below, int above) {
   // int below = -1, above = -1, show_extremedata;
   if (below == -1 && above == -1) {
     if (below == -1) below = 0;
     if (below != 0) below = 1;
     if (above == -1) above = 0;
     if (above != 0) above = 1;
-  } else {
+  }
+  else {
     if (show_extremedata != 1) show_extremedata = 0;
     if (show_extremedata == 1) {
       below = 1;
       above = 1;
-    } else {
+    }
+    else {
       below = 0;
       above = 0;
     }
@@ -3334,19 +3366,20 @@ int set_showextremedata(int show_extremedata, int below, int above) {
   return 0;
 } // SHOWEXTREMEDATA
 
-int set_smokecolor(int r, int g, int b) {
+int SetSmokecolor(int r, int g, int b) {
   smoke_color_int255[0] = r;
   smoke_color_int255[1] = g;
   smoke_color_int255[2] = b;
   return 0;
 } // SMOKECOLOR
 
-int set_smokecull(int v) {
+int SetSmokecull(int v) {
 #ifdef pp_CULL
   if (gpuactive == 1) {
     cullsmoke = v;
     if (cullsmoke != 0) cullsmoke = 1;
-  } else {
+  }
+  else {
     cullsmoke = 0;
   }
 #else
@@ -3355,18 +3388,18 @@ int set_smokecull(int v) {
   return 0;
 } // SMOKECULL
 
-int set_smokeskip(int v) {
+int SetSmokeskip(int v) {
   smokeskipm1 = v;
   return 0;
 } // SMOKESKIP
 
-int set_smokealbedo(float v) {
+int SetSmokealbedo(float v) {
   smoke_albedo = v;
   return 0;
 } // SMOKEALBEDO
 
 #ifdef pp_GPU
-int set_smokerthick(float v) {
+int SetSmokerthick(float v) {
   // smoke3d_rthick = v;
   // smoke3d_rthick = CLAMP(smoke3d_rthick, 1.0, 255.0);
   // smoke3d_thick = LogBase2(smoke3d_rthick);
@@ -3380,120 +3413,122 @@ int set_smokerthick(float v) {
 // } // SMOKETHICK
 
 #ifdef pp_GPU
-int set_usegpu(int v) {
+int SetUsegpu(int v) {
   usegpu = v;
   return 0;
 }
 #endif
 
 // *** ZONE FIRE PARAMETRES ***
-int set_showhazardcolors(int v) {
+int SetShowhazardcolors(int v) {
   zonecolortype = v;
   return 0;
 } // SHOWHAZARDCOLORS
 
-int set_showhzone(int v) {
+int SetShowhzone(int v) {
   if (v) {
     visZonePlane = ZONE_ZPLANE;
-  } else {
+  }
+  else {
     visZonePlane = ZONE_HIDDEN;
   }
   return 0;
 } // SHOWHZONE
 
-int set_showszone(int v) {
+int SetShowszone(int v) {
   visSZone = v;
   return 0;
 } // SHOWSZONE
 
-int set_showvzone(int v) {
+int SetShowvzone(int v) {
   if (v) {
     visZonePlane = ZONE_YPLANE;
-  } else {
+  }
+  else {
     visZonePlane = ZONE_HIDDEN;
   }
   return 0;
 } // SHOWVZONE
 
-int set_showzonefire(int v) {
+int SetShowzonefire(int v) {
   viszonefire = v;
   return 0;
 } // SHOWZONEFIRE
 
 // *** TOUR INFO ***
-int set_showpathnodes(int v) {
+int SetShowpathnodes(int v) {
   show_path_knots = v;
   return 0;
 } // SHOWPATHNODES
 
-int set_showtourroute(int v) {
+int SetShowtourroute(int v) {
   edittour = v;
   return 0;
 } // SHOWTOURROUTE
 
 // TOURCOLORS
-int set_tourcolors_selectedpathline(float r, float g, float b) {
+int SetTourcolorsSelectedpathline(float r, float g, float b) {
   tourcol_selectedpathline[0] = r;
   tourcol_selectedpathline[1] = g;
   tourcol_selectedpathline[2] = b;
   return 0;
 }
-int set_tourcolors_selectedpathlineknots(float r, float g, float b) {
+int SetTourcolorsSelectedpathlineknots(float r, float g, float b) {
   tourcol_selectedpathlineknots[0] = r;
   tourcol_selectedpathlineknots[1] = g;
   tourcol_selectedpathlineknots[2] = b;
   return 0;
 }
-int set_tourcolors_selectedknot(float r, float g, float b) {
+int SetTourcolorsSelectedknot(float r, float g, float b) {
   tourcol_selectedknot[0] = r;
   tourcol_selectedknot[1] = g;
   tourcol_selectedknot[2] = b;
   return 0;
 }
-int set_tourcolors_pathline(float r, float g, float b) {
+int SetTourcolorsPathline(float r, float g, float b) {
   tourcol_pathline[0] = r;
   tourcol_pathline[1] = g;
   tourcol_pathline[2] = b;
   return 0;
 }
-int set_tourcolors_pathknots(float r, float g, float b) {
+int SetTourcolorsPathknots(float r, float g, float b) {
   tourcol_pathknots[0] = r;
   tourcol_pathknots[1] = g;
   tourcol_pathknots[2] = b;
   return 0;
 }
-int set_tourcolors_text(float r, float g, float b) {
+int SetTourcolorsText(float r, float g, float b) {
   tourcol_text[0] = r;
   tourcol_text[1] = g;
   tourcol_text[2] = b;
   return 0;
 }
-int set_tourcolors_avatar(float r, float g, float b) {
+int SetTourcolorsAvatar(float r, float g, float b) {
   tourcol_avatar[0] = r;
   tourcol_avatar[1] = g;
   tourcol_avatar[2] = b;
   return 0;
 }
 
-int set_viewalltours(int v) {
+int SetViewalltours(int v) {
   viewalltours = v;
   return 0;
 } // VIEWALLTOURS
 
-int set_viewtimes(float start, float stop, int ntimes) {
+int SetViewtimes(float start, float stop, int ntimes) {
   tour_tstart = start;
   tour_tstop = stop;
   tour_ntimes = ntimes;
   return 0;
 } // VIEWTIMES
 
-int set_viewtourfrompath(int v) {
+int SetViewtourfrompath(int v) {
   viewtourfrompath = v;
   return 0;
 } // VIEWTOURFROMPATH
 
-int set_devicevectordimensions(float baselength, float basediameter,
-                               float headlength, float headdiameter) {
+int SetDevicevectordimensions(float baselength, float basediameter,
+                              float headlength, float headdiameter) {
   vector_baselength = baselength;
   vector_basediameter = basediameter;
   vector_headlength = headlength;
@@ -3501,13 +3536,13 @@ int set_devicevectordimensions(float baselength, float basediameter,
   return 0;
 } // DEVICEVECTORDIMENSIONS
 
-int set_devicebounds(float min, float max) {
+int SetDevicebounds(float min, float max) {
   device_valmin = min;
   device_valmax = max;
   return 0;
 } // DEVICEBOUNDS
 
-int set_deviceorientation(int a, float b) {
+int SetDeviceorientation(int a, float b) {
   show_device_orientation = a;
   orientation_scale = b;
   show_device_orientation = CLAMP(show_device_orientation, 0, 1);
@@ -3515,7 +3550,7 @@ int set_deviceorientation(int a, float b) {
   return 0;
 } // DEVICEORIENTATION
 
-int set_gridparms(int vx, int vy, int vz, int px, int py, int pz) {
+int SetGridparms(int vx, int vy, int vz, int px, int py, int pz) {
   visx_all = vx;
   visy_all = vy;
   visz_all = vz;
@@ -3531,8 +3566,8 @@ int set_gridparms(int vx, int vy, int vz, int px, int py, int pz) {
   return 0;
 } // GRIDPARMS
 
-int set_gsliceparms(int vis_data, int vis_triangles, int vis_triangulation,
-                    int vis_normal, float xyz[], float azelev[]) {
+int SetGsliceparms(int vis_data, int vis_triangles, int vis_triangulation,
+                   int vis_normal, float xyz[], float azelev[]) {
   vis_gslice_data = vis_data;
   show_gslice_triangles = vis_triangles;
   show_gslice_triangulation = vis_triangulation;
@@ -3554,18 +3589,18 @@ int set_gsliceparms(int vis_data, int vis_triangles, int vis_triangulation,
   return 0;
 } // GSLICEPARMS
 
-int set_loadfilesatstartup(int v) {
+int SetLoadfilesatstartup(int v) {
   loadfiles_at_startup = v;
   return 0;
 } // LOADFILESATSTARTUP
-int set_mscale(float a, float b, float c) {
+int SetMscale(float a, float b, float c) {
   mscale[0] = a;
   mscale[1] = b;
   mscale[2] = c;
   return 0;
 } // MSCALE
 
-int set_sliceauto(int n, int vals[]) {
+int SetSliceauto(int n, int vals[]) {
 
   int n3dsmokes = 0;
   int seq_id;
@@ -3579,7 +3614,7 @@ int set_sliceauto(int n, int vals[]) {
   return 0;
 } // SLICEAUTO
 
-int set_msliceauto(int n, int vals[]) {
+int SetMsliceauto(int n, int vals[]) {
 
   int n3dsmokes = 0;
   int seq_id;
@@ -3598,7 +3633,7 @@ int set_msliceauto(int n, int vals[]) {
   return 0;
 } // MSLICEAUTO
 
-int set_compressauto(int v) {
+int SetCompressauto(int v) {
   compress_autoloaded = v;
   return 0;
 } // COMPRESSAUTO
@@ -3650,7 +3685,7 @@ int set_compressauto(int v) {
 //   return 0;
 // } // PART5COLOR
 
-int set_propindex(int nvals, int *vals) {
+int SetPropindex(int nvals, int *vals) {
 
   for (size_t i = 0; i < nvals; i++) {
     propdata *propi;
@@ -3672,10 +3707,9 @@ int set_propindex(int nvals, int *vals) {
   return 0;
 } // PROPINDEX
 
-int set_shooter(float xyz[], float dxyz[], float uvw[], float velmag,
-                float veldir, float pointsize, int fps, int vel_type,
-                int nparts, int vis, int cont_update, float duration,
-                float v_inf) {
+int SetShooter(float xyz[], float dxyz[], float uvw[], float velmag,
+               float veldir, float pointsize, int fps, int vel_type, int nparts,
+               int vis, int cont_update, float duration, float v_inf) {
   shooter_xyz[0] = xyz[0];
   shooter_xyz[1] = xyz[1];
   shooter_xyz[2] = xyz[2];
@@ -3704,7 +3738,7 @@ int set_shooter(float xyz[], float dxyz[], float uvw[], float velmag,
   return 0;
 } // SHOOTER
 
-int set_showdevices(int ndevices_ini, const char *const *names) {
+int SetShowdevices(int ndevices_ini, const char *const *names) {
   sv_object *obj_typei;
 
   char tempname[255]; // temporary buffer to convert from const string
@@ -3724,10 +3758,10 @@ int set_showdevices(int ndevices_ini, const char *const *names) {
   return 0;
 } // SHOWDEVICES
 
-int set_showdevicevals(int vshowdeviceval, int vshowvdeviceval,
-                       int vdevicetypes_index, int vcolordeviceval,
-                       int vvectortype, int vviswindrose, int vshowdevicetype,
-                       int vshowdeviceunit) {
+int SetShowdevicevals(int vshowdeviceval, int vshowvdeviceval,
+                      int vdevicetypes_index, int vcolordeviceval,
+                      int vvectortype, int vviswindrose, int vshowdevicetype,
+                      int vshowdeviceunit) {
   showdevice_val = vshowdeviceval;
   showvdevice_val = vshowvdeviceval;
   devicetypes_index = vdevicetypes_index;
@@ -3741,22 +3775,22 @@ int set_showdevicevals(int vshowdeviceval, int vshowvdeviceval,
   return 0;
 } // SHOWDEVICEVALS
 
-int set_showmissingobjects(int v) {
+int SetShowmissingobjects(int v) {
   show_missing_objects = v;
   ONEORZERO(show_missing_objects);
   return 0;
 } // SHOWMISSINGOBJECTS
 
-int set_tourindex(int v) {
+int SetTourindex(int v) {
   selectedtour_index_ini = v;
   if (selectedtour_index_ini < 0) selectedtour_index_ini = -1;
   update_selectedtour_index = 1;
   return 0;
 } // TOURINDEX
 
-int set_userticks(int vis, int auto_place, int sub, float origin[], float min[],
-                  float max[], float step[], int show_x, int show_y,
-                  int show_z) {
+int SetUserticks(int vis, int auto_place, int sub, float origin[], float min[],
+                 float max[], float step[], int show_x, int show_y,
+                 int show_z) {
   visUSERticks = vis;
   auto_user_tick_placement = auto_place;
   user_tick_sub = sub;
@@ -3784,8 +3818,8 @@ int set_userticks(int vis, int auto_place, int sub, float origin[], float min[],
   return 0;
 } // USERTICKS
 
-int set_c_particles(int minFlag, float minValue, int maxFlag, float maxValue,
-                    const char *label) {
+int SetCParticles(int minFlag, float minValue, int maxFlag, float maxValue,
+                  const char *label) {
   if (label == NULL) {
     label = "";
   }
@@ -3810,8 +3844,8 @@ int set_c_particles(int minFlag, float minValue, int maxFlag, float maxValue,
   return 0;
 }
 
-int set_c_slice(int minFlag, float minValue, int maxFlag, float maxValue,
-                const char *label) {
+int SetCSlice(int minFlag, float minValue, int maxFlag, float maxValue,
+              const char *label) {
 
   // if there is a label, use it
   if (strcmp(label, "") != 0) {
@@ -3824,7 +3858,8 @@ int set_c_slice(int minFlag, float minValue, int maxFlag, float maxValue,
       break;
     }
     // if there is no label apply values to all slice types
-  } else {
+  }
+  else {
     for (size_t i = 0; i < nslicebounds; i++) {
       slicebounds[i].setchopmin = minFlag;
       slicebounds[i].setchopmax = maxFlag;
@@ -3835,31 +3870,31 @@ int set_c_slice(int minFlag, float minValue, int maxFlag, float maxValue,
   return 0;
 }
 
-int set_cache_boundarydata(int setting) {
+int SetCacheBoundarydata(int setting) {
   cache_boundary_data = setting;
   return 0;
 } // CACHE_BOUNDARYDATA
 
-int set_cache_qdata(int setting) {
+int SetCacheQdata(int setting) {
   cache_plot3d_data = setting;
   return 0;
 } // CACHE_QDATA
 
-int set_percentilelevel(float p_level_min, float p_level_max) {
+int SetPercentilelevel(float p_level_min, float p_level_max) {
   percentile_level_min = CLAMP(p_level_min, 0.0, 1.0);
   if (p_level_max < 0.0) p_level_max = 1.0 - percentile_level_min;
   percentile_level_max = CLAMP(p_level_max, percentile_level_min + 0.0001, 1.0);
   return 0;
 } // PERCENTILELEVEL
 
-int set_timeoffset(int setting) {
+int SetTimeoffset(int setting) {
   timeoffset = setting;
   return 0;
 } // TIMEOFFSET
 
-int set_patchdataout(int outputFlag, float tmin, float tmax, float xmin,
-                     float xmax, float ymin, float ymax, float zmin,
-                     float zmax) {
+int SetPatchdataout(int outputFlag, float tmin, float tmax, float xmin,
+                    float xmax, float ymin, float ymax, float zmin,
+                    float zmax) {
   output_patchdata = outputFlag;
   patchout_tmin = tmin;
   patchout_tmax = tmax;
@@ -3873,8 +3908,8 @@ int set_patchdataout(int outputFlag, float tmin, float tmax, float xmin,
   return 0;
 } // PATCHDATAOUT
 
-int set_c_plot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
-                 int maxVals[]) {
+int SetCPlot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
+               int maxVals[]) {
 
   if (n3d > MAXPLOT3DVARS) n3d = MAXPLOT3DVARS;
   for (size_t i = 0; i < n3d; i++) {
@@ -3886,8 +3921,8 @@ int set_c_plot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
   return 0;
 } // C_PLOT3D
 
-int set_v_plot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
-                 int maxVals[]) {
+int SetVPlot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
+               int maxVals[]) {
 
   if (n3d > MAXPLOT3DVARS) n3d = MAXPLOT3DVARS;
   for (size_t i = 0; i < n3d; i++) {
@@ -3899,7 +3934,7 @@ int set_v_plot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
   return 0;
 } // V_PLOT3D
 
-int set_pl3d_bound_min(int pl3dValueIndex, int set, float value) {
+int SetPl3dBoundMin(int pl3dValueIndex, int set, float value) {
   setp3min_all[pl3dValueIndex] = set;
   p3min_all[pl3dValueIndex] = value;
   // TODO: remove this reload and hardcoded value
@@ -3907,7 +3942,7 @@ int set_pl3d_bound_min(int pl3dValueIndex, int set, float value) {
   return 0;
 }
 
-int set_pl3d_bound_max(int pl3dValueIndex, int set, float value) {
+int SetPl3dBoundMax(int pl3dValueIndex, int set, float value) {
   setp3max_all[pl3dValueIndex] = set;
   p3max_all[pl3dValueIndex] = value;
   // TODO: remove this reload and hardcoded value
@@ -3915,8 +3950,8 @@ int set_pl3d_bound_max(int pl3dValueIndex, int set, float value) {
   return 0;
 }
 
-int set_tload(int beginFlag, float beginVal, int endFlag, int endVal,
-              int skipFlag, int skipVal) {
+int SetTload(int beginFlag, float beginVal, int endFlag, int endVal,
+             int skipFlag, int skipVal) {
   use_tload_begin = beginFlag;
   tload_begin = beginVal;
   use_tload_end = endFlag;
@@ -3926,8 +3961,8 @@ int set_tload(int beginFlag, float beginVal, int endFlag, int endVal,
   return 0;
 } // TLOAD
 
-int set_v5_particles(int minFlag, float minValue, int maxFlag, float maxValue,
-                     const char *label) {
+int SetV5Particles(int minFlag, float minValue, int maxFlag, float maxValue,
+                   const char *label) {
   if (label == NULL) {
     label = "";
   }
@@ -3981,7 +4016,7 @@ int set_v5_particles(int minFlag, float minValue, int maxFlag, float maxValue,
   return 0;
 }
 
-int set_v_particles(int minFlag, float minValue, int maxFlag, float maxValue) {
+int SetVParticles(int minFlag, float minValue, int maxFlag, float maxValue) {
   setpartmin = minFlag;
   glui_partmin = minValue;
   setpartmax = maxFlag;
@@ -3989,7 +4024,7 @@ int set_v_particles(int minFlag, float minValue, int maxFlag, float maxValue) {
   return 0;
 } // V_PARTICLES
 
-int set_v_target(int minFlag, float minValue, int maxFlag, float maxValue) {
+int SetVTarget(int minFlag, float minValue, int maxFlag, float maxValue) {
   settargetmin = minFlag;
   targetmin = minValue;
   settargetmax = maxFlag;
@@ -3997,8 +4032,8 @@ int set_v_target(int minFlag, float minValue, int maxFlag, float maxValue) {
   return 0;
 } // V_TARGET
 
-int set_v_slice(int minFlag, float minValue, int maxFlag, float maxValue,
-                const char *label, float lineMin, float lineMax, int lineNum) {
+int SetVSlice(int minFlag, float minValue, int maxFlag, float maxValue,
+              const char *label, float lineMin, float lineMax, int lineNum) {
 
   // if there is a label to apply, use it
   if (strcmp(label, "") != 0) {
@@ -4015,7 +4050,8 @@ int set_v_slice(int minFlag, float minValue, int maxFlag, float maxValue,
       break;
     }
     // if there is no label apply values to all slice types
-  } else {
+  }
+  else {
     for (size_t i = 0; i < nslicebounds; i++) {
       slicebounds[i].dlg_setvalmin = minFlag;
       slicebounds[i].dlg_setvalmax = maxFlag;
@@ -4030,7 +4066,7 @@ int set_v_slice(int minFlag, float minValue, int maxFlag, float maxValue,
   return 0;
 } // V_SLICE
 
-int show_smoke3d_showall() {
+int ShowSmoke3dShowall() {
   smoke3ddata *smoke3di;
 
   updatemenu = 1;
@@ -4045,7 +4081,7 @@ int show_smoke3d_showall() {
   return 0;
 }
 
-int show_smoke3d_hideall() {
+int ShowSmoke3dHideall() {
   smoke3ddata *smoke3di;
 
   updatemenu = 1;
@@ -4058,7 +4094,7 @@ int show_smoke3d_hideall() {
   return 0;
 }
 
-int show_slices_showall() {
+int ShowSlicesShowall() {
 
   updatemenu = 1;
   GLUTPOSTREDISPLAY;
@@ -4074,7 +4110,7 @@ int show_slices_showall() {
   return 0;
 }
 
-int show_slices_hideall() {
+int ShowSlicesHideall() {
 
   updatemenu = 1;
   GLUTPOSTREDISPLAY;

--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -103,7 +103,7 @@ int SetSliceBoundMax(const char *slice_type, int set, float value) {
 /// @param[in] valmax
 /// @return Non-zero on error
 int CApiSetSliceBounds(const char *slice_type, int set_valmin, float valmin,
-                   int set_valmax, float valmax) {
+                       int set_valmax, float valmax) {
   int slice_type_index = GetSliceBoundIndex(slice_type);
   if (slice_type_index < 0) {
     // Slice type index could not be found.
@@ -168,7 +168,7 @@ int Loadsmvall(const char *input_filename) {
 /// @param[out] input_filename_ext
 /// @return
 int ParseSmvFilepath(const char *smv_filepath, char *fdsprefix,
-                       char *input_filename_ext) {
+                     char *input_filename_ext) {
   int len_casename;
   strcpy(input_filename_ext, "");
   len_casename = (int)strlen(smv_filepath);

--- a/Source/smokeview/c_api.h
+++ b/Source/smokeview/c_api.h
@@ -15,7 +15,7 @@ void SetColorbar(size_t value);
 ERROR_CODE SetNamedColorbar(const char *name);
 ERROR_CODE GetNamedColorbar(const char *name, size_t *index);
 ERROR_CODE CApiSetSliceBounds(const char *slice_type, int set_min,
-                            float value_min, int set_max, float value_max);
+                              float value_min, int set_max, float value_max);
 ERROR_CODE SetSliceBoundMin(const char *slice_type, int set, float value);
 ERROR_CODE SetSliceBoundMax(const char *slice_type, int set, float value);
 ERROR_CODE GetSliceBounds(const char *slice_type, simple_bounds *bounds);
@@ -135,11 +135,11 @@ void SetSceneclipZMax(int flag, float value);
 
 int RenderFrameLua(int view_mode, const char *basename);
 char *FormFilename(int view_mode, char *renderfile_name, char *renderfile_dir,
-                    char *renderfile_path, int woffset, int hoffset,
-                    int screenH, const char *basename);
+                   char *renderfile_path, int woffset, int hoffset, int screenH,
+                   const char *basename);
 
 int ParseSmvFilepath(const char *smv_filepath, char *fdsprefix,
-                       char *input_filename_ext);
+                     char *input_filename_ext);
 
 // --------- show/hide label options--------
 
@@ -291,8 +291,8 @@ int SetForegroundcolor(float r, float g, float b); // FOREGROUNDCOLOR
 int SetHeatoffcolor(float r, float g, float b);    // HEATOFFCOLOR
 int SetHeatoncolor(float r, float g, float b);     // HEATONCOLOR
 int SetIsocolors(float shininess, float transparency, int transparency_option,
-                  int opacity_change, float specular[3], int n_colors,
-                  float colors[][4]);
+                 int opacity_change, float specular[3], int n_colors,
+                 float colors[][4]);
 int SetColortable(int ncolors, int colors[][4], char **names);
 int SetLightpos0(float x, float y, float z, float w); // LIGHTPOS0
 int SetLightpos1(float x, float y, float z, float w); // LIGHTPOS1
@@ -324,7 +324,7 @@ int SetStreaklinewidth(float v);  // STREAKLINEWIDTH
 int SetTicklinewidth(float v);    // TICKLINEWIDTH
 int SetUsenewdrawface(int v);     // USENEWDRAWFACE
 int SetVeclength(float vf, int vec_uniform_length_in,
-                  int vec_uniform_spacing_in); // VECLENGTH
+                 int vec_uniform_spacing_in); // VECLENGTH
 int SetVectorlinewidth(float a, float b);     // VECTORLINEWIDTH
 int SetVectorpointsize(float v);              // VECTORPOINTSIZE
 int SetVentlinewidth(float v);                // VENTLINEWIDTH
@@ -347,7 +347,7 @@ int SetSlicedataout(int v);                             // SLICEDATAOUT
 int SetSlicezipstep(int v);                             // SLICEZIPSTEP
 int SetSmoke3dzipstep(int v);                           // SMOKE3DZIPSTEP
 int SetUserrotate(int index, int show_center, float x, float y,
-                   float z); // USER_ROTATE
+                  float z); // USER_ROTATE
 
 // --  *** VIEW PARAMETERS ***
 
@@ -384,8 +384,8 @@ int SetP3dsurfacetype(int v);                          // P3DSURFACETYPE
 int SetP3dsurfacesmooth(int v);                        // P3DSURFACESMOOTH
 int SetSbatstart(int v);                               // SBATSTART
 int SetScaledfont(int height2d, float height2dwidth, int thickness2d,
-                   int height3d, float height3dwidth,
-                   int thickness3d); // SCALEDFONT
+                  int height3d, float height3dwidth,
+                  int thickness3d); // SCALEDFONT
 int GetScaledfontHeight2d();
 int SetScaledfontHeight2d(int height2d);
 int SetShowalltextures(int v);      // SHOWALLTEXTURES
@@ -419,14 +419,14 @@ int SetShowsmokepart(int v);        // SHOWSMOKEPART
 int SetShowsprinkpart(int v);       // SHOWSPRINKPART
 int SetShowstreak(int show, int step, int showhead, int index); // SHOWSTREAK
 int SetShowterrain(int v);                                      // SHOWTERRAIN
-int SetShowthreshold(int a, int b, float c); // SHOWTHRESHOLD
-int SetShowticks(int v);                     // SHOWTICKS
-int SetShowtimebar(int v);                   // SHOWTIMEBAR
-int SetShowtimelabel(int v);                 // SHOWTIMELABEL
-int SetShowtitle(int v);                     // SHOWTITLE
-int SetShowtracersalways(int v);             // SHOWTRACERSALWAYS
+int SetShowthreshold(int a, int b, float c);                    // SHOWTHRESHOLD
+int SetShowticks(int v);                                        // SHOWTICKS
+int SetShowtimebar(int v);                                      // SHOWTIMEBAR
+int SetShowtimelabel(int v);                                    // SHOWTIMELABEL
+int SetShowtitle(int v);                                        // SHOWTITLE
+int SetShowtracersalways(int v); // SHOWTRACERSALWAYS
 int SetShowtriangles(int a, int b, int c, int d, int e,
-                      int f);                            // SHOWTRIANGLES
+                     int f);                            // SHOWTRIANGLES
 int SetShowtransparent(int v);                          // SHOWTRANSPARENT
 int SetShowtransparentvents(int v);                     // SHOWTRANSPARENTVENTS
 int SetShowtrianglecount(int v);                        // SHOWTRIANGLECOUNT
@@ -440,7 +440,7 @@ int SetStartuplang(const char *lang);                   // STARTUPLANG
 int SetStereo(int v);                                   // STEREO
 int SetSurfinc(int v);                                  // SURFINC
 int SetTerrainparams(int r_min, int g_min, int b_min, int r_max, int g_max,
-                      int b_max, int v);                      // TERRAINPARMS
+                     int b_max, int v);                      // TERRAINPARMS
 int SetTitlesafe(int v);                                     // TITLESAFE
 int SetTrainermode(int v);                                   // TRAINERMODE
 int SetTrainerview(int v);                                   // TRAINERVIEW
@@ -449,7 +449,7 @@ int SetTreeparms(int minsize, int visx, int visy, int visz); // TREEPARMS
 int SetTwosidedvents(int internal, int external);            // TWOSIDEDVENTS
 int SetVectorskip(int v);                                    // VECTORSKIP
 int SetVolsmoke(int a, int b, int c, int d, int e, float f, float g, float h,
-                 float i, float j, float k, float l); // VOLSMOKE
+                float i, float j, float k, float l); // VOLSMOKE
 int SetZoom(int a, float b);                         // ZOOM
 
 // --  *** MISC ***
@@ -469,7 +469,7 @@ int SetZaxisangles(float a, float b, float c);
 
 int SetColorbartype(int v, const char *label); // COLORBARTYPE
 int SetExtremecolors(int a, int b, int c, int d, int e,
-                      int f);                 // EXTREMECOLORS
+                     int f);                 // EXTREMECOLORS
 int SetFirecolor(int r, int g, int b);       // FIRECOLOR
 int SetFirecolormap(int a, int b);           // FIRECOLORMAP
 int SetFiredepth(float v);                   // FIREDEPTH
@@ -512,13 +512,13 @@ int SetViewtourfrompath(int v);            // VIEWTOURFROMPATH
 
 int SetAvatarevac(int v); // AVATAREVAC
 int SetDevicevectordimensions(float baselength, float basediameter,
-                               float headlength,
-                               float headdiameter); // DEVICEVECTORDIMENSIONS
+                              float headlength,
+                              float headdiameter); // DEVICEVECTORDIMENSIONS
 int SetDevicebounds(float a, float b);             // DEVICEBOUNDS
 int SetDeviceorientation(int a, float b);          // DEVICEORIENTATION
 int SetGridparms(int vx, int vy, int vz, int px, int py, int pz); // GRIDPARMS
 int SetGsliceparms(int vis_data, int vis_triangles, int vis_triangulation,
-                    int vis_normal, float xyz[], float azelev[]); // GSLICEPARMS
+                   int vis_normal, float xyz[], float azelev[]); // GSLICEPARMS
 int SetLoadfilesatstartup(int v);         // LOADFILESATSTARTUP
 int SetMscale(float a, float b, float c); // MSCALE
 int SetSliceauto(int n, int vals[]);      // SLICEAUTO
@@ -528,48 +528,48 @@ int SetPart5propdisp(int vals[]);         // PART5PROPDISP
 int SetPart5color(int v);                 // PART5COLOR
 int SetPropindex(int nvals, int *vals);   // PROPINDEX
 int SetShooter(float xyz[], float dxyz[], float uvw[], float velmag,
-                float veldir, float pointsize, int fps, int vel_type,
-                int nparts, int vis, int cont_update, float duration,
-                float v_inf);                         // SHOOTER
+               float veldir, float pointsize, int fps, int vel_type, int nparts,
+               int vis, int cont_update, float duration,
+               float v_inf);                         // SHOOTER
 int SetShowdevices(int n, const char *const *names); // SHOWDEVICES
 int SetShowdevicevals(int showdeviceval, int showvdeviceval,
-                       int devicetypes_index, int colordeviceval,
-                       int vectortype, int vispilot, int showdevicetype,
-                       int showdeviceunit); // SHOWDEVICEVALS
+                      int devicetypes_index, int colordeviceval, int vectortype,
+                      int vispilot, int showdevicetype,
+                      int showdeviceunit); // SHOWDEVICEVALS
 int SetShowmissingobjects(int v);          // SHOWMISSINGOBJECTS
 int SetTourindex(int v);                   // TOURINDEX
 int SetUserticks(int vis, int auto_place, int sub, float origin[], float min[],
-                  float max[], float step[], int show_x, int show_y,
-                  int show_z); // USERTICKS
+                 float max[], float step[], int show_x, int show_y,
+                 int show_z); // USERTICKS
 int SetCParticles(int minFlag, float minValue, int maxFlag, float maxValue,
-                    const char *label); // C_PARTICLES
+                  const char *label); // C_PARTICLES
 int SetCSlice(int minFlag, float minValue, int maxFlag, float maxValue,
-                const char *label);      // C_SLICE
+              const char *label);      // C_SLICE
 int SetCacheBoundarydata(int setting); // CACHE_BOUNDARYDATA
 int SetCacheQdata(int setting);        // CACHE_QDATA
 int SetPercentilelevel(float percentile_level_min,
-                        float p_level_max); // PERCENTILELEVEL
+                       float p_level_max); // PERCENTILELEVEL
 int SetTimeoffset(int setting);            // TIMEOFFSET
 int SetPatchdataout(int outputFlag, float tmin, float tmax, float xmin,
-                     float xmax, float ymin, float ymax, float zmin,
-                     float zmax); // PATCHDATAOUT
+                    float xmax, float ymin, float ymax, float zmin,
+                    float zmax); // PATCHDATAOUT
 int SetCPlot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
-                 int maxVals[]); // C_PLOT3D
+               int maxVals[]); // C_PLOT3D
 int SetVPlot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
-                 int maxVals[]); // V_PLOT3D
+               int maxVals[]); // V_PLOT3D
 int SetPl3dBoundMin(int pl3dValueIndex, int set, float value);
 int SetPl3dBoundMax(int pl3dValueIndex, int set, float value);
 int SetTload(int beginFlag, float beginVal, int endFlag, int endVal,
-              int skipFlag, int skipVal); // TLOAD
+             int skipFlag, int skipVal); // TLOAD
 int SetV5Particles(int minFlag, float minValue, int maxFlag, float maxValue,
-                     const char *label); // V5_PARTICLES
+                   const char *label); // V5_PARTICLES
 int SetVParticles(int minFlag, float minValue, int maxFlag, float maxValue);
 // V_PARTICLES
 int SetVTarget(int minFlag, float minValue, int maxFlag, float maxValue);
 // V_TARGET
 int SetVSlice(int minFlag, float minValue, int maxFlag, float maxValue,
-                const char *label, float lineMin, float lineMax,
-                int lineNum); // V_SLICE
+              const char *label, float lineMin, float lineMax,
+              int lineNum); // V_SLICE
 // -- VIEWPOINT5
 // --  0 10 2
 // --  0.490669 -2.257067 0.018868 1.000000 -2

--- a/Source/smokeview/c_api.h
+++ b/Source/smokeview/c_api.h
@@ -1,4 +1,5 @@
 #include "options_common.h"
+
 #include "gd.h"
 
 // Verified, the declarations below are part of the verified and test API.
@@ -10,213 +11,213 @@ typedef struct _simple_bounds {
   float min, max;
 } simple_bounds;
 
-void set_colorbar(size_t value);
-ERROR_CODE set_named_colorbar(const char *name);
-ERROR_CODE get_named_colorbar(const char *name, size_t *index);
-ERROR_CODE set_slice_bounds(const char *slice_type, int set_min,
+void SetColorbar(size_t value);
+ERROR_CODE SetNamedColorbar(const char *name);
+ERROR_CODE GetNamedColorbar(const char *name, size_t *index);
+ERROR_CODE CApiSetSliceBounds(const char *slice_type, int set_min,
                             float value_min, int set_max, float value_max);
-ERROR_CODE set_slice_bound_min(const char *slice_type, int set, float value);
-ERROR_CODE set_slice_bound_max(const char *slice_type, int set, float value);
-ERROR_CODE get_slice_bounds(const char *slice_type, simple_bounds *bounds);
-ERROR_CODE render(const char *filename);
-int getframe();
-void setframe(int framenumber);
-float gettime();
-int settime(float timeval);
+ERROR_CODE SetSliceBoundMin(const char *slice_type, int set, float value);
+ERROR_CODE SetSliceBoundMax(const char *slice_type, int set, float value);
+ERROR_CODE GetSliceBounds(const char *slice_type, simple_bounds *bounds);
+ERROR_CODE CApiRender(const char *filename);
+int Getframe();
+void Setframe(int framenumber);
+float Gettime();
+int Settime(float timeval);
 
 // Non-Verified, the declarations below are of variable quality.
-int loadsmvall(const char *input_filepath);
-int loadsmv(char *input_filename, char *input_filename_ext);
-void renderclip(int flag, int left, int right, int bottom, int top);
-void gsliceview(int data, int show_triangles, int show_triangulation,
+int Loadsmvall(const char *input_filepath);
+int Loadsmv(char *input_filename, char *input_filename_ext);
+void Renderclip(int flag, int left, int right, int bottom, int top);
+void Gsliceview(int data, int show_triangles, int show_triangulation,
                 int show_normal);
 void ShowPlot3dData(int meshnumber, int plane_orientation, int display,
                     int showhide, float position, int isolevel);
-void gslicepos(float x, float y, float z);
-void gsliceorien(float az, float elev);
-void settourkeyframe(float keyframe_time);
-void settourview(int edittourArg, int mode, int show_tourlocusArg,
+void Gslicepos(float x, float y, float z);
+void Gsliceorien(float az, float elev);
+void Settourkeyframe(float keyframe_time);
+void Settourview(int edittourArg, int mode, int show_tourlocusArg,
                  float tour_global_tensionArg);
-int loadfile(const char *filename);
-void loadinifile(const char *filepath);
-int loadvfile(const char *filepath);
-void loadboundaryfile(const char *filepath);
-void loadboundary(const char *filepath);
-void label(const char *label);
-void load3dsmoke(const char *smoke_type);
-void set_slice_in_obst(int setting);
-int get_slice_in_obst();
-void loadvolsmoke(int meshnumber);
-void loadvolsmokeframe(int meshnumber, int framenumber, int flag);
-int set_rendertype(const char *type);
-int get_rendertype(void);
-void set_movietype(const char *type);
-int get_movietype(void);
-void makemovie(const char *name, const char *base, float framerate);
-int loadtour(const char *tourname);
-void loadparticles(const char *name);
-void partclasscolor(const char *color);
-void partclasstype(const char *part_type);
-void plot3dprops(int variable_index, int showvector, int vector_length_index,
+int Loadfile(const char *filename);
+void Loadinifile(const char *filepath);
+int Loadvfile(const char *filepath);
+void Loadboundaryfile(const char *filepath);
+void Loadboundary(const char *filepath);
+void Label(const char *label);
+void Load3dsmoke(const char *smoke_type);
+void SetSliceInObst(int setting);
+int GetSliceInObst();
+void Loadvolsmoke(int meshnumber);
+void Loadvolsmokeframe(int meshnumber, int framenumber, int flag);
+int SetRendertype(const char *type);
+int GetRendertype(void);
+void SetMovietype(const char *type);
+int GetMovietype(void);
+void Makemovie(const char *name, const char *base, float framerate);
+int Loadtour(const char *tourname);
+void Loadparticles(const char *name);
+void Partclasscolor(const char *color);
+void Partclasstype(const char *part_type);
+void Plot3dprops(int variable_index, int showvector, int vector_length_index,
                  int display_type, float vector_length);
-void loadplot3d(int meshnumber, float time_local);
-void loadiso(const char *type);
-void loadslice(const char *type, int axis, float distance);
-FILE_SIZE loadsliceindex(size_t index, int *errorcode);
-void loadvslice(const char *type, int axis, float distance);
-int unloadall();
-void unloadtour();
-void exit_smokeview();
-void setcolorbarflip(int flip);
-int getcolorbarflip();
-int setviewpoint(const char *viewpoint);
-int set_ortho_preset(const char *viewpoint);
-int setrenderdir(const char *dir);
-void setwindowsize(int width, int height);
-void setgridvisibility(int selection);
-void setgridparms(int x_vis, int y_vis, int z_vis, int x_plot, int y_plot,
+void Loadplot3d(int meshnumber, float time_local);
+void Loadiso(const char *type);
+void Loadslice(const char *type, int axis, float distance);
+FILE_SIZE Loadsliceindex(size_t index, int *errorcode);
+void Loadvslice(const char *type, int axis, float distance);
+int Unloadall();
+void Unloadtour();
+void ExitSmokeview();
+void Setcolorbarflip(int flip);
+int Getcolorbarflip();
+int Setviewpoint(const char *viewpoint);
+int SetOrthoPreset(const char *viewpoint);
+int Setrenderdir(const char *dir);
+void Setwindowsize(int width, int height);
+void Setgridvisibility(int selection);
+void Setgridparms(int x_vis, int y_vis, int z_vis, int x_plot, int y_plot,
                   int z_plot);
-void setcolorbarindex(int chosen_index);
-int getcolorbarindex();
-void camera_set_eyeview(int eyeview);
-void camera_set_rotation_index(int rotation_index);
-int camera_get_rotation_index();
+void Setcolorbarindex(int chosen_index);
+int Getcolorbarindex();
+void CameraSetEyeview(int eyeview);
+void CameraSetRotationIndex(int rotation_index);
+int CameraGetRotationIndex();
 
-void camera_set_rotation_type(int rotation_type);
-int camera_get_rotation_type();
+void CameraSetRotationType(int rotation_type);
+int CameraGetRotationType();
 
-void camera_set_view_id(int view_id);
+void CameraSetViewId(int view_id);
 // void viewpoint_set_viewdir(float xcen, float ycen, float zcen);
 
-void camera_mod_eyex(float delta);
-void camera_mod_eyey(float delta);
-void camera_mod_eyez(float delta);
+void CameraModEyex(float delta);
+void CameraModEyey(float delta);
+void CameraModEyez(float delta);
 
-void camera_set_eyex(float eyex);
-void camera_set_eyey(float eyey);
-void camera_set_eyez(float eyez);
+void CameraSetEyex(float eyex);
+void CameraSetEyey(float eyey);
+void CameraSetEyez(float eyez);
 
-float camera_get_eyex();
-float camera_get_eyey();
-float camera_get_eyez();
+float CameraGetEyex();
+float CameraGetEyey();
+float CameraGetEyez();
 
-void camera_mod_az(float delta);
-void camera_set_az(float az);
-float camera_get_az();
-int camera_zoom_to_fit();
-void camera_mod_elev(float delta);
-void camera_set_elev(float elev);
-float camera_get_elev();
+void CameraModAz(float delta);
+void CameraSetAz(float az);
+float CameraGetAz();
+int CameraZoomToFit();
+void CameraModElev(float delta);
+void CameraSetElev(float elev);
+float CameraGetElev();
 
-void camera_set_viewdir(float xcen, float ycen, float zcen);
-float camera_get_xcen();
-float camera_get_ycen();
-float camera_get_zcen();
-void camera_set_xcen(float xcen);
-void camera_set_ycen(float ycen);
-void camera_set_zcen(float zcen);
+void CameraSetViewdir(float xcen, float ycen, float zcen);
+float CameraGetXcen();
+float CameraGetYcen();
+float CameraGetZcen();
+void CameraSetXcen(float xcen);
+void CameraSetYcen(float ycen);
+void CameraSetZcen(float zcen);
 
-void camera_toggle_projection_type();
-int camera_set_projection_type(int projection_type);
-int camera_get_projection_type();
+void CameraToggleProjectionType();
+int CameraSetProjectionType(int projection_type);
+int CameraGetProjectionType();
 
-int get_clipping_mode();
-void set_clipping_mode(int mode);
-void set_sceneclip_x(int clipMin, float min, int clipMax, float max);
-void set_sceneclip_x_min(int flag, float value);
-void set_sceneclip_x_max(int flag, float value);
-void set_sceneclip_y(int clipMin, float min, int clipMax, float max);
-void set_sceneclip_y_min(int flag, float value);
-void set_sceneclip_y_max(int flag, float value);
-void set_sceneclip_z(int clipMin, float min, int clipMax, float max);
-void set_sceneclip_z_min(int flag, float value);
-void set_sceneclip_z_max(int flag, float value);
+int GetClippingMode();
+void SetClippingMode(int mode);
+void SetSceneclipX(int clipMin, float min, int clipMax, float max);
+void SetSceneclipXMin(int flag, float value);
+void SetSceneclipXMax(int flag, float value);
+void SetSceneclipY(int clipMin, float min, int clipMax, float max);
+void SetSceneclipYMin(int flag, float value);
+void SetSceneclipYMax(int flag, float value);
+void SetSceneclipZ(int clipMin, float min, int clipMax, float max);
+void SetSceneclipZMin(int flag, float value);
+void SetSceneclipZMax(int flag, float value);
 
 int RenderFrameLua(int view_mode, const char *basename);
-char *form_filename(int view_mode, char *renderfile_name, char *renderfile_dir,
+char *FormFilename(int view_mode, char *renderfile_name, char *renderfile_dir,
                     char *renderfile_path, int woffset, int hoffset,
                     int screenH, const char *basename);
 
-int parse_smv_filepath(const char *smv_filepath, char *fdsprefix,
+int ParseSmvFilepath(const char *smv_filepath, char *fdsprefix,
                        char *input_filename_ext);
 
 // --------- show/hide label options--------
 
 // colorbar
-void set_colorbar_visibility_vertical(int setting);
-int get_colorbar_visibility_vertical();
-void toggle_colorbar_visibility_vertical();
+void SetColorbarVisibilityVertical(int setting);
+int GetColorbarVisibilityVertical();
+void ToggleColorbarVisibilityVertical();
 
-void set_colorbar_visibility_horizontal(int setting);
-int get_colorbar_visibility_horizontal();
-void toggle_colorbar_visibility_horizontal();
+void SetColorbarVisibilityHorizontal(int setting);
+int GetColorbarVisibilityHorizontal();
+void ToggleColorbarVisibilityHorizontal();
 
-void set_colorbar_visibility(int setting);
-int get_colorbar_visibility();
-void toggle_colorbar_visibility();
+void SetColorbarVisibility(int setting);
+int GetColorbarVisibility();
+void ToggleColorbarVisibility();
 
 // timebar
-void set_timebar_visibility(int setting);
-int get_timebar_visibility();
-void toggle_timebar_visibility();
+void SetTimebarVisibility(int setting);
+int GetTimebarVisibility();
+void ToggleTimebarVisibility();
 
 // title
-void set_title_visibility(int setting);
-int get_title_visibility();
-void toggle_title_visibility();
+void SetTitleVisibility(int setting);
+int GetTitleVisibility();
+void ToggleTitleVisibility();
 
 // smv_version
-void set_smv_version_visibility(int setting);
-int get_smv_version_visibility();
-void toggle_smv_version_visibility();
+void SetSmvVersionVisibility(int setting);
+int GetSmvVersionVisibility();
+void ToggleSmvVersionVisibility();
 
 // chid
-void set_chid_visibility(int setting);
-int get_chid_visibility();
-void toggle_chid_visibility();
+void SetChidVisibility(int setting);
+int GetChidVisibility();
+void ToggleChidVisibility();
 
 // blockages
-void blockages_hide_all();
+void BlockagesHideAll();
 
 // outlines
-void outlines_hide();
-void outlines_show();
+void OutlinesHide();
+void OutlinesShow();
 
 // surfaces
-void surfaces_hide_all();
+void SurfacesHideAll();
 
 // devices
-void devices_hide_all();
+void DevicesHideAll();
 
 // axis
-void set_axis_visibility(int setting);
-int get_axis_visibility();
-void toggle_axis_visibility();
+void SetAxisVisibility(int setting);
+int GetAxisVisibility();
+void ToggleAxisVisibility();
 
 // frame
-void set_framelabel_visibility(int setting);
-int get_framelabel_visibility();
-void toggle_framelabel_visibility();
+void SetFramelabelVisibility(int setting);
+int GetFramelabelVisibility();
+void ToggleFramelabelVisibility();
 
 // framerate
-void set_framerate_visibility(int setting);
-int get_framerate_visibility();
-void toggle_framerate_visibility();
+void SetFramerateVisibility(int setting);
+int GetFramerateVisibility();
+void ToggleFramerateVisibility();
 
 // grid locations
-void set_gridloc_visibility(int setting);
-int get_gridloc_visibility();
-void toggle_gridloc_visibility();
+void SetGridlocVisibility(int setting);
+int GetGridlocVisibility();
+void ToggleGridlocVisibility();
 
 // hrrpuv cutoff
-void set_hrrcutoff_visibility(int setting);
-int get_hrrcutoff_visibility();
-void toggle_hrrcutoff_visibility();
+void SetHrrcutoffVisibility(int setting);
+int GetHrrcutoffVisibility();
+void ToggleHrrcutoffVisibility();
 
 // hrr label
-void set_hrrlabel_visibility(int setting);
-int get_hrrlabel_visibility();
-void toggle_hrrlabel_visibility();
+void SetHrrlabelVisibility(int setting);
+int GetHrrlabelVisibility();
+void ToggleHrrlabelVisibility();
 
 // memory load
 #ifdef pp_memstatus
@@ -226,347 +227,347 @@ void toggle_memload_visibility();
 #endif
 
 // mesh
-void set_meshlabel_visibility(int setting);
-int get_meshlabel_visibility();
-void toggle_meshlabel_visibility();
+void SetMeshlabelVisibility(int setting);
+int GetMeshlabelVisibility();
+void ToggleMeshlabelVisibility();
 
 // slice average
-void set_slice_average_visibility(int setting);
-int get_slice_average_visibility();
-void toggle_slice_average_visibility();
+void SetSliceAverageVisibility(int setting);
+int GetSliceAverageVisibility();
+void ToggleSliceAverageVisibility();
 
 // time
-void set_time_visibility(int setting);
-int get_time_visibility();
-void toggle_time_visibility();
+void SetTimeVisibility(int setting);
+int GetTimeVisibility();
+void ToggleTimeVisibility();
 
 // user settable ticks
-void set_user_ticks_visibility(int setting);
-int get_user_ticks_visibility();
-void toggle_user_ticks_visibility();
+void SetUserTicksVisibility(int setting);
+int GetUserTicksVisibility();
+void ToggleUserTicksVisibility();
 
 // version info
-void set_version_info_visibility(int setting);
-int get_version_info_visibility();
-void toggle_version_info_visibility();
+void SetVersionInfoVisibility(int setting);
+int GetVersionInfoVisibility();
+void ToggleVersionInfoVisibility();
 
 // set all
-void set_all_label_visibility(int setting);
+void SetAllLabelVisibility(int setting);
 
 // --------- options--------
 
 // Display Units
 // time
-void set_timehms(int setting);
-int get_timehms();
-void toggle_timehms();
+void SetTimehms(int setting);
+int GetTimehms();
+void ToggleTimehms();
 
 // arbitrary
-void set_units(int unitclass, int unit_index);
-void set_units_default();
-void set_unitclass_default(int unitclass);
+void SetUnits(int unitclass, int unit_index);
+void SetUnitsDefault();
+void SetUnitclassDefault(int unitclass);
 
-int blockage_view_method(int setting);
-int blockage_outline_color(int setting);
-int blockage_locations(int setting);
+int BlockageViewMethod(int setting);
+int BlockageOutlineColor(int setting);
+int BlockageLocations(int setting);
 
 // .ini config options
-int set_ambientlight(float r, float g, float b);    // AMBIENTLIGHT
-int set_backgroundcolor(float r, float g, float b); // BACKGROUNDCOLOR
-int set_blockcolor(float r, float g, float b);      // BLOCKCOLOR
-int set_blockshininess(float v);                    // BLOCKSHININESS
-int set_blockspecular(float r, float g, float b);   // BLOCKSPECULAR
-int set_boundcolor(float r, float g, float b);      // BOUNDCOLOR
-int set_colorbar_textureflag(int v);
-int get_colorbar_textureflag();
-int set_colorbar_contourvalue(int v);
-int set_colorbar_colors(int ncolors, float *colors);
-int set_color2bar_colors(int ncolors, float *colors);
-int set_diffuselight(float r, float g, float b);   // DIFFUSELIGHT
-int set_directioncolor(float r, float g, float b); // DIRECTIONCOLOR
-int set_flip(int setting);                         // FLIP
-int get_flip();
-int set_foregroundcolor(float r, float g, float b); // FOREGROUNDCOLOR
-int set_heatoffcolor(float r, float g, float b);    // HEATOFFCOLOR
-int set_heatoncolor(float r, float g, float b);     // HEATONCOLOR
-int set_isocolors(float shininess, float transparency, int transparency_option,
+int SetAmbientlight(float r, float g, float b);    // AMBIENTLIGHT
+int SetBackgroundcolor(float r, float g, float b); // BACKGROUNDCOLOR
+int SetBlockcolor(float r, float g, float b);      // BLOCKCOLOR
+int SetBlockshininess(float v);                    // BLOCKSHININESS
+int SetBlockspecular(float r, float g, float b);   // BLOCKSPECULAR
+int SetBoundcolor(float r, float g, float b);      // BOUNDCOLOR
+int SetColorbarTextureflag(int v);
+int GetColorbarTextureflag();
+int SetColorbarContourvalue(int v);
+int SetColorbarColors(int ncolors, float *colors);
+int SetColor2barColors(int ncolors, float *colors);
+int SetDiffuselight(float r, float g, float b);   // DIFFUSELIGHT
+int SetDirectioncolor(float r, float g, float b); // DIRECTIONCOLOR
+int SetFlip(int setting);                         // FLIP
+int GetFlip();
+int SetForegroundcolor(float r, float g, float b); // FOREGROUNDCOLOR
+int SetHeatoffcolor(float r, float g, float b);    // HEATOFFCOLOR
+int SetHeatoncolor(float r, float g, float b);     // HEATONCOLOR
+int SetIsocolors(float shininess, float transparency, int transparency_option,
                   int opacity_change, float specular[3], int n_colors,
                   float colors[][4]);
-int set_colortable(int ncolors, int colors[][4], char **names);
-int set_lightpos0(float x, float y, float z, float w); // LIGHTPOS0
-int set_lightpos1(float x, float y, float z, float w); // LIGHTPOS1
-int set_sensorcolor(float r, float g, float b);        // SENSORCOLOR
-int set_sensornormcolor(float r, float g, float b);    // SENSORNORMCOLOR
-int set_bw(int geo_setting, int data_setting);         // SETBW
-int set_sprinkleroffcolor(float r, float g, float b);  // SPRINKOFFCOLOR
-int set_sprinkleroncolor(float r, float g, float b);   // SPRINKONCOLOR
-int set_staticpartcolor(float r, float g, float b);    // STATICPARTCOLOR
-int set_timebarcolor(float r, float g, float b);       // TIMEBARCOLOR
-int set_ventcolor(float r, float g, float b);          // VENTCOLOR
+int SetColortable(int ncolors, int colors[][4], char **names);
+int SetLightpos0(float x, float y, float z, float w); // LIGHTPOS0
+int SetLightpos1(float x, float y, float z, float w); // LIGHTPOS1
+int SetSensorcolor(float r, float g, float b);        // SENSORCOLOR
+int SetSensornormcolor(float r, float g, float b);    // SENSORNORMCOLOR
+int SetBw(int geo_setting, int data_setting);         // SETBW
+int SetSprinkleroffcolor(float r, float g, float b);  // SPRINKOFFCOLOR
+int SetSprinkleroncolor(float r, float g, float b);   // SPRINKONCOLOR
+int SetStaticpartcolor(float r, float g, float b);    // STATICPARTCOLOR
+int SetTimebarcolor(float r, float g, float b);       // TIMEBARCOLOR
+int SetVentcolor(float r, float g, float b);          // VENTCOLOR
 
 // --    *** SIZES/OFFSETS ***
 
-int set_gridlinewidth(float v);    // GRIDLINEWIDTH
-int set_isolinewidth(float v);     // ISOLINEWIDTH
-int set_isopointsize(float v);     // ISOPOINTSIZE
-int set_linewidth(float v);        // LINEWIDTH
-int set_partpointsize(float v);    // PARTPOINTSIZE
-int set_plot3dlinewidth(float v);  // PLOT3DLINEWIDTH
-int set_plot3dpointsize(float v);  // PLOT3DPOINTSIZE
-int set_sensorabssize(float v);    // SENSORABSSIZE
-int set_sensorrelsize(float v);    // SENSORRELSIZE
-int set_sliceoffset(float v);      // SLICEOFFSET
-int set_smoothlines(int v);        // SMOOTHLINES
-int set_spheresegs(int v);         // SPHERESEGS
-int set_sprinklerabssize(float v); // SPRINKLERABSSIZE
-int set_streaklinewidth(float v);  // STREAKLINEWIDTH
-int set_ticklinewidth(float v);    // TICKLINEWIDTH
-int set_usenewdrawface(int v);     // USENEWDRAWFACE
-int set_veclength(float vf, int vec_uniform_length_in,
+int SetGridlinewidth(float v);    // GRIDLINEWIDTH
+int SetIsolinewidth(float v);     // ISOLINEWIDTH
+int SetIsopointsize(float v);     // ISOPOINTSIZE
+int SetLinewidth(float v);        // LINEWIDTH
+int SetPartpointsize(float v);    // PARTPOINTSIZE
+int SetPlot3dlinewidth(float v);  // PLOT3DLINEWIDTH
+int SetPlot3dpointsize(float v);  // PLOT3DPOINTSIZE
+int SetSensorabssize(float v);    // SENSORABSSIZE
+int SetSensorrelsize(float v);    // SENSORRELSIZE
+int SetSliceoffset(float v);      // SLICEOFFSET
+int SetSmoothlines(int v);        // SMOOTHLINES
+int SetSpheresegs(int v);         // SPHERESEGS
+int SetSprinklerabssize(float v); // SPRINKLERABSSIZE
+int SetStreaklinewidth(float v);  // STREAKLINEWIDTH
+int SetTicklinewidth(float v);    // TICKLINEWIDTH
+int SetUsenewdrawface(int v);     // USENEWDRAWFACE
+int SetVeclength(float vf, int vec_uniform_length_in,
                   int vec_uniform_spacing_in); // VECLENGTH
-int set_vectorlinewidth(float a, float b);     // VECTORLINEWIDTH
-int set_vectorpointsize(float v);              // VECTORPOINTSIZE
-int set_ventlinewidth(float v);                // VENTLINEWIDTH
-int set_ventoffset(float v);                   // VENTOFFSET
-int set_windowoffset(int v);                   // WINDOWOFFSET
-int set_windowwidth(int v);                    // WINDOWWIDTH
-int set_windowheight(int v);                   // WINDOWHEIGHT
+int SetVectorlinewidth(float a, float b);     // VECTORLINEWIDTH
+int SetVectorpointsize(float v);              // VECTORPOINTSIZE
+int SetVentlinewidth(float v);                // VENTLINEWIDTH
+int SetVentoffset(float v);                   // VENTOFFSET
+int SetWindowoffset(int v);                   // WINDOWOFFSET
+int SetWindowwidth(int v);                    // WINDOWWIDTH
+int SetWindowheight(int v);                   // WINDOWHEIGHT
 
 // --  *** DATA LOADING ***
 
-int set_boundzipstep(int v);           // BOUNDZIPSTEP
-int set_fed(int v);                    // FED
-int set_fedcolorbar(const char *name); // FEDCOLORBAR
-int set_isozipstep(int v);             // ISOZIPSTEP
-int set_nopart(int v);                 // NOPART
+int SetBoundzipstep(int v);           // BOUNDZIPSTEP
+int SetFed(int v);                    // FED
+int SetFedcolorbar(const char *name); // FEDCOLORBAR
+int SetIsozipstep(int v);             // ISOZIPSTEP
+int SetNopart(int v);                 // NOPART
 // int set_partpointstep(int v); // PARTPOINTSTEP
-int set_showfedarea(int v);                              // SHOWFEDAREA
-int set_sliceaverage(int flag, float interval, int vis); // SLICEAVERAGE
-int set_slicedataout(int v);                             // SLICEDATAOUT
-int set_slicezipstep(int v);                             // SLICEZIPSTEP
-int set_smoke3dzipstep(int v);                           // SMOKE3DZIPSTEP
-int set_userrotate(int index, int show_center, float x, float y,
+int SetShowfedarea(int v);                              // SHOWFEDAREA
+int SetSliceaverage(int flag, float interval, int vis); // SLICEAVERAGE
+int SetSlicedataout(int v);                             // SLICEDATAOUT
+int SetSlicezipstep(int v);                             // SLICEZIPSTEP
+int SetSmoke3dzipstep(int v);                           // SMOKE3DZIPSTEP
+int SetUserrotate(int index, int show_center, float x, float y,
                    float z); // USER_ROTATE
 
 // --  *** VIEW PARAMETERS ***
 
-int set_aperture(int v); // APERTURE
+int SetAperture(int v); // APERTURE
 // int set_axissmooth(int v); // AXISSMOOTH
-int set_blocklocation(int v);        // BLOCKLOCATION
-int set_boundarytwoside(int v);      // BOUNDARYTWOSIDE
-int set_clip(float near, float far); // CLIP
-int set_contourtype(int v);          // CONTOURTYPE
-int set_cullfaces(int v);            // CULLFACES
-int set_texturelighting(int v);      // ENABLETEXTURELIGHTING
-int set_eyeview(int v);              // EYEVIEW
-int set_eyex(float v);               // EYEX
-int set_eyey(float v);               // EYEY
-int set_eyez(float v);               // EYEZ
-int set_fontsize(int v);             // FONTSIZE
-int set_frameratevalue(int v);       // FRAMERATEVALUE
+int SetBlocklocation(int v);        // BLOCKLOCATION
+int SetBoundarytwoside(int v);      // BOUNDARYTWOSIDE
+int SetClip(float near, float far); // CLIP
+int SetContourtype(int v);          // CONTOURTYPE
+int SetCullfaces(int v);            // CULLFACES
+int SetTexturelighting(int v);      // ENABLETEXTURELIGHTING
+int SetEyeview(int v);              // EYEVIEW
+int SetEyex(float v);               // EYEX
+int SetEyey(float v);               // EYEY
+int SetEyez(float v);               // EYEZ
+int SetFontsize(int v);             // FONTSIZE
+int SetFrameratevalue(int v);       // FRAMERATEVALUE
 // GEOMSHOW
-int set_showfaces_interior(int v);
-int set_showfaces_exterior(int v);
-int set_showfaces_solid(int v);
-int set_showfaces_outline(int v);
-int set_smoothgeomnormal(int v);
-int set_geomvertexag(int v);
-int set_geommaxangle(int v);
-int set_gversion(int v);                                // GVERSION
-int set_isotran2(int v);                                // ISOTRAN2
-int set_meshvis(int n, int vals[]);                     // MESHVIS
-int set_meshoffset(int meshnum, int value);             // MESHOFFSET
-int set_northangle(int vis, float x, float y, float z); // NORTHANGLE
-int set_offsetslice(int v);                             // OFFSETSLICE
-int set_outlinemode(int a, int b);                      // OUTLINEMODE
-int set_p3dsurfacetype(int v);                          // P3DSURFACETYPE
-int set_p3dsurfacesmooth(int v);                        // P3DSURFACESMOOTH
-int set_sbatstart(int v);                               // SBATSTART
-int set_scaledfont(int height2d, float height2dwidth, int thickness2d,
+int SetShowfacesInterior(int v);
+int SetShowfacesExterior(int v);
+int SetShowfacesSolid(int v);
+int SetShowfacesOutline(int v);
+int SetSmoothgeomnormal(int v);
+int SetGeomvertexag(int v);
+int SetGeommaxangle(int v);
+int SetGversion(int v);                                // GVERSION
+int SetIsotran2(int v);                                // ISOTRAN2
+int SetMeshvis(int n, int vals[]);                     // MESHVIS
+int SetMeshoffset(int meshnum, int value);             // MESHOFFSET
+int SetNorthangle(int vis, float x, float y, float z); // NORTHANGLE
+int SetOffsetslice(int v);                             // OFFSETSLICE
+int SetOutlinemode(int a, int b);                      // OUTLINEMODE
+int SetP3dsurfacetype(int v);                          // P3DSURFACETYPE
+int SetP3dsurfacesmooth(int v);                        // P3DSURFACESMOOTH
+int SetSbatstart(int v);                               // SBATSTART
+int SetScaledfont(int height2d, float height2dwidth, int thickness2d,
                    int height3d, float height3dwidth,
                    int thickness3d); // SCALEDFONT
-int get_scaledfont_height2d();
-int set_scaledfont_height2d(int height2d);
-int set_showalltextures(int v);      // SHOWALLTEXTURES
-int set_showaxislabels(int v);       // SHOWAXISLABELS
-int set_showblocklabel(int v);       // SHOWBLOCKLABEL
-int set_showblocks(int v);           // SHOWBLOCKS
-int set_showcadandgrid(int v);       // SHOWCADANDGRID
-int set_showcadopaque(int v);        // SHOWCADOPAQUE
-int set_showceiling(int v);          // SHOWCEILING
-int set_showcolorbars(int v);        // SHOWCOLORBARS
-int set_showcvents(int a, int b);    // SHOWCVENTS
-int set_showdummyvents(int v);       // SHOWDUMMYVENTS
-int set_showfloor(int v);            // SHOWFLOOR
-int set_showframe(int v);            // SHOWFRAME
-int set_showframelabel(int v);       // SHOWFRAMELABEL
-int set_showframerate(int v);        // SHOWFRAMERATE
-int set_showgrid(int v);             // SHOWGRID
-int set_showgridloc(int v);          // SHOWGRIDLOC
-int set_showhmstimelabel(int v);     // SHOWHMSTIMELABEL
-int set_showhrrcutoff(int v);        // SHOWHRRCUTOFF
-int set_showiso(int v);              // SHOWISO
-int set_showisonormals(int v);       // SHOWISONORMALS
-int set_showlabels(int v);           // SHOWLABELS
-int set_showmemload(int v);          // SHOWMEMLOAD
-int set_shownormalwhensmooth(int v); // SHOWNORMALWHENSMOOTH
-int set_showopenvents(int a, int b); // SHOWOPENVENTS
-int set_showothervents(int v);       // SHOWOTHERVENTS
-int set_showsensors(int a, int b);   // SHOWSENSORS
-int set_showsliceinobst(int v);      // SHOWSLICEINOBST
-int set_showsmokepart(int v);        // SHOWSMOKEPART
-int set_showsprinkpart(int v);       // SHOWSPRINKPART
-int set_showstreak(int show, int step, int showhead, int index); // SHOWSTREAK
-int set_showterrain(int v);                                      // SHOWTERRAIN
-int set_showthreshold(int a, int b, float c); // SHOWTHRESHOLD
-int set_showticks(int v);                     // SHOWTICKS
-int set_showtimebar(int v);                   // SHOWTIMEBAR
-int set_showtimelabel(int v);                 // SHOWTIMELABEL
-int set_showtitle(int v);                     // SHOWTITLE
-int set_showtracersalways(int v);             // SHOWTRACERSALWAYS
-int set_showtriangles(int a, int b, int c, int d, int e,
+int GetScaledfontHeight2d();
+int SetScaledfontHeight2d(int height2d);
+int SetShowalltextures(int v);      // SHOWALLTEXTURES
+int SetShowaxislabels(int v);       // SHOWAXISLABELS
+int SetShowblocklabel(int v);       // SHOWBLOCKLABEL
+int SetShowblocks(int v);           // SHOWBLOCKS
+int SetShowcadandgrid(int v);       // SHOWCADANDGRID
+int SetShowcadopaque(int v);        // SHOWCADOPAQUE
+int SetShowceiling(int v);          // SHOWCEILING
+int SetShowcolorbars(int v);        // SHOWCOLORBARS
+int SetShowcvents(int a, int b);    // SHOWCVENTS
+int SetShowdummyvents(int v);       // SHOWDUMMYVENTS
+int SetShowfloor(int v);            // SHOWFLOOR
+int SetShowframe(int v);            // SHOWFRAME
+int SetShowframelabel(int v);       // SHOWFRAMELABEL
+int SetShowframerate(int v);        // SHOWFRAMERATE
+int SetShowgrid(int v);             // SHOWGRID
+int SetShowgridloc(int v);          // SHOWGRIDLOC
+int SetShowhmstimelabel(int v);     // SHOWHMSTIMELABEL
+int SetShowhrrcutoff(int v);        // SHOWHRRCUTOFF
+int SetShowiso(int v);              // SHOWISO
+int SetShowisonormals(int v);       // SHOWISONORMALS
+int SetShowlabels(int v);           // SHOWLABELS
+int SetShowmemload(int v);          // SHOWMEMLOAD
+int SetShownormalwhensmooth(int v); // SHOWNORMALWHENSMOOTH
+int SetShowopenvents(int a, int b); // SHOWOPENVENTS
+int SetShowothervents(int v);       // SHOWOTHERVENTS
+int SetShowsensors(int a, int b);   // SHOWSENSORS
+int SetShowsliceinobst(int v);      // SHOWSLICEINOBST
+int SetShowsmokepart(int v);        // SHOWSMOKEPART
+int SetShowsprinkpart(int v);       // SHOWSPRINKPART
+int SetShowstreak(int show, int step, int showhead, int index); // SHOWSTREAK
+int SetShowterrain(int v);                                      // SHOWTERRAIN
+int SetShowthreshold(int a, int b, float c); // SHOWTHRESHOLD
+int SetShowticks(int v);                     // SHOWTICKS
+int SetShowtimebar(int v);                   // SHOWTIMEBAR
+int SetShowtimelabel(int v);                 // SHOWTIMELABEL
+int SetShowtitle(int v);                     // SHOWTITLE
+int SetShowtracersalways(int v);             // SHOWTRACERSALWAYS
+int SetShowtriangles(int a, int b, int c, int d, int e,
                       int f);                            // SHOWTRIANGLES
-int set_showtransparent(int v);                          // SHOWTRANSPARENT
-int set_showtransparentvents(int v);                     // SHOWTRANSPARENTVENTS
-int set_showtrianglecount(int v);                        // SHOWTRIANGLECOUNT
-int set_showventflow(int a, int b, int c, int d, int e); // SHOWVENTFLOW
-int set_showvents(int v);                                // SHOWVENTS
-int set_showwalls(int v);                                // SHOWWALLS
-int set_skipembedslice(int v);                           // SKIPEMBEDSLICE
-int set_smokesensors(int a, int b);                      // SMOKESENSORS
-int set_smoothblocksolid(int v);                         // SMOOTHBLOCKSOLID
-int set_startuplang(const char *lang);                   // STARTUPLANG
-int set_stereo(int v);                                   // STEREO
-int set_surfinc(int v);                                  // SURFINC
-int set_terrainparams(int r_min, int g_min, int b_min, int r_max, int g_max,
+int SetShowtransparent(int v);                          // SHOWTRANSPARENT
+int SetShowtransparentvents(int v);                     // SHOWTRANSPARENTVENTS
+int SetShowtrianglecount(int v);                        // SHOWTRIANGLECOUNT
+int SetShowventflow(int a, int b, int c, int d, int e); // SHOWVENTFLOW
+int SetShowvents(int v);                                // SHOWVENTS
+int SetShowwalls(int v);                                // SHOWWALLS
+int SetSkipembedslice(int v);                           // SKIPEMBEDSLICE
+int SetSmokesensors(int a, int b);                      // SMOKESENSORS
+int SetSmoothblocksolid(int v);                         // SMOOTHBLOCKSOLID
+int SetStartuplang(const char *lang);                   // STARTUPLANG
+int SetStereo(int v);                                   // STEREO
+int SetSurfinc(int v);                                  // SURFINC
+int SetTerrainparams(int r_min, int g_min, int b_min, int r_max, int g_max,
                       int b_max, int v);                      // TERRAINPARMS
-int set_titlesafe(int v);                                     // TITLESAFE
-int set_trainermode(int v);                                   // TRAINERMODE
-int set_trainerview(int v);                                   // TRAINERVIEW
-int set_transparent(int a, float b);                          // TRANSPARENT
-int set_treeparms(int minsize, int visx, int visy, int visz); // TREEPARMS
-int set_twosidedvents(int internal, int external);            // TWOSIDEDVENTS
-int set_vectorskip(int v);                                    // VECTORSKIP
-int set_volsmoke(int a, int b, int c, int d, int e, float f, float g, float h,
+int SetTitlesafe(int v);                                     // TITLESAFE
+int SetTrainermode(int v);                                   // TRAINERMODE
+int SetTrainerview(int v);                                   // TRAINERVIEW
+int SetTransparent(int a, float b);                          // TRANSPARENT
+int SetTreeparms(int minsize, int visx, int visy, int visz); // TREEPARMS
+int SetTwosidedvents(int internal, int external);            // TWOSIDEDVENTS
+int SetVectorskip(int v);                                    // VECTORSKIP
+int SetVolsmoke(int a, int b, int c, int d, int e, float f, float g, float h,
                  float i, float j, float k, float l); // VOLSMOKE
-int set_zoom(int a, float b);                         // ZOOM
+int SetZoom(int a, float b);                         // ZOOM
 
 // --  *** MISC ***
 
-int set_cellcentertext(int v);                     // CELLCENTERTEXT
-int set_inputfile(const char *filename);           // INPUT_FILE
-int set_labelstartupview(const char *startupview); // LABELSTARTUPVIEW
+int SetCellcentertext(int v);                     // CELLCENTERTEXT
+int SetInputfile(const char *filename);           // INPUT_FILE
+int SetLabelstartupview(const char *startupview); // LABELSTARTUPVIEW
 // int set_pixelskip(int v); // PIXELSKIP
-int set_renderclip(int a, int b, int c, int d, int e); // RENDERCLIP
+int SetRenderclip(int a, int b, int c, int d, int e); // RENDERCLIP
 // int set_renderfilelabel(int v); // RENDERFILELABEL
-int set_renderfiletype(int a, int b); // RENDERFILETYPE
+int SetRenderfiletype(int a, int b); // RENDERFILETYPE
 // int set_renderoption(int a, int b); // RENDEROPTION
-int set_unitclasses(int n, int values[]); // UNITCLASSES
-int set_zaxisangles(float a, float b, float c);
+int SetUnitclasses(int n, int values[]); // UNITCLASSES
+int SetZaxisangles(float a, float b, float c);
 
 // --  *** 3D SMOKE INFO ***
 
-int set_colorbartype(int v, const char *label); // COLORBARTYPE
-int set_extremecolors(int a, int b, int c, int d, int e,
+int SetColorbartype(int v, const char *label); // COLORBARTYPE
+int SetExtremecolors(int a, int b, int c, int d, int e,
                       int f);                 // EXTREMECOLORS
-int set_firecolor(int r, int g, int b);       // FIRECOLOR
-int set_firecolormap(int a, int b);           // FIRECOLORMAP
-int set_firedepth(float v);                   // FIREDEPTH
-int set_showextremedata(int a, int b, int c); // SHOWEXTREMEDATA
-int set_smokecolor(int r, int g, int b);      // SMOKECOLOR
-int set_smokecull(int v);                     // SMOKECULL
-int set_smokeskip(int v);                     // SMOKESKIP
-int set_smokealbedo(float v);                 // SMOKEALBEDO
-int set_smokerthick(float v);                 // SMOKERTHICK
+int SetFirecolor(int r, int g, int b);       // FIRECOLOR
+int SetFirecolormap(int a, int b);           // FIRECOLORMAP
+int SetFiredepth(float v);                   // FIREDEPTH
+int SetShowextremedata(int a, int b, int c); // SHOWEXTREMEDATA
+int SetSmokecolor(int r, int g, int b);      // SMOKECOLOR
+int SetSmokecull(int v);                     // SMOKECULL
+int SetSmokeskip(int v);                     // SMOKESKIP
+int SetSmokealbedo(float v);                 // SMOKEALBEDO
+int SetSmokerthick(float v);                 // SMOKERTHICK
 // int set_smokethick(float v); // SMOKETHICK
-int set_usegpu(int v); // USEGPU
+int SetUsegpu(int v); // USEGPU
 
 // --  *** ZONE FIRE PARAMETRES ***
 
-int set_showhazardcolors(int v); // SHOWHAZARDCOLORS
-int set_showhzone(int v);        // SHOWHZONE
-int set_showszone(int v);        // SHOWSZONE
-int set_showvzone(int v);        // SHOWVZONE
-int set_showzonefire(int v);     // SHOWZONEFIRE
+int SetShowhazardcolors(int v); // SHOWHAZARDCOLORS
+int SetShowhzone(int v);        // SHOWHZONE
+int SetShowszone(int v);        // SHOWSZONE
+int SetShowvzone(int v);        // SHOWVZONE
+int SetShowzonefire(int v);     // SHOWZONEFIRE
 
 // --  *** TOUR INFO ***
 
-int set_showpathnodes(int v); // SHOWPATHNODES
-int set_showtourroute(int v); // SHOWTOURROUTE
+int SetShowpathnodes(int v); // SHOWPATHNODES
+int SetShowtourroute(int v); // SHOWTOURROUTE
 
 // TOURCOLORS
-int set_tourcolors_selectedpathline(float r, float g, float b);
-int set_tourcolors_selectedpathlineknots(float r, float g, float b);
-int set_tourcolors_selectedknot(float r, float g, float b);
-int set_tourcolors_pathline(float r, float g, float b);
-int set_tourcolors_pathknots(float r, float g, float b);
-int set_tourcolors_text(float r, float g, float b);
-int set_tourcolors_avatar(float r, float g, float b);
+int SetTourcolorsSelectedpathline(float r, float g, float b);
+int SetTourcolorsSelectedpathlineknots(float r, float g, float b);
+int SetTourcolorsSelectedknot(float r, float g, float b);
+int SetTourcolorsPathline(float r, float g, float b);
+int SetTourcolorsPathknots(float r, float g, float b);
+int SetTourcolorsText(float r, float g, float b);
+int SetTourcolorsAvatar(float r, float g, float b);
 
-int set_viewalltours(int v);                // VIEWALLTOURS
-int set_viewtimes(float a, float b, int c); // VIEWTIMES
-int set_viewtourfrompath(int v);            // VIEWTOURFROMPATH
+int SetViewalltours(int v);                // VIEWALLTOURS
+int SetViewtimes(float a, float b, int c); // VIEWTIMES
+int SetViewtourfrompath(int v);            // VIEWTOURFROMPATH
 
 // --  ------------ local ini settings ------------
 
-int set_avatarevac(int v); // AVATAREVAC
-int set_devicevectordimensions(float baselength, float basediameter,
+int SetAvatarevac(int v); // AVATAREVAC
+int SetDevicevectordimensions(float baselength, float basediameter,
                                float headlength,
                                float headdiameter); // DEVICEVECTORDIMENSIONS
-int set_devicebounds(float a, float b);             // DEVICEBOUNDS
-int set_deviceorientation(int a, float b);          // DEVICEORIENTATION
-int set_gridparms(int vx, int vy, int vz, int px, int py, int pz); // GRIDPARMS
-int set_gsliceparms(int vis_data, int vis_triangles, int vis_triangulation,
+int SetDevicebounds(float a, float b);             // DEVICEBOUNDS
+int SetDeviceorientation(int a, float b);          // DEVICEORIENTATION
+int SetGridparms(int vx, int vy, int vz, int px, int py, int pz); // GRIDPARMS
+int SetGsliceparms(int vis_data, int vis_triangles, int vis_triangulation,
                     int vis_normal, float xyz[], float azelev[]); // GSLICEPARMS
-int set_loadfilesatstartup(int v);         // LOADFILESATSTARTUP
-int set_mscale(float a, float b, float c); // MSCALE
-int set_sliceauto(int n, int vals[]);      // SLICEAUTO
-int set_msliceauto(int n, int vals[]);     // MSLICEAUTO
-int set_compressauto(int v);               // COMPRESSAUTO
-int set_part5propdisp(int vals[]);         // PART5PROPDISP
-int set_part5color(int v);                 // PART5COLOR
-int set_propindex(int nvals, int *vals);   // PROPINDEX
-int set_shooter(float xyz[], float dxyz[], float uvw[], float velmag,
+int SetLoadfilesatstartup(int v);         // LOADFILESATSTARTUP
+int SetMscale(float a, float b, float c); // MSCALE
+int SetSliceauto(int n, int vals[]);      // SLICEAUTO
+int SetMsliceauto(int n, int vals[]);     // MSLICEAUTO
+int SetCompressauto(int v);               // COMPRESSAUTO
+int SetPart5propdisp(int vals[]);         // PART5PROPDISP
+int SetPart5color(int v);                 // PART5COLOR
+int SetPropindex(int nvals, int *vals);   // PROPINDEX
+int SetShooter(float xyz[], float dxyz[], float uvw[], float velmag,
                 float veldir, float pointsize, int fps, int vel_type,
                 int nparts, int vis, int cont_update, float duration,
                 float v_inf);                         // SHOOTER
-int set_showdevices(int n, const char *const *names); // SHOWDEVICES
-int set_showdevicevals(int showdeviceval, int showvdeviceval,
+int SetShowdevices(int n, const char *const *names); // SHOWDEVICES
+int SetShowdevicevals(int showdeviceval, int showvdeviceval,
                        int devicetypes_index, int colordeviceval,
                        int vectortype, int vispilot, int showdevicetype,
                        int showdeviceunit); // SHOWDEVICEVALS
-int set_showmissingobjects(int v);          // SHOWMISSINGOBJECTS
-int set_tourindex(int v);                   // TOURINDEX
-int set_userticks(int vis, int auto_place, int sub, float origin[], float min[],
+int SetShowmissingobjects(int v);          // SHOWMISSINGOBJECTS
+int SetTourindex(int v);                   // TOURINDEX
+int SetUserticks(int vis, int auto_place, int sub, float origin[], float min[],
                   float max[], float step[], int show_x, int show_y,
                   int show_z); // USERTICKS
-int set_c_particles(int minFlag, float minValue, int maxFlag, float maxValue,
+int SetCParticles(int minFlag, float minValue, int maxFlag, float maxValue,
                     const char *label); // C_PARTICLES
-int set_c_slice(int minFlag, float minValue, int maxFlag, float maxValue,
+int SetCSlice(int minFlag, float minValue, int maxFlag, float maxValue,
                 const char *label);      // C_SLICE
-int set_cache_boundarydata(int setting); // CACHE_BOUNDARYDATA
-int set_cache_qdata(int setting);        // CACHE_QDATA
-int set_percentilelevel(float percentile_level_min,
+int SetCacheBoundarydata(int setting); // CACHE_BOUNDARYDATA
+int SetCacheQdata(int setting);        // CACHE_QDATA
+int SetPercentilelevel(float percentile_level_min,
                         float p_level_max); // PERCENTILELEVEL
-int set_timeoffset(int setting);            // TIMEOFFSET
-int set_patchdataout(int outputFlag, float tmin, float tmax, float xmin,
+int SetTimeoffset(int setting);            // TIMEOFFSET
+int SetPatchdataout(int outputFlag, float tmin, float tmax, float xmin,
                      float xmax, float ymin, float ymax, float zmin,
                      float zmax); // PATCHDATAOUT
-int set_c_plot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
+int SetCPlot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
                  int maxVals[]); // C_PLOT3D
-int set_v_plot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
+int SetVPlot3d(int n3d, int minFlags[], int minVals[], int maxFlags[],
                  int maxVals[]); // V_PLOT3D
-int set_pl3d_bound_min(int pl3dValueIndex, int set, float value);
-int set_pl3d_bound_max(int pl3dValueIndex, int set, float value);
-int set_tload(int beginFlag, float beginVal, int endFlag, int endVal,
+int SetPl3dBoundMin(int pl3dValueIndex, int set, float value);
+int SetPl3dBoundMax(int pl3dValueIndex, int set, float value);
+int SetTload(int beginFlag, float beginVal, int endFlag, int endVal,
               int skipFlag, int skipVal); // TLOAD
-int set_v5_particles(int minFlag, float minValue, int maxFlag, float maxValue,
+int SetV5Particles(int minFlag, float minValue, int maxFlag, float maxValue,
                      const char *label); // V5_PARTICLES
-int set_v_particles(int minFlag, float minValue, int maxFlag, float maxValue);
+int SetVParticles(int minFlag, float minValue, int maxFlag, float maxValue);
 // V_PARTICLES
-int set_v_target(int minFlag, float minValue, int maxFlag, float maxValue);
+int SetVTarget(int minFlag, float minValue, int maxFlag, float maxValue);
 // V_TARGET
-int set_v_slice(int minFlag, float minValue, int maxFlag, float maxValue,
+int SetVSlice(int minFlag, float minValue, int maxFlag, float maxValue,
                 const char *label, float lineMin, float lineMax,
                 int lineNum); // V_SLICE
 // -- VIEWPOINT5
@@ -583,10 +584,10 @@ int set_v_slice(int minFlag, float minValue, int maxFlag, float maxValue,
 // --  -0.424000 -1.204000 -0.016000 424.424011 203.203995 5.193398
 // --  topDown
 
-int show_smoke3d_showall();
-int show_smoke3d_hideall();
-int show_slices_showall();
-int show_slices_hideall();
+int ShowSmoke3dShowall();
+int ShowSmoke3dHideall();
+int ShowSlicesShowall();
+int ShowSlicesHideall();
 int RenderFrameLuaVar(int view_mode, gdImagePtr *RENDERimage);
 
 #define PROPINDEX_STRIDE 2

--- a/Source/smokeview/callbacks.c
+++ b/Source/smokeview/callbacks.c
@@ -3897,11 +3897,11 @@ void DoStereo(void){
 void DoScriptLua(void){
   int script_return_code;
   if(runluascript == 1){
-    if(strlen(luascript_filename)>0) load_script(luascript_filename);
+    if(strlen(luascript_filename)>0) LoadScript(luascript_filename);
     runluascript = 0;
     PRINTF("running lua script section\n");
     fflush(stdout);
-    script_return_code = runLuaScript();
+    script_return_code = RunLuaScript();
     if(script_return_code != LUA_OK && script_return_code != LUA_YIELD && exit_on_script_crash){
         SMV_EXIT(1);
     }
@@ -3917,7 +3917,7 @@ void DoScript(void){
   if(runscript == 1){
   // csv files are read in the background.  the following line ensures that they will all be read in
   // before the script begins. gpf
-      JOIN_CSV_FILES; 
+      JOIN_CSV_FILES;
       runscript = 0;
       PRINTF("running ssf script instruction\n");
       fflush(stdout);

--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -3063,7 +3063,7 @@ int LuaSetIsocolors(lua_State *L) {
     GetColor(L, -1, colors[i - 1]);
   }
   int return_code = SetIsocolors(shininess, transparency, transparency_option,
-                                  opacity_change, specular, n_colors, colors);
+                                 opacity_change, specular, n_colors, colors);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -3666,7 +3666,7 @@ int LuaSetScaledfont(lua_State *L) {
   int height3dwidth = lua_tonumber(L, 5);
   int thickness3d = lua_tonumber(L, 6);
   int return_code = SetScaledfont(height2d, height2dwidth, thickness2d,
-                                   height3d, height3dwidth, thickness3d);
+                                  height3d, height3dwidth, thickness3d);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -4604,7 +4604,7 @@ int LuaSetDevicevectordimensions(lua_State *L) {
   float headlength = lua_tonumber(L, 3);
   float headdiameter = lua_tonumber(L, 4);
   int return_code = SetDevicevectordimensions(baselength, basediameter,
-                                               headlength, headdiameter);
+                                              headlength, headdiameter);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -4661,7 +4661,7 @@ int LuaSetGsliceparms(lua_State *L) {
     i++;
   }
   int return_code = SetGsliceparms(vis_data, vis_triangles, vis_triangulation,
-                                    vis_normal, xyz, azelev);
+                                   vis_normal, xyz, azelev);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -4853,8 +4853,7 @@ int LuaSetCSlice(lua_State *L) {
   if (lua_gettop(L) == 5) {
     label = lua_tostring(L, 5);
   }
-  int return_code =
-      SetCSlice(min_flag, min_value, max_flag, max_value, label);
+  int return_code = SetCSlice(min_flag, min_value, max_flag, max_value, label);
   lua_pushnumber(L, return_code);
   return 1;
 } // C_SLICE
@@ -4911,7 +4910,7 @@ int LuaSetVSlice(lua_State *L) {
   float line_max = lua_tonumber(L, 7);
   int line_num = lua_tonumber(L, 8);
   int return_code = SetVSlice(min_flag, min_value, max_flag, max_value, label,
-                                line_min, line_max, line_num);
+                              line_min, line_max, line_num);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -4927,7 +4926,7 @@ int LuaSetPatchdataout(lua_State *L) {
   int zmin = lua_tonumber(L, 7);
   int zmax = lua_tonumber(L, 8);
   int return_code = SetPatchdataout(output_flag, tmin, tmax, xmin, xmax, ymin,
-                                     ymax, zmin, zmax);
+                                    ymax, zmin, zmax);
   lua_pushnumber(L, return_code);
   return 1;
 } // PATCHDATAOUT

--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -26,8 +26,9 @@
 #include <direct.h>
 #endif
 
+// NOLINTNEXTLINE
 lua_State *L;
-int lua_displayCB(lua_State *L);
+int LuaDisplayCb(lua_State *L);
 
 #ifdef WIN32
 #define snprintf _snprintf
@@ -92,7 +93,7 @@ int ProgramSetupLua(lua_State *L, int argc, char **argv) {
 /// @brief We can only take strings from the Lua interpreter as consts, as they
 /// are 'owned' by the Lua code and we should not change them in C. This
 /// function creates a copy that we can change in C.
-char **copy_argv(const int argc, const char *const *argv_sv) {
+char **CopyArgv(const int argc, const char *const *argv_sv) {
   char **argv_sv_non_const;
   // Allocate pointers for list of smokeview arguments
   NewMemory((void **)&argv_sv_non_const, argc * sizeof(char *));
@@ -107,7 +108,7 @@ char **copy_argv(const int argc, const char *const *argv_sv) {
 }
 
 /// @brief The corresponding function to free the memory allocated by copy_argv.
-void free_argv(const int argc, char **argv_sv_non_const) {
+void FreeArgv(const int argc, char **argv_sv_non_const) {
   // Free the memory allocated for each argument
   int i;
   for (i = 0; i < argc; i++) {
@@ -117,18 +118,18 @@ void free_argv(const int argc, char **argv_sv_non_const) {
   FREEMEMORY(argv_sv_non_const);
 }
 
-int lua_SetupGLUT(lua_State *L) {
+int LuaSetupGlut(lua_State *L) {
   int argc = lua_tonumber(L, 1);
   const char *const *argv_sv = lua_topointer(L, 2);
   // Here we must copy the arguments received from the Lua interperter to
   // allow them to be non-const (i.e. let the C code modify them).
-  char **argv_sv_non_const = copy_argv(argc, argv_sv);
+  char **argv_sv_non_const = CopyArgv(argc, argv_sv);
   SetupGlut(argc, argv_sv_non_const);
-  free_argv(argc, argv_sv_non_const);
+  FreeArgv(argc, argv_sv_non_const);
   return 0;
 }
 
-int lua_SetupCase(lua_State *L) {
+int LuaSetupCase(lua_State *L) {
   const char *filename = lua_tostring(L, -1);
   char *filename_mut;
   // Allocate some new memory in case smv tries to modify it.
@@ -161,10 +162,10 @@ int RunLuaBranch(lua_State *L, int argc, char **argv) {
 
   lua_pushnumber(L, argc);
   lua_pushlightuserdata(L, argv);
-  lua_SetupGLUT(L);
+  LuaSetupGlut(L);
   START_TIMER(startup_time);
   // Load information about smokeview into the lua interpreter.
-  lua_initsmvproginfo(L);
+  LuaInitsmvproginfo(L);
 
   if (smv_filename == NULL) {
     return 0;
@@ -172,7 +173,7 @@ int RunLuaBranch(lua_State *L, int argc, char **argv) {
   lua_pushstring(L, smv_filename);
   // TODO: only set up a case if one is specified, otherwise leave it to the
   // interpreter to call this.
-  lua_SetupCase(L);
+  LuaSetupCase(L);
   return_code = lua_tonumber(L, -1);
 
   if (return_code == 0 && update_bounds == 1) {
@@ -205,7 +206,7 @@ int RunLuaBranch(lua_State *L, int argc, char **argv) {
 /// callback (DisplayCB, in callbacks.c). These two loading routines are
 /// included to load the scripts early in the piece, before the display
 /// callback. Both runluascript and runscript are global.
-int load_script(const char *filename) {
+int LoadScript(const char *filename) {
   if (runluascript == 1 && runscript == 1) {
     fprintf(stderr, "Both a Lua script and an SSF script cannot be run "
                     "simultaneously\n");
@@ -213,7 +214,7 @@ int load_script(const char *filename) {
   }
   if (runluascript == 1) {
     // Load the Lua script in order for it to be run later.
-    if (loadLuaScript(filename) != LUA_OK) {
+    if (LoadLuaScript(filename) != LUA_OK) {
       fprintf(stderr, "There was an error loading the script, and so it "
                       "will not run.\n");
       if (exit_on_script_crash) {
@@ -222,7 +223,8 @@ int load_script(const char *filename) {
       runluascript = 0; // set this to false so that the smokeview no longer
                         // tries to run the script as it failed to load
       fprintf(stderr, "Running smokeview normally.\n");
-    } else {
+    }
+    else {
       fprintf(stderr, "%s successfully loaded\n", filename);
     }
   }
@@ -247,65 +249,65 @@ int load_script(const char *filename) {
 
 /// @brief Load a .smv file. This is currently not used as it is dependent on
 /// Smokeview being able to run without a .smv file loaded.
-int lua_loadsmvall(lua_State *L) {
+int LuaLoadsmvall(lua_State *L) {
   // The first argument is taken from the stack as a string.
   const char *filepath = lua_tostring(L, 1);
   // The function from the C api is called using this string.
-  loadsmvall(filepath);
+  Loadsmvall(filepath);
   // 0 arguments are returned.
   return 0;
 }
 
 /// @brief Set render clipping.
-int lua_renderclip(lua_State *L) {
+int LuaRenderclip(lua_State *L) {
   int flag = lua_toboolean(L, 1);
   int left = lua_tonumber(L, 2);
   int right = lua_tonumber(L, 3);
   int bottom = lua_tonumber(L, 4);
   int top = lua_tonumber(L, 5);
-  renderclip(flag, left, right, bottom, top);
+  Renderclip(flag, left, right, bottom, top);
   return 0;
 }
 
 /// @brief Render the current frame to a file.
-int lua_render(lua_State *L) {
-  lua_displayCB(L);
+int LuaRender(lua_State *L) {
+  LuaDisplayCb(L);
   const char *basename = lua_tostring(L, 1);
-  int ret = render(basename);
+  int ret = CApiRender(basename);
   lua_pushnumber(L, ret);
   return 1;
 }
 
 /// @brief Returns an error code then the image data.
-int lua_render_var(lua_State *L) {
-  gdImagePtr RENDERimage;
+int LuaRenderVar(lua_State *L) {
+  gdImagePtr rende_rimage;
   int return_code;
-  char *imageData;
-  int imageSize;
+  char *image_data;
+  int image_size;
 
   // render image to RENDERimage gd buffer
-  return_code = RenderFrameLuaVar(VIEW_CENTER, &RENDERimage);
+  return_code = RenderFrameLuaVar(VIEW_CENTER, &rende_rimage);
   lua_pushnumber(L, return_code);
   // convert to a simpler byte-buffer
-  imageData = gdImagePngPtr(RENDERimage, &imageSize);
+  image_data = gdImagePngPtr(rende_rimage, &image_size);
   // push to stack
-  lua_pushlstring(L, imageData, imageSize);
+  lua_pushlstring(L, image_data, image_size);
   // destroy C copy
-  gdImageDestroy(RENDERimage);
+  gdImageDestroy(rende_rimage);
 
   return 2;
 }
 
-int lua_gsliceview(lua_State *L) {
+int LuaGsliceview(lua_State *L) {
   int data = lua_tonumber(L, 1);
   int show_triangles = lua_toboolean(L, 2);
   int show_triangulation = lua_toboolean(L, 3);
   int show_normal = lua_toboolean(L, 4);
-  gsliceview(data, show_triangles, show_triangulation, show_normal);
+  Gsliceview(data, show_triangles, show_triangulation, show_normal);
   return 0;
 }
 
-int lua_showplot3ddata(lua_State *L) {
+int LuaShowplot3ddata(lua_State *L) {
   int meshnumber = lua_tonumber(L, 1);
   int plane_orientation = lua_tonumber(L, 2);
   int display = lua_tonumber(L, 3);
@@ -315,37 +317,37 @@ int lua_showplot3ddata(lua_State *L) {
   return 0;
 }
 
-int lua_gslicepos(lua_State *L) {
+int LuaGslicepos(lua_State *L) {
   float x = lua_tonumber(L, 1);
   float y = lua_tonumber(L, 2);
   float z = lua_tonumber(L, 3);
-  gslicepos(x, y, z);
+  Gslicepos(x, y, z);
   return 0;
 }
-int lua_gsliceorien(lua_State *L) {
+int LuaGsliceorien(lua_State *L) {
   float az = lua_tonumber(L, 1);
   float elev = lua_tonumber(L, 2);
-  gsliceorien(az, elev);
+  Gsliceorien(az, elev);
   return 0;
 }
 
-int lua_settourview(lua_State *L) {
-  int edittourArg = lua_tonumber(L, 1);
+int LuaSettourview(lua_State *L) {
+  int edittour_arg = lua_tonumber(L, 1);
   int mode = lua_tonumber(L, 2);
-  int show_tourlocusArg = lua_toboolean(L, 3);
-  float tour_global_tensionArg = lua_tonumber(L, 4);
-  settourview(edittourArg, mode, show_tourlocusArg, tour_global_tensionArg);
+  int show_tourlocus_arg = lua_toboolean(L, 3);
+  float tour_global_tension_arg = lua_tonumber(L, 4);
+  Settourview(edittour_arg, mode, show_tourlocus_arg, tour_global_tension_arg);
   return 0;
 }
 
-int lua_settourkeyframe(lua_State *L) {
+int LuaSettourkeyframe(lua_State *L) {
   float keyframe_time = lua_tonumber(L, 1);
-  settourkeyframe(keyframe_time);
+  Settourkeyframe(keyframe_time);
   return 0;
 }
 
 /// @brief Trigger the display callback.
-int lua_displayCB(lua_State *L) {
+int LuaDisplayCb(lua_State *L) {
   // runluascript=0;
   DisplayCB();
   // runluascript=1;
@@ -355,7 +357,7 @@ int lua_displayCB(lua_State *L) {
 /// @brief Hide the smokeview window. This should not currently be used as it
 /// prevents the display callback being called, and therefore the script will
 /// not continue (the script is called as part of the display callback).
-int lua_hidewindow(lua_State *L) {
+int LuaHidewindow(lua_State *L) {
   glutHideWindow();
   // once we hide the window the display callback is never called
   return 0;
@@ -364,22 +366,22 @@ int lua_hidewindow(lua_State *L) {
 /// @brief By calling yieldscript, the script is suspended and the smokeview
 /// display is updated. It is necessary to call this before producing any
 /// outputs (such as renderings).
-int lua_yieldscript(lua_State *L) {
+int LuaYieldscript(lua_State *L) {
   lua_yield(L, 0 /*zero results*/);
   return 0;
 }
 
 /// @brief As with lua_yieldscript, but immediately resumes the script after
 /// letting the display callback run.
-int lua_tempyieldscript(lua_State *L) {
+int LuaTempyieldscript(lua_State *L) {
   runluascript = 1;
   lua_yield(L, 0 /*zero results*/);
   return 0;
 }
 
 /// @brief Return the current frame number which Smokeivew has loaded.
-int lua_getframe(lua_State *L) {
-  int framenumber = getframe();
+int LuaGetframe(lua_State *L) {
+  int framenumber = Getframe();
   // Push a return value to the Lua stack.
   lua_pushinteger(L, framenumber);
   // Tell Lua that there is a single return value left on the stack.
@@ -387,53 +389,54 @@ int lua_getframe(lua_State *L) {
 }
 
 /// @brief Shift to a specific frame number.
-int lua_setframe(lua_State *L) {
+int LuaSetframe(lua_State *L) {
   int f = lua_tonumber(L, 1);
-  setframe(f);
+  Setframe(f);
   return 0;
 }
 
 /// @brief Get the time value of the currently loaded frame.
-int lua_gettime(lua_State *L) {
+int LuaGettime(lua_State *L) {
   if (global_times != NULL && nglobal_times > 0) {
-    float time = gettime();
+    float time = Gettime();
     lua_pushnumber(L, time);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
 /// @brief Shift to the closest frame to given a time value.
-int lua_settime(lua_State *L) {
-  lua_displayCB(L);
+int LuaSettime(lua_State *L) {
+  LuaDisplayCb(L);
   float t = lua_tonumber(L, 1);
-  int return_code = settime(t);
+  int return_code = Settime(t);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
 /// @brief Load an FDS data file directly (i.e. as a filepath).
-int lua_loaddatafile(lua_State *L) {
+int LuaLoaddatafile(lua_State *L) {
   const char *filename = lua_tostring(L, 1);
-  int return_value = loadfile(filename);
+  int return_value = Loadfile(filename);
   lua_pushnumber(L, return_value);
   return 1;
 }
 
 /// @brief Load a Smokeview config (.ini) file.
-int lua_loadinifile(lua_State *L) {
+int LuaLoadinifile(lua_State *L) {
   const char *filename = lua_tostring(L, 1);
-  loadinifile(filename);
+  Loadinifile(filename);
   return 0;
 }
 
 /// @brief Load an FDS vector data file directly (i.e. as a filepath). This
 /// function handles the loading of any additional data files necessary to
 /// display vectors.
-int lua_loadvdatafile(lua_State *L) {
+int LuaLoadvdatafile(lua_State *L) {
   const char *filename = lua_tostring(L, 1);
-  int return_value = loadvfile(filename);
+  int return_value = Loadvfile(filename);
   lua_pushnumber(L, return_value);
   return 1;
 }
@@ -441,35 +444,35 @@ int lua_loadvdatafile(lua_State *L) {
 /// @brief Load an FDS boundary file directly (i.e. as a filepath). This is
 /// equivalent to lua_loadfile, but specialised for boundary files. This is
 /// included to reflect the underlying code.
-int lua_loadboundaryfile(lua_State *L) {
+int LuaLoadboundaryfile(lua_State *L) {
   const char *filename = lua_tostring(L, 1);
-  loadboundaryfile(filename);
+  Loadboundaryfile(filename);
   return 0;
 }
 
 /// @brief Load a slice file given the type of slice, the axis along which it
 /// exists and its position along this axis.
-int lua_loadslice(lua_State *L) {
+int LuaLoadslice(lua_State *L) {
   const char *type = lua_tostring(L, 1);
   int axis = lua_tonumber(L, 2);
   float distance = lua_tonumber(L, 3);
-  loadslice(type, axis, distance);
+  Loadslice(type, axis, distance);
   return 0;
 }
 
 /// @brief Load a slice based on its index in sliceinfo.
-int lua_loadsliceindex(lua_State *L) {
+int LuaLoadsliceindex(lua_State *L) {
   size_t index = lua_tonumber(L, 1);
   int error = 0;
-  loadsliceindex(index, &error);
+  Loadsliceindex(index, &error);
   if (error) {
     return luaL_error(L, "Could not load slice at index %zu", index);
   }
   return 0;
 }
 
-int lua_get_clipping_mode(lua_State *L) {
-  lua_pushnumber(L, get_clipping_mode());
+int LuaGetClippingMode(lua_State *L) {
+  lua_pushnumber(L, GetClippingMode());
   return 1;
 }
 
@@ -481,78 +484,78 @@ int lua_get_clipping_mode(lua_State *L) {
 ///    1: Clip blockages and data.
 ///    2: Clip blockages.
 ///    3: Clip data.
-int lua_set_clipping_mode(lua_State *L) {
+int LuaSetClippingMode(lua_State *L) {
   int mode = lua_tonumber(L, 1);
-  set_clipping_mode(mode);
+  SetClippingMode(mode);
   return 0;
 }
 
-int lua_set_sceneclip_x(lua_State *L) {
-  int clipMin = lua_toboolean(L, 1);
+int LuaSetSceneclipX(lua_State *L) {
+  int clip_min = lua_toboolean(L, 1);
   float min = lua_tonumber(L, 2);
-  int clipMax = lua_toboolean(L, 3);
+  int clip_max = lua_toboolean(L, 3);
   float max = lua_tonumber(L, 4);
-  set_sceneclip_x(clipMin, min, clipMax, max);
+  SetSceneclipX(clip_min, min, clip_max, max);
   return 0;
 }
 
-int lua_set_sceneclip_x_min(lua_State *L) {
+int LuaSetSceneclipXMin(lua_State *L) {
   int flag = lua_toboolean(L, 1);
   float value = lua_tonumber(L, 2);
-  set_sceneclip_x_min(flag, value);
+  SetSceneclipXMin(flag, value);
   return 0;
 }
 
-int lua_set_sceneclip_x_max(lua_State *L) {
+int LuaSetSceneclipXMax(lua_State *L) {
   int flag = lua_toboolean(L, 1);
   float value = lua_tonumber(L, 2);
-  set_sceneclip_x_max(flag, value);
+  SetSceneclipXMax(flag, value);
   return 0;
 }
 
-int lua_set_sceneclip_y(lua_State *L) {
-  int clipMin = lua_toboolean(L, 1);
+int LuaSetSceneclipY(lua_State *L) {
+  int clip_min = lua_toboolean(L, 1);
   float min = lua_tonumber(L, 2);
-  int clipMax = lua_toboolean(L, 3);
+  int clip_max = lua_toboolean(L, 3);
   float max = lua_tonumber(L, 4);
-  set_sceneclip_y(clipMin, min, clipMax, max);
+  SetSceneclipY(clip_min, min, clip_max, max);
   return 0;
 }
 
-int lua_set_sceneclip_y_min(lua_State *L) {
+int LuaSetSceneclipYMin(lua_State *L) {
   int flag = lua_toboolean(L, 1);
   float value = lua_tonumber(L, 2);
-  set_sceneclip_y_min(flag, value);
+  SetSceneclipYMin(flag, value);
   return 0;
 }
 
-int lua_set_sceneclip_y_max(lua_State *L) {
+int LuaSetSceneclipYMax(lua_State *L) {
   int flag = lua_toboolean(L, 1);
   float value = lua_tonumber(L, 2);
-  set_sceneclip_y_max(flag, value);
+  SetSceneclipYMax(flag, value);
   return 0;
 }
 
-int lua_set_sceneclip_z(lua_State *L) {
-  int clipMin = lua_toboolean(L, 1);
+int LuaSetSceneclipZ(lua_State *L) {
+  int clip_min = lua_toboolean(L, 1);
   float min = lua_tonumber(L, 2);
-  int clipMax = lua_toboolean(L, 3);
+  int clip_max = lua_toboolean(L, 3);
   float max = lua_tonumber(L, 4);
-  set_sceneclip_z(clipMin, min, clipMax, max);
+  SetSceneclipZ(clip_min, min, clip_max, max);
   return 0;
 }
 
-int lua_set_sceneclip_z_min(lua_State *L) {
+int LuaSetSceneclipZMin(lua_State *L) {
   int flag = lua_toboolean(L, 1);
   float value = lua_tonumber(L, 2);
-  set_sceneclip_z_min(flag, value);
+  SetSceneclipZMin(flag, value);
   return 0;
 }
 
-int lua_set_sceneclip_z_max(lua_State *L) {
+int LuaSetSceneclipZMax(lua_State *L) {
   int flag = lua_toboolean(L, 1);
   float value = lua_tonumber(L, 2);
-  set_sceneclip_z_max(flag, value);
+  SetSceneclipZMax(flag, value);
   return 0;
 }
 
@@ -561,7 +564,7 @@ int lua_set_sceneclip_z_max(lua_State *L) {
 /// the table is a float representing the time.
 /// @param L The lua interpreter
 /// @return Number of stack items left on stack.
-int lua_get_global_times(lua_State *L) {
+int LuaGetGlobalTimes(lua_State *L) {
   lua_createtable(L, 0, nglobal_times);
   int i;
   for (i = 0; i < nglobal_times; i++) {
@@ -575,11 +578,12 @@ int lua_get_global_times(lua_State *L) {
 /// @brief Given a frame number return the time.
 /// @param L The lua interpreter
 /// @return Number of stack items left on stack.
-int lua_get_global_time(lua_State *L) {
+int LuaGetGlobalTime(lua_State *L) {
   int frame_number = lua_tonumber(L, 1);
   if (frame_number >= 0 && frame_number < nglobal_times) {
     lua_pushnumber(L, global_times[frame_number]);
-  } else {
+  }
+  else {
     lua_pushnil(L);
   }
   return 1;
@@ -588,24 +592,24 @@ int lua_get_global_time(lua_State *L) {
 /// @brief Get the number of (global) frames available to smokeview.
 /// @param L
 /// @return
-int lua_get_nglobal_times(lua_State *L) {
+int LuaGetNglobalTimes(lua_State *L) {
   lua_pushnumber(L, nglobal_times);
   return 1;
 }
 
 /// @brief Get the number of meshes in the loaded model.
-int lua_get_nmeshes(lua_State *L) {
+int LuaGetNmeshes(lua_State *L) {
   lua_pushnumber(L, nmeshes);
   return 1;
 }
 
 /// @brief Get the number of particle files in the loaded model.
-int lua_get_npartinfo(lua_State *L) {
+int LuaGetNpartinfo(lua_State *L) {
   lua_pushnumber(L, npartinfo);
   return 1;
 }
 
-int lua_getiblankcell(lua_State *L) {
+int LuaGetiblankcell(lua_State *L) {
   // The offset in the global meshinfo table.
   int mesh_index = lua_tonumber(L, lua_upvalueindex(1));
   // The offsets into the mesh requested
@@ -618,13 +622,14 @@ int lua_getiblankcell(lua_State *L) {
       mesh->c_iblank_cell[(i) + (j)*mesh->ibar + (k)*mesh->ibar * mesh->jbar];
   if (iblank == GAS) {
     lua_pushboolean(L, 1);
-  } else {
+  }
+  else {
     lua_pushboolean(L, 0);
   }
   return 1;
 }
 
-int lua_getiblanknode(lua_State *L) {
+int LuaGetiblanknode(lua_State *L) {
   // The offset in the global meshinfo table.
   int mesh_index = lua_tonumber(L, lua_upvalueindex(1));
   // The offsets into the mesh requested.
@@ -637,7 +642,8 @@ int lua_getiblanknode(lua_State *L) {
                                     (k) * (mesh->ibar + 1) * (mesh->jbar + 1)];
   if (iblank == GAS) {
     lua_pushboolean(L, 1);
-  } else {
+  }
+  else {
     lua_pushboolean(L, 0);
   }
   return 1;
@@ -646,7 +652,7 @@ int lua_getiblanknode(lua_State *L) {
 /// @brief Build a Lua table with information on the meshes of the model. The
 /// key of the table is the mesh number.
 // TODO: provide more information via this interface.
-int lua_get_meshes(lua_State *L) {
+int LuaGetMeshes(lua_State *L) {
   int entries = nmeshes;
   meshdata *infotable = meshinfo;
   lua_createtable(L, 0, entries);
@@ -683,11 +689,11 @@ int lua_get_meshes(lua_State *L) {
     lua_setfield(L, -2, "xyzmaxdiff");
 
     lua_pushnumber(L, i);
-    lua_pushcclosure(L, lua_getiblankcell, 1);
+    lua_pushcclosure(L, LuaGetiblankcell, 1);
     lua_setfield(L, -2, "iblank_cell");
 
     lua_pushnumber(L, i);
-    lua_pushcclosure(L, lua_getiblanknode, 1);
+    lua_pushcclosure(L, LuaGetiblanknode, 1);
     lua_setfield(L, -2, "iblank_node");
 
     // loop for less than ibar
@@ -747,13 +753,13 @@ int lua_get_meshes(lua_State *L) {
 }
 
 /// @brief Get the number of meshes in the loaded model.
-int lua_get_ndevices(lua_State *L) {
+int LuaGetNdevices(lua_State *L) {
   lua_pushnumber(L, ndeviceinfo);
   return 1;
 }
 
 /// @brief Build a Lua table with information on the devices of the model.
-int lua_get_devices(lua_State *L) {
+int LuaGetDevices(lua_State *L) {
   int entries = ndeviceinfo;
   devicedata *infotable = deviceinfo;
   lua_createtable(L, 0, entries);
@@ -770,7 +776,7 @@ int lua_get_devices(lua_State *L) {
   return 1;
 }
 
-int lua_create_vector(lua_State *L, csvdata *csv_x, csvdata *csv_y) {
+int LuaCreateVector(lua_State *L, csvdata *csv_x, csvdata *csv_y) {
   size_t i;
   lua_createtable(L, 0, 3);
 
@@ -809,12 +815,12 @@ int lua_create_vector(lua_State *L, csvdata *csv_x, csvdata *csv_y) {
 }
 
 /// @brief Get the number of CSV files available to the model.
-int lua_get_ncsvinfo(lua_State *L) {
+int LuaGetNcsvinfo(lua_State *L) {
   lua_pushnumber(L, ncsvfileinfo);
   return 1;
 }
 
-csvfiledata *get_csvinfo(const char *key) {
+csvfiledata *GetCsvinfo(const char *key) {
   // Loop through csvinfo until we find the right entry
   size_t i;
   for (i = 0; i < ncsvfileinfo; ++i) {
@@ -825,7 +831,7 @@ csvfiledata *get_csvinfo(const char *key) {
   return NULL;
 }
 
-int get_csvindex(const char *key) {
+int GetCsvindex(const char *key) {
   // Loop through csvinfo until we find the right entry
   size_t i;
   for (i = 0; i < ncsvfileinfo; ++i) {
@@ -836,22 +842,22 @@ int get_csvindex(const char *key) {
   return -1;
 }
 
-void load_csv(csvfiledata *csventry) {
+void LoadCsv(csvfiledata *csventry) {
   ReadCSVFile(csventry, LOAD);
   csventry->loaded = 1;
 }
 
-int lua_load_csv(lua_State *L) {
+int LuaLoadCsv(lua_State *L) {
   lua_pushstring(L, "c_type");
   lua_gettable(L, 1);
   const char *key = lua_tostring(L, -1);
-  csvfiledata *csventry = get_csvinfo(key);
+  csvfiledata *csventry = GetCsvinfo(key);
   if (csventry == NULL) return 0;
-  load_csv(csventry);
+  LoadCsv(csventry);
   return 0;
 }
 
-int access_csventry_prop(lua_State *L) {
+int AccessCsventryProp(lua_State *L) {
   // Take the index from the table.
   lua_pushstring(L, "index");
   lua_gettable(L, 1);
@@ -860,13 +866,15 @@ int access_csventry_prop(lua_State *L) {
   if (strcmp(field, "loaded") == 0) {
     lua_pushboolean(L, csvfileinfo[index].loaded);
     return 1;
-  } else if (strcmp(field, "display") == 0) {
+  }
+  else if (strcmp(field, "display") == 0) {
     lua_pushboolean(L, csvfileinfo[index].display);
     return 1;
-  } else if (strcmp(field, "vectors") == 0) {
+  }
+  else if (strcmp(field, "vectors") == 0) {
     csvfiledata *csventry = &csvfileinfo[index];
     if (!csventry->loaded) {
-      load_csv(csventry);
+      LoadCsv(csventry);
     }
     // TODO: don't create every time
     lua_createtable(L, 0, csventry->ncsvinfo);
@@ -876,40 +884,41 @@ int access_csventry_prop(lua_State *L) {
       // TODO: change to access indirectly rater than copying via stack
       // printf("adding: %s\n", csventry->vectors[j].y->name);
 
-      lua_create_vector(L, csventry->time, &(csventry->csvinfo[j]));
+      LuaCreateVector(L, csventry->time, &(csventry->csvinfo[j]));
       lua_setfield(L, -2, csventry->csvinfo[j].label.longlabel);
     }
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_csv_is_loaded(lua_State *L) {
+int LuaCsvIsLoaded(lua_State *L) {
   const char *key = lua_tostring(L, lua_upvalueindex(1));
-  csvfiledata *csventry = get_csvinfo(key);
+  csvfiledata *csventry = GetCsvinfo(key);
   lua_pushboolean(L, csventry->loaded);
   return 1;
 }
 
 /// @brief Create a table so that a metatable can be used.
-int lua_get_csvdata(lua_State *L) {
+int LuaGetCsvdata(lua_State *L) {
   // L1 is the table
   // L2 is the string key
   const char *key = lua_tostring(L, 2);
   // char *file = lua_tostring(L, 1);
-  csvfiledata *csventry = get_csvinfo(key);
+  csvfiledata *csventry = GetCsvinfo(key);
   // Check if the chosen csv data is loaded
   if (!csventry->loaded) {
     // Load the data.
-    load_csv(csventry);
+    LoadCsv(csventry);
   }
   // TODO: put userdata on stack
   lua_pushlightuserdata(L, csventry->csvinfo);
   return 1;
 }
 
-int access_pl3dentry_prop(lua_State *L) {
+int AccessPl3dentryProp(lua_State *L) {
   // Take the index from the table.
   lua_pushstring(L, "index");
   lua_gettable(L, 1);
@@ -918,34 +927,35 @@ int access_pl3dentry_prop(lua_State *L) {
   if (strcmp(field, "loaded") == 0) {
     lua_pushboolean(L, plot3dinfo[index].loaded);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_set_pl3d_bound_min(lua_State *L) {
-  int pl3dValueIndex = lua_tonumber(L, 1);
+int LuaSetPl3dBoundMin(lua_State *L) {
+  int pl3d_value_index = lua_tonumber(L, 1);
   int set = lua_toboolean(L, 2);
   float value = lua_tonumber(L, 3);
-  set_pl3d_bound_min(pl3dValueIndex, set, value);
+  SetPl3dBoundMin(pl3d_value_index, set, value);
   return 0;
 }
 
-int lua_set_pl3d_bound_max(lua_State *L) {
-  int pl3dValueIndex = lua_tonumber(L, 1);
+int LuaSetPl3dBoundMax(lua_State *L) {
+  int pl3d_value_index = lua_tonumber(L, 1);
   int set = lua_toboolean(L, 2);
   float value = lua_tonumber(L, 3);
-  set_pl3d_bound_max(pl3dValueIndex, set, value);
+  SetPl3dBoundMax(pl3d_value_index, set, value);
   return 0;
 }
 
 /// @brief Get the number of PL3D files available to the model.
-int lua_get_nplot3dinfo(lua_State *L) {
+int LuaGetNplot3dinfo(lua_State *L) {
   lua_pushnumber(L, nplot3dinfo);
   return 1;
 }
 
-int lua_get_plot3dentry(lua_State *L) {
+int LuaGetPlot3dentry(lua_State *L) {
   int lua_index = lua_tonumber(L, -1);
   int index = lua_index - 1;
   int i;
@@ -1005,7 +1015,7 @@ int lua_get_plot3dentry(lua_State *L) {
   // TODO: this metatable might be more easily implemented directly in Lua
   // so that we don't need to reimplement table access.
   lua_createtable(L, 0, 1);
-  lua_pushcfunction(L, &access_pl3dentry_prop);
+  lua_pushcfunction(L, &AccessPl3dentryProp);
   lua_setfield(L, -2, "__index");
   // then set the metatable
   lua_setmetatable(L, -2);
@@ -1013,19 +1023,19 @@ int lua_get_plot3dentry(lua_State *L) {
   return 1;
 }
 
-int lua_get_plot3dinfo(lua_State *L) {
+int LuaGetPlot3dinfo(lua_State *L) {
   lua_createtable(L, 0, nplot3dinfo);
   int i;
   for (i = 0; i < nplot3dinfo; i++) {
     lua_pushnumber(L, i + 1);
-    lua_get_plot3dentry(L);
+    LuaGetPlot3dentry(L);
 
     lua_settable(L, -3);
   }
   return 1;
 }
 
-int lua_get_qdata_sum(lua_State *L) {
+int LuaGetQdataSum(lua_State *L) {
   int meshnumber = lua_tonumber(L, 1);
   int vari, i, j, k;
   meshdata mesh = meshinfo[meshnumber];
@@ -1057,7 +1067,7 @@ int lua_get_qdata_sum(lua_State *L) {
 }
 
 /// @brief Sum bounded data in a given mesh
-int lua_get_qdata_sum_bounded(lua_State *L) {
+int LuaGetQdataSumBounded(lua_State *L) {
   int meshnumber = lua_tonumber(L, 1);
   int vari, i, j, k;
   int i1, i2, j1, j2, k1, k2;
@@ -1098,7 +1108,7 @@ int lua_get_qdata_sum_bounded(lua_State *L) {
 }
 
 /// @brief Sum bounded data in a given mesh
-int lua_get_qdata_max_bounded(lua_State *L) {
+int LuaGetQdataMaxBounded(lua_State *L) {
   int meshnumber = lua_tonumber(L, 1);
   int vari, i, j, k;
   int i1, i2, j1, j2, k1, k2;
@@ -1140,7 +1150,7 @@ int lua_get_qdata_max_bounded(lua_State *L) {
   return vars + 1;
 }
 
-int lua_get_qdata_mean(lua_State *L) {
+int LuaGetQdataMean(lua_State *L) {
   int meshnumber = lua_tonumber(L, 1);
   int vari, i, j, k;
   meshdata mesh = meshinfo[meshnumber];
@@ -1170,7 +1180,7 @@ int lua_get_qdata_mean(lua_State *L) {
   return vars;
 }
 
-int lua_get_global_time_n(lua_State *L) {
+int LuaGetGlobalTimeN(lua_State *L) {
   // argument 1 is the table, argument 2 is the index
   int index = lua_tonumber(L, 2);
   if (index < 0 || index >= nglobal_times) {
@@ -1181,7 +1191,7 @@ int lua_get_global_time_n(lua_State *L) {
 }
 
 // TODO: remove this from a hardcoded string.
-int setup_pl3dtables(lua_State *L) {
+int SetupPl3dtables(lua_State *L) {
   luaL_dostring(L, "\
     pl3d = {}\
     local allpl3dtimes = {}\
@@ -1200,7 +1210,7 @@ int setup_pl3dtables(lua_State *L) {
   return 0;
 }
 
-int lua_case_title(lua_State *L) {
+int LuaCaseTitle(lua_State *L) {
   lua_pushstring(L, "chid");
   lua_gettable(L, 1);
   const char *chid = lua_tostring(L, -1);
@@ -1209,24 +1219,26 @@ int lua_case_title(lua_State *L) {
   return 1;
 }
 
-int lua_case_index(lua_State *L) {
+int LuaCaseIndex(lua_State *L) {
   const char *field = lua_tostring(L, 2);
   if (strcmp(field, "chid") == 0) {
     lua_pushstring(L, chidfilebase);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_case_newindex(lua_State *L) {
+int LuaCaseNewindex(lua_State *L) {
   const char *field = lua_tostring(L, 2);
   if (strcmp(field, "chid") == 0) {
     luaL_error(L, "case.chid is read-only");
     // lua_pushstring(L, value);
     // lua_setrenderdir(L);
     return 0;
-  } else {
+  }
+  else {
     return 0;
   }
 }
@@ -1237,7 +1249,7 @@ int lua_case_newindex(lua_State *L) {
 /// increase separation. This will likely be removed in future versions.
 // TODO: Consider converting most of these to userdata, rather than copying them
 // into the lua interpreter.
-int lua_create_case(lua_State *L) {
+int LuaCreateCase(lua_State *L) {
   // Create case table
   lua_newtable(L);
   // lua_pushstring(L, chidfilebase);
@@ -1245,7 +1257,7 @@ int lua_create_case(lua_State *L) {
   lua_pushstring(L, fdsprefix);
   lua_setfield(L, -2, "fdsprefix");
 
-  lua_pushcfunction(L, &lua_case_title);
+  lua_pushcfunction(L, &LuaCaseTitle);
   lua_setfield(L, -2, "plot_title");
 
   // TODO: copying the array into lua allows for slightly faster access,
@@ -1260,9 +1272,9 @@ int lua_create_case(lua_State *L) {
   lua_newtable(L);
   // Create "global_times" metatable
   lua_newtable(L);
-  lua_pushcfunction(L, &lua_get_nglobal_times);
+  lua_pushcfunction(L, &LuaGetNglobalTimes);
   lua_setfield(L, -2, "__len");
-  lua_pushcfunction(L, &lua_get_global_time_n);
+  lua_pushcfunction(L, &LuaGetGlobalTimeN);
   lua_setfield(L, -2, "__index");
   // then set the metatable
   lua_setmetatable(L, -2);
@@ -1270,24 +1282,24 @@ int lua_create_case(lua_State *L) {
 
   // while the meshes themselve will rarely change, the information about them
   // will change regularly. This is handled by the mesh table.
-  lua_get_meshes(L);
+  LuaGetMeshes(L);
   // meshes is currently on the stack
   // add a metatable to it.
   // first create the table
   lua_createtable(L, 0, 1);
-  lua_pushcfunction(L, &lua_get_nmeshes);
+  lua_pushcfunction(L, &LuaGetNmeshes);
   lua_setfield(L, -2, "__len");
   // then set the metatable
   lua_setmetatable(L, -2);
   lua_setfield(L, -2, "meshes");
 
   // As with meshes the number and names of devices is unlikely to change
-  lua_get_devices(L);
+  LuaGetDevices(L);
   // devices is currently on the stack
   // add a metatable to it.
   // first create the table
   lua_createtable(L, 0, 1);
-  lua_pushcfunction(L, &lua_get_ndevices);
+  lua_pushcfunction(L, &LuaGetNdevices);
   lua_setfield(L, -2, "__len");
   // then set the metatable
   lua_setmetatable(L, -2);
@@ -1295,29 +1307,29 @@ int lua_create_case(lua_State *L) {
 
   // sliceinfo is a 1-indexed array so the lua length operator
   // works without the need for a metatable
-  lua_get_sliceinfo(L);
+  LuaGetSliceinfo(L);
   lua_setfield(L, -2, "slices");
 
   // lua_get_rampinfo(L);
   // lua_setglobal(L, "rampinfo");
 
-  lua_get_csvinfo(L);
+  LuaGetCsvinfo(L);
   // csvinfo is currently on the stack
   // add a metatable to it.
   // first create the table
   lua_createtable(L, 0, 1);
-  lua_pushcfunction(L, &lua_get_ncsvinfo);
+  lua_pushcfunction(L, &LuaGetNcsvinfo);
   lua_setfield(L, -2, "__len");
   // then set the metatable
   lua_setmetatable(L, -2);
   lua_setfield(L, -2, "csvs");
 
-  lua_get_plot3dinfo(L);
+  LuaGetPlot3dinfo(L);
   // plot3dinfo is currently on the stack
   // add a metatable to it.
   // first create the table
   lua_createtable(L, 0, 1);
-  lua_pushcfunction(L, &lua_get_nplot3dinfo);
+  lua_pushcfunction(L, &LuaGetNplot3dinfo);
   lua_setfield(L, -2, "__len");
   // then set the metatable
   lua_setmetatable(L, -2);
@@ -1331,9 +1343,9 @@ int lua_create_case(lua_State *L) {
 
   // Case metatable
   lua_createtable(L, 0, 1);
-  lua_pushcfunction(L, &lua_case_index);
+  lua_pushcfunction(L, &LuaCaseIndex);
   lua_setfield(L, -2, "__index");
-  lua_pushcfunction(L, &lua_case_newindex);
+  lua_pushcfunction(L, &LuaCaseNewindex);
   lua_setfield(L, -2, "__newindex");
   lua_setmetatable(L, -2);
 
@@ -1342,12 +1354,12 @@ int lua_create_case(lua_State *L) {
 
 /// @brief As with lua_initsmvdata(), but for information relating to Smokeview
 /// itself.
-int lua_initsmvproginfo(lua_State *L) {
+int LuaInitsmvproginfo(lua_State *L) {
   char version[256];
   // char githash[256];
 
   GetProgVersion(version);
-  addLuaPaths(L);
+  AddLuaPaths(L);
   // getGitHash(githash);
 
   lua_createtable(L, 0, 6);
@@ -1377,7 +1389,7 @@ int lua_initsmvproginfo(lua_State *L) {
   return 0;
 }
 
-int lua_get_slice(lua_State *L) {
+int LuaGetSlice(lua_State *L) {
   // This should push a lightuserdata onto the stack which is a pointer to the
   // slicedata. This takes the index of the slice (in the sliceinfo array) as an
   // argument.
@@ -1394,7 +1406,7 @@ int lua_get_slice(lua_State *L) {
 
 /// @brief This takes a lightuserdata pointer as an argument, and returns the
 /// slice label as a string.
-int lua_slice_get_label(lua_State *L) {
+int LuaSliceGetLabel(lua_State *L) {
   // get the lightuserdata from the stack, which is a pointer to the 'slicedata'
   slicedata *slice = (slicedata *)lua_touserdata(L, 1);
   // Push the string onto the stack
@@ -1404,7 +1416,7 @@ int lua_slice_get_label(lua_State *L) {
 
 /// @brief This takes a lightuserdata pointer as an argument, and returns the
 /// slice filename as a string.
-int lua_slice_get_filename(lua_State *L) {
+int LuaSliceGetFilename(lua_State *L) {
   // Get the lightuserdata from the stack, which is a pointer to the
   // 'slicedata'.
   slicedata *slice = (slicedata *)lua_touserdata(L, 1);
@@ -1413,7 +1425,7 @@ int lua_slice_get_filename(lua_State *L) {
   return 1;
 }
 
-int lua_slice_get_data(lua_State *L) {
+int LuaSliceGetData(lua_State *L) {
   // get the lightuserdata from the stack, which is a pointer to the 'slicedata'
   slicedata *slice = (slicedata *)lua_touserdata(L, 1);
   // Push a lightuserdata (a pointer) onto the lua stack that points to the
@@ -1422,7 +1434,7 @@ int lua_slice_get_data(lua_State *L) {
   return 1;
 }
 
-int lua_slice_get_times(lua_State *L) {
+int LuaSliceGetTimes(lua_State *L) {
   int i;
   // get the lightuserdata from the stack, which is a pointer to the 'slicedata'
   slicedata *slice = (slicedata *)lua_touserdata(L, 1);
@@ -1437,7 +1449,7 @@ int lua_slice_get_times(lua_State *L) {
   return 1;
 }
 
-int lua_get_part(lua_State *L) {
+int LuaGetPart(lua_State *L) {
   // This should push a lightuserdata onto the stack which is a pointer to the
   // partdata. This takes the index of the part (in the partinfo array) as an
   // argument.
@@ -1453,7 +1465,7 @@ int lua_get_part(lua_State *L) {
 }
 
 // pass in the part data
-int lua_get_part_npoints(lua_State *L) {
+int LuaGetPartNpoints(lua_State *L) {
   int index;
   partdata *parti = (partdata *)lua_touserdata(L, 1);
   if (!parti->loaded) {
@@ -1529,7 +1541,7 @@ int lua_get_part_npoints(lua_State *L) {
 
 // int lua_get_all_part_
 
-int lua_slice_data_map_frames(lua_State *L) {
+int LuaSliceDataMapFrames(lua_State *L) {
   // The first argument to this function is the slice pointer. This function
   // receives the values of the slice at a particular frame as an array.
   slicedata *slice = (slicedata *)lua_touserdata(L, 1);
@@ -1576,7 +1588,7 @@ int lua_slice_data_map_frames(lua_State *L) {
   return 1;
 }
 
-int lua_slice_data_map_frames_count_less(lua_State *L) {
+int LuaSliceDataMapFramesCountLess(lua_State *L) {
   slicedata *slice = (slicedata *)lua_touserdata(L, 1);
   if (!slice->loaded) {
     return luaL_error(L, "slice %s not loaded", slice->file);
@@ -1604,7 +1616,7 @@ int lua_slice_data_map_frames_count_less(lua_State *L) {
   return 1;
 }
 
-int lua_slice_data_map_frames_count_less_eq(lua_State *L) {
+int LuaSliceDataMapFramesCountLessEq(lua_State *L) {
   slicedata *slice = (slicedata *)lua_touserdata(L, 1);
   if (!slice->loaded) {
     return luaL_error(L, "slice %s not loaded", slice->file);
@@ -1632,7 +1644,7 @@ int lua_slice_data_map_frames_count_less_eq(lua_State *L) {
   return 1;
 }
 
-int lua_slice_data_map_frames_count_greater(lua_State *L) {
+int LuaSliceDataMapFramesCountGreater(lua_State *L) {
   slicedata *slice = (slicedata *)lua_touserdata(L, 1);
   if (!slice->loaded) {
     return luaL_error(L, "slice %s not loaded", slice->file);
@@ -1660,7 +1672,7 @@ int lua_slice_data_map_frames_count_greater(lua_State *L) {
   return 1;
 }
 
-int lua_slice_data_map_frames_count_greater_eq(lua_State *L) {
+int LuaSliceDataMapFramesCountGreaterEq(lua_State *L) {
   slicedata *slice = (slicedata *)lua_touserdata(L, 1);
   if (!slice->loaded) {
     return luaL_error(L, "slice %s not loaded", slice->file);
@@ -1695,7 +1707,7 @@ int lua_slice_data_map_frames_count_greater_eq(lua_State *L) {
 /// 3. int j
 /// 4. ink k
 /// The slice index is stored as part of a closure.
-int lua_getslicedata(lua_State *L) {
+int LuaGetslicedata(lua_State *L) {
   // The offset in the global sliceinfo table of the slice.
   int slice_index = lua_tonumber(L, lua_upvalueindex(1));
   // The time frame to use
@@ -1741,7 +1753,7 @@ int lua_getslicedata(lua_State *L) {
 
 /// @brief Build a Lua table with information on the slices of the model.
 // TODO: change this to use userdata instead
-int lua_get_sliceinfo(lua_State *L) {
+int LuaGetSliceinfo(lua_State *L) {
   lua_createtable(L, 0, nsliceinfo);
   int i;
   for (i = 0; i < nsliceinfo; i++) {
@@ -1820,7 +1832,7 @@ int lua_get_sliceinfo(lua_State *L) {
     lua_pushnumber(L, i);
     // Push a closure which has been provided with the first argument (the slice
     // index)
-    lua_pushcclosure(L, lua_getslicedata, 1);
+    lua_pushcclosure(L, LuaGetslicedata, 1);
     lua_setfield(L, -2, "getdata");
 
     lua_settable(L, -3);
@@ -1828,10 +1840,10 @@ int lua_get_sliceinfo(lua_State *L) {
   return 1;
 }
 
-int lua_get_csventry(lua_State *L) {
+int LuaGetCsventry(lua_State *L) {
   const char *key = lua_tostring(L, -1);
-  csvfiledata *csventry = get_csvinfo(key);
-  int index = get_csvindex(key);
+  csvfiledata *csventry = GetCsvinfo(key);
+  int index = GetCsvindex(key);
   lua_createtable(L, 0, 4);
   lua_pushstring(L, csventry->file);
   lua_setfield(L, -2, "file");
@@ -1843,13 +1855,13 @@ int lua_get_csventry(lua_State *L) {
   lua_setfield(L, -2, "index");
 
   lua_pushstring(L, key);
-  lua_pushcclosure(L, &lua_load_csv, 1);
+  lua_pushcclosure(L, &LuaLoadCsv, 1);
   lua_setfield(L, -2, "load");
 
   // Create a metatable.
   // TODO: this metatable might be more easily implemented directly in Lua.
   lua_createtable(L, 0, 1);
-  lua_pushcfunction(L, &access_csventry_prop);
+  lua_pushcfunction(L, &AccessCsventryProp);
   lua_setfield(L, -2, "__index");
   // then set the metatable
   lua_setmetatable(L, -2);
@@ -1860,47 +1872,47 @@ int lua_get_csventry(lua_State *L) {
 /// model.
 // TODO: provide more information via this interface.
 // TODO: use metatables so that the most up-to-date information is retrieved.
-int lua_get_csvinfo(lua_State *L) {
+int LuaGetCsvinfo(lua_State *L) {
   lua_createtable(L, 0, ncsvfileinfo);
   int i;
   for (i = 0; i < ncsvfileinfo; i++) {
     lua_pushstring(L, csvfileinfo[i].c_type);
-    lua_get_csventry(L);
+    LuaGetCsventry(L);
     lua_settable(L, -3);
   }
   return 1;
 }
 
-int lua_loadvslice(lua_State *L) {
+int LuaLoadvslice(lua_State *L) {
   const char *type = lua_tostring(L, 1);
   int axis = lua_tonumber(L, 2);
   float distance = lua_tonumber(L, 3);
-  loadvslice(type, axis, distance);
+  Loadvslice(type, axis, distance);
   return 0;
 }
 
-int lua_loadiso(lua_State *L) {
+int LuaLoadiso(lua_State *L) {
   const char *type = lua_tostring(L, 1);
-  loadiso(type);
+  Loadiso(type);
   return 0;
 }
 
-int lua_load3dsmoke(lua_State *L) {
+int LuaLoad3dsmoke(lua_State *L) {
   const char *smoke_type = lua_tostring(L, 1);
-  load3dsmoke(smoke_type);
+  Load3dsmoke(smoke_type);
   return 0;
 }
 
-int lua_loadvolsmoke(lua_State *L) {
+int LuaLoadvolsmoke(lua_State *L) {
   int meshnumber = lua_tonumber(L, 1);
-  loadvolsmoke(meshnumber);
+  Loadvolsmoke(meshnumber);
   return 0;
 }
 
-int lua_loadvolsmokeframe(lua_State *L) {
+int LuaLoadvolsmokeframe(lua_State *L) {
   int meshnumber = lua_tonumber(L, 1);
   int framenumber = lua_tonumber(L, 1);
-  loadvolsmokeframe(meshnumber, framenumber, 1);
+  Loadvolsmokeframe(meshnumber, framenumber, 1);
   // returnval = 1; // TODO: determine if this is the correct behaviour.
   // this is what is done in the SSF code.
   return 0;
@@ -1910,16 +1922,16 @@ int lua_loadvolsmokeframe(lua_State *L) {
 /// a string. The acceptable values are:
 ///   "JPG"
 ///   "PNG"
-int lua_set_rendertype(lua_State *L) {
+int LuaSetRendertype(lua_State *L) {
   const char *type = lua_tostring(L, 1);
-  if (set_rendertype(type)) {
+  if (SetRendertype(type)) {
     return luaL_error(L, "%s is not a valid render type", type);
   }
   return 0;
 }
 
-int lua_get_rendertype(lua_State *L) {
-  int render_type = get_rendertype();
+int LuaGetRendertype(lua_State *L) {
+  int render_type = GetRendertype();
   switch (render_type) {
   case JPEG:
     lua_pushstring(L, "JPG");
@@ -1939,14 +1951,14 @@ int lua_get_rendertype(lua_State *L) {
 ///    - "WMV"
 ///    - "MP4"
 ///    - "AVI"
-int lua_set_movietype(lua_State *L) {
+int LuaSetMovietype(lua_State *L) {
   const char *type = lua_tostring(L, 1);
-  set_movietype(type);
+  SetMovietype(type);
   return 0;
 }
 
-int lua_get_movietype(lua_State *L) {
-  int movie_type = get_movietype();
+int LuaGetMovietype(lua_State *L) {
+  int movie_type = GetMovietype();
   switch (movie_type) {
   case WMV:
     lua_pushstring(L, "WMV");
@@ -1964,120 +1976,120 @@ int lua_get_movietype(lua_State *L) {
   return 1;
 }
 
-int lua_makemovie(lua_State *L) {
+int LuaMakemovie(lua_State *L) {
   const char *name = lua_tostring(L, 1);
   const char *base = lua_tostring(L, 2);
   float framerate = lua_tonumber(L, 3);
-  makemovie(name, base, framerate);
+  Makemovie(name, base, framerate);
   return 0;
 }
 
-int lua_loadtour(lua_State *L) {
+int LuaLoadtour(lua_State *L) {
   const char *name = lua_tostring(L, 1);
-  int error_code = loadtour(name);
+  int error_code = Loadtour(name);
   lua_pushnumber(L, error_code);
   return 1;
 }
 
-int lua_loadparticles(lua_State *L) {
+int LuaLoadparticles(lua_State *L) {
   const char *name = lua_tostring(L, 1);
-  loadparticles(name);
+  Loadparticles(name);
   return 0;
 }
 
-int lua_partclasscolor(lua_State *L) {
+int LuaPartclasscolor(lua_State *L) {
   const char *color = lua_tostring(L, 1);
-  partclasscolor(color);
+  Partclasscolor(color);
   return 0;
 }
 
-int lua_partclasstype(lua_State *L) {
+int LuaPartclasstype(lua_State *L) {
   const char *type = lua_tostring(L, 1);
-  partclasstype(type);
+  Partclasstype(type);
   return 0;
 }
 
-int lua_plot3dprops(lua_State *L) {
+int LuaPlot3dprops(lua_State *L) {
   int variable_index = lua_tonumber(L, 1);
   int showvector = lua_toboolean(L, 2);
   int vector_length_index = lua_tonumber(L, 3);
   int display_type = lua_tonumber(L, 4);
   float vector_length = lua_tonumber(L, 5);
-  plot3dprops(variable_index, showvector, vector_length_index, display_type,
+  Plot3dprops(variable_index, showvector, vector_length_index, display_type,
               vector_length);
   return 0;
 }
 
-int lua_loadplot3d(lua_State *L) {
+int LuaLoadplot3d(lua_State *L) {
   int meshnumber = lua_tonumber(L, 1);
   float time_local = lua_tonumber(L, 2);
-  loadplot3d(meshnumber, time_local);
+  Loadplot3d(meshnumber, time_local);
   return 0;
 }
 
-int lua_unloadall(lua_State *L) {
-  unloadall();
+int LuaUnloadall(lua_State *L) {
+  Unloadall();
   return 0;
 }
 
-int lua_unloadtour(lua_State *L) {
-  unloadtour();
+int LuaUnloadtour(lua_State *L) {
+  Unloadtour();
   return 0;
 }
 
-int lua_setrenderdir(lua_State *L) {
+int LuaSetrenderdir(lua_State *L) {
   const char *dir = lua_tostring(L, -1);
-  int return_code = setrenderdir(dir);
+  int return_code = Setrenderdir(dir);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_getrenderdir(lua_State *L) {
+int LuaGetrenderdir(lua_State *L) {
   lua_pushstring(L, script_dir_path);
   return 1;
 }
 
-int lua_set_ortho_preset(lua_State *L) {
+int LuaSetOrthoPreset(lua_State *L) {
   const char *viewpoint = lua_tostring(L, 1);
-  int errorcode = set_ortho_preset(viewpoint);
+  int errorcode = SetOrthoPreset(viewpoint);
   lua_pushnumber(L, errorcode);
   return 1;
 }
 
-int lua_setviewpoint(lua_State *L) {
+int LuaSetviewpoint(lua_State *L) {
   const char *viewpoint = lua_tostring(L, 1);
-  int errorcode = setviewpoint(viewpoint);
+  int errorcode = Setviewpoint(viewpoint);
   lua_pushnumber(L, errorcode);
   return 1;
 }
 
-int lua_getviewpoint(lua_State *L) {
+int LuaGetviewpoint(lua_State *L) {
   lua_pushstring(L, camera_current->name);
   return 1;
 }
 
-int lua_exit_smokeview(lua_State *L) {
-  exit_smokeview();
+int LuaExitSmokeview(lua_State *L) {
+  ExitSmokeview();
   return 0;
 }
 
-int lua_setwindowsize(lua_State *L) {
+int LuaSetwindowsize(lua_State *L) {
   int width = lua_tonumber(L, 1);
   int height = lua_tonumber(L, 2);
-  setwindowsize(width, height);
+  Setwindowsize(width, height);
   // Using the DisplayCB is not sufficient in this case,
   // control must be temporarily returned to the main glut loop.
-  lua_tempyieldscript(L);
+  LuaTempyieldscript(L);
   return 0;
 }
 
-int lua_setgridvisibility(lua_State *L) {
+int LuaSetgridvisibility(lua_State *L) {
   int selection = lua_tonumber(L, 1);
-  setgridvisibility(selection);
+  Setgridvisibility(selection);
   return 0;
 }
 
-int lua_setgridparms(lua_State *L) {
+int LuaSetgridparms(lua_State *L) {
   int x_vis = lua_tonumber(L, 1);
   int y_vis = lua_tonumber(L, 2);
   int z_vis = lua_tonumber(L, 3);
@@ -2086,57 +2098,57 @@ int lua_setgridparms(lua_State *L) {
   int y_plot = lua_tonumber(L, 5);
   int z_plot = lua_tonumber(L, 6);
 
-  setgridparms(x_vis, y_vis, z_vis, x_plot, y_plot, z_plot);
+  Setgridparms(x_vis, y_vis, z_vis, x_plot, y_plot, z_plot);
 
   return 0;
 }
 
-int lua_setcolorbarflip(lua_State *L) {
+int LuaSetcolorbarflip(lua_State *L) {
   int flip = lua_toboolean(L, 1);
-  setcolorbarflip(flip);
-  lua_tempyieldscript(L);
+  Setcolorbarflip(flip);
+  LuaTempyieldscript(L);
   return 0;
 }
 
-int lua_getcolorbarflip(lua_State *L) {
-  int flip = getcolorbarflip();
+int LuaGetcolorbarflip(lua_State *L) {
+  int flip = Getcolorbarflip();
   lua_pushboolean(L, flip);
   return 1;
 }
 
-int lua_setcolorbarindex(lua_State *L) {
+int LuaSetcolorbarindex(lua_State *L) {
   int chosen_index = lua_tonumber(L, 1);
-  setcolorbarindex(chosen_index);
+  Setcolorbarindex(chosen_index);
   return 0;
 }
 
-int lua_getcolorbarindex(lua_State *L) {
-  int index = getcolorbarindex();
+int LuaGetcolorbarindex(lua_State *L) {
+  int index = Getcolorbarindex();
   lua_pushnumber(L, index);
   return 1;
 }
 
-int lua_set_slice_in_obst(lua_State *L) {
+int LuaSetSliceInObst(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_slice_in_obst(setting);
+  SetSliceInObst(setting);
   return 0;
 }
 
-int lua_get_slice_in_obst(lua_State *L) {
-  int setting = get_slice_in_obst();
+int LuaGetSliceInObst(lua_State *L) {
+  int setting = GetSliceInObst();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_set_colorbar(lua_State *L) {
+int LuaSetColorbar(lua_State *L) {
   int index = lua_tonumber(L, 1);
-  set_colorbar(index);
+  SetColorbar(index);
   return 0;
 }
 
-int lua_set_named_colorbar(lua_State *L) {
+int LuaSetNamedColorbar(lua_State *L) {
   const char *name = lua_tostring(L, 1);
-  int err = set_named_colorbar(name);
+  int err = SetNamedColorbar(name);
   if (err == 1) {
     luaL_error(L, "%s is not a valid colorbar name", name);
   }
@@ -2144,7 +2156,7 @@ int lua_set_named_colorbar(lua_State *L) {
 }
 
 // int lua_get_named_colorbar(lua_State *L) {
-//   int err = get_named_colorbar();
+//   int err = GetNamedColorbar();
 //   if (err == 1) {
 //     luaL_error(L, "%s is not a valid colorbar name", name);
 //   }
@@ -2153,546 +2165,546 @@ int lua_set_named_colorbar(lua_State *L) {
 
 //////////////////////
 
-int lua_set_colorbar_visibility(lua_State *L) {
+int LuaSetColorbarVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_colorbar_visibility(setting);
+  SetColorbarVisibility(setting);
   return 0;
 }
 
-int lua_get_colorbar_visibility(lua_State *L) {
-  int setting = get_colorbar_visibility();
+int LuaGetColorbarVisibility(lua_State *L) {
+  int setting = GetColorbarVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_colorbar_visibility(lua_State *L) {
-  toggle_colorbar_visibility();
+int LuaToggleColorbarVisibility(lua_State *L) {
+  ToggleColorbarVisibility();
   return 0;
 }
 
-int lua_set_colorbar_visibility_horizontal(lua_State *L) {
+int LuaSetColorbarVisibilityHorizontal(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_colorbar_visibility_horizontal(setting);
+  SetColorbarVisibilityHorizontal(setting);
   return 0;
 }
 
-int lua_get_colorbar_visibility_horizontal(lua_State *L) {
-  int setting = get_colorbar_visibility_horizontal();
+int LuaGetColorbarVisibilityHorizontal(lua_State *L) {
+  int setting = GetColorbarVisibilityHorizontal();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_colorbar_visibility_horizontal(lua_State *L) {
-  toggle_colorbar_visibility_horizontal();
+int LuaToggleColorbarVisibilityHorizontal(lua_State *L) {
+  ToggleColorbarVisibilityHorizontal();
   return 0;
 }
 
-int lua_set_colorbar_visibility_vertical(lua_State *L) {
+int LuaSetColorbarVisibilityVertical(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_colorbar_visibility_vertical(setting);
+  SetColorbarVisibilityVertical(setting);
   return 0;
 }
 
-int lua_get_colorbar_visibility_vertical(lua_State *L) {
-  int setting = get_colorbar_visibility_vertical();
+int LuaGetColorbarVisibilityVertical(lua_State *L) {
+  int setting = GetColorbarVisibilityVertical();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_colorbar_visibility_vertical(lua_State *L) {
-  toggle_colorbar_visibility_vertical();
+int LuaToggleColorbarVisibilityVertical(lua_State *L) {
+  ToggleColorbarVisibilityVertical();
   return 0;
 }
 
-int lua_set_timebar_visibility(lua_State *L) {
+int LuaSetTimebarVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_timebar_visibility(setting);
+  SetTimebarVisibility(setting);
   return 0;
 }
 
-int lua_get_timebar_visibility(lua_State *L) {
-  int setting = get_timebar_visibility();
+int LuaGetTimebarVisibility(lua_State *L) {
+  int setting = GetTimebarVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_timebar_visibility(lua_State *L) {
-  toggle_timebar_visibility();
+int LuaToggleTimebarVisibility(lua_State *L) {
+  ToggleTimebarVisibility();
   return 0;
 }
 
 // title
-int lua_set_title_visibility(lua_State *L) {
+int LuaSetTitleVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_title_visibility(setting);
+  SetTitleVisibility(setting);
   return 0;
 }
 
-int lua_get_title_visibility(lua_State *L) {
-  int setting = get_title_visibility();
+int LuaGetTitleVisibility(lua_State *L) {
+  int setting = GetTitleVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_title_visibility(lua_State *L) {
-  toggle_title_visibility();
+int LuaToggleTitleVisibility(lua_State *L) {
+  ToggleTitleVisibility();
   return 0;
 }
 
 // smv_version
-int lua_set_smv_version_visibility(lua_State *L) {
+int LuaSetSmvVersionVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_smv_version_visibility(setting);
+  SetSmvVersionVisibility(setting);
   return 0;
 }
 
-int lua_get_smv_version_visibility(lua_State *L) {
-  int setting = get_smv_version_visibility();
+int LuaGetSmvVersionVisibility(lua_State *L) {
+  int setting = GetSmvVersionVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_smv_version_visibility(lua_State *L) {
-  toggle_smv_version_visibility();
+int LuaToggleSmvVersionVisibility(lua_State *L) {
+  ToggleSmvVersionVisibility();
   return 0;
 }
 
 // chid
-int lua_set_chid_visibility(lua_State *L) {
+int LuaSetChidVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_chid_visibility(setting);
+  SetChidVisibility(setting);
   return 0;
 }
 
-int lua_get_chid_visibility(lua_State *L) {
-  int setting = get_chid_visibility();
+int LuaGetChidVisibility(lua_State *L) {
+  int setting = GetChidVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_chid_visibility(lua_State *L) {
-  toggle_chid_visibility();
+int LuaToggleChidVisibility(lua_State *L) {
+  ToggleChidVisibility();
   return 0;
 }
 
 // blockages
-int lua_blockages_hide_all(lua_State *L) {
-  blockages_hide_all();
+int LuaBlockagesHideAll(lua_State *L) {
+  BlockagesHideAll();
   return 0;
 }
 
 // outlines
-int lua_outlines_hide(lua_State *L) {
-  outlines_hide();
+int LuaOutlinesHide(lua_State *L) {
+  OutlinesHide();
   return 0;
 }
-int lua_outlines_show(lua_State *L) {
-  outlines_show();
+int LuaOutlinesShow(lua_State *L) {
+  OutlinesShow();
   return 0;
 }
 
 // surfaces
-int lua_surfaces_hide_all(lua_State *L) {
-  surfaces_hide_all();
+int LuaSurfacesHideAll(lua_State *L) {
+  SurfacesHideAll();
   return 0;
 }
 
 // devices
-int lua_devices_hide_all(lua_State *L) {
-  devices_hide_all();
+int LuaDevicesHideAll(lua_State *L) {
+  DevicesHideAll();
   return 0;
 }
 
 // axis
-int lua_set_axis_visibility(lua_State *L) {
+int LuaSetAxisVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_axis_visibility(setting);
+  SetAxisVisibility(setting);
   return 0;
 }
 
-int lua_get_axis_visibility(lua_State *L) {
-  int setting = get_axis_visibility();
+int LuaGetAxisVisibility(lua_State *L) {
+  int setting = GetAxisVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_axis_visibility(lua_State *L) {
-  toggle_axis_visibility();
+int LuaToggleAxisVisibility(lua_State *L) {
+  ToggleAxisVisibility();
   return 0;
 }
 
 // frame
-int lua_set_framelabel_visibility(lua_State *L) {
+int LuaSetFramelabelVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_framelabel_visibility(setting);
+  SetFramelabelVisibility(setting);
   return 0;
 }
 
-int lua_get_framelabel_visibility(lua_State *L) {
-  int setting = get_framelabel_visibility();
+int LuaGetFramelabelVisibility(lua_State *L) {
+  int setting = GetFramelabelVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_framelabel_visibility(lua_State *L) {
-  toggle_framelabel_visibility();
+int LuaToggleFramelabelVisibility(lua_State *L) {
+  ToggleFramelabelVisibility();
   return 0;
 }
 
 // framerate
-int lua_set_framerate_visibility(lua_State *L) {
+int LuaSetFramerateVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_framerate_visibility(setting);
+  SetFramerateVisibility(setting);
   return 0;
 }
 
-int lua_get_framerate_visibility(lua_State *L) {
-  int setting = get_framerate_visibility();
+int LuaGetFramerateVisibility(lua_State *L) {
+  int setting = GetFramerateVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_framerate_visibility(lua_State *L) {
-  toggle_framerate_visibility();
+int LuaToggleFramerateVisibility(lua_State *L) {
+  ToggleFramerateVisibility();
   return 0;
 }
 
 // grid locations
-int lua_set_gridloc_visibility(lua_State *L) {
+int LuaSetGridlocVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_gridloc_visibility(setting);
+  SetGridlocVisibility(setting);
   return 0;
 }
 
-int lua_get_gridloc_visibility(lua_State *L) {
-  int setting = get_gridloc_visibility();
+int LuaGetGridlocVisibility(lua_State *L) {
+  int setting = GetGridlocVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_gridloc_visibility(lua_State *L) {
-  toggle_gridloc_visibility();
+int LuaToggleGridlocVisibility(lua_State *L) {
+  ToggleGridlocVisibility();
   return 0;
 }
 
 // hrrpuv cutoff
-int lua_set_hrrcutoff_visibility(lua_State *L) {
+int LuaSetHrrcutoffVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_hrrcutoff_visibility(setting);
+  SetHrrcutoffVisibility(setting);
   return 0;
 }
 
-int lua_get_hrrcutoff_visibility(lua_State *L) {
-  int setting = get_hrrcutoff_visibility();
+int LuaGetHrrcutoffVisibility(lua_State *L) {
+  int setting = GetHrrcutoffVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_hrrcutoff_visibility(lua_State *L) {
-  toggle_hrrcutoff_visibility();
+int LuaToggleHrrcutoffVisibility(lua_State *L) {
+  ToggleHrrcutoffVisibility();
   return 0;
 }
 
 // HRR Label Visbility
-int lua_set_hrrlabel_visibility(lua_State *L) {
+int LuaSetHrrlabelVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_hrrlabel_visibility(setting);
+  SetHrrlabelVisibility(setting);
   return 0;
 }
 
-int lua_get_hrrlabel_visibility(lua_State *L) {
-  int setting = get_hrrlabel_visibility();
+int LuaGetHrrlabelVisibility(lua_State *L) {
+  int setting = GetHrrlabelVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_hrrlabel_visibility(lua_State *L) {
-  toggle_hrrlabel_visibility();
+int LuaToggleHrrlabelVisibility(lua_State *L) {
+  ToggleHrrlabelVisibility();
   return 0;
 }
 // memory load
 #ifdef pp_memstatus
-int lua_set_memload_visibility(lua_State *L) {
+int LuaSetMemloadVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
   set_memload_visibility(setting);
   return 0;
 }
 
-int lua_get_memload_visibility(lua_State *L) {
+int LuaGetMemloadVisibility(lua_State *L) {
   int setting = get_memload_visibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_memload_visibility(lua_State *L) {
+int LuaToggleMemloadVisibility(lua_State *L) {
   toggle_memload_visibility();
   return 0;
 }
 #endif
 
 // mesh label
-int lua_set_meshlabel_visibility(lua_State *L) {
+int LuaSetMeshlabelVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_meshlabel_visibility(setting);
+  SetMeshlabelVisibility(setting);
   return 0;
 }
 
-int lua_get_meshlabel_visibility(lua_State *L) {
-  int setting = get_meshlabel_visibility();
+int LuaGetMeshlabelVisibility(lua_State *L) {
+  int setting = GetMeshlabelVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_meshlabel_visibility(lua_State *L) {
-  toggle_meshlabel_visibility();
+int LuaToggleMeshlabelVisibility(lua_State *L) {
+  ToggleMeshlabelVisibility();
   return 0;
 }
 
 // slice average
-int lua_set_slice_average_visibility(lua_State *L) {
+int LuaSetSliceAverageVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_slice_average_visibility(setting);
+  SetSliceAverageVisibility(setting);
   return 0;
 }
 
-int lua_get_slice_average_visibility(lua_State *L) {
-  int setting = get_slice_average_visibility();
+int LuaGetSliceAverageVisibility(lua_State *L) {
+  int setting = GetSliceAverageVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_slice_average_visibility(lua_State *L) {
-  toggle_slice_average_visibility();
+int LuaToggleSliceAverageVisibility(lua_State *L) {
+  ToggleSliceAverageVisibility();
   return 0;
 }
 
 // time
-int lua_set_time_visibility(lua_State *L) {
+int LuaSetTimeVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_time_visibility(setting);
+  SetTimeVisibility(setting);
   return 0;
 }
 
-int lua_get_time_visibility(lua_State *L) {
-  int setting = get_time_visibility();
+int LuaGetTimeVisibility(lua_State *L) {
+  int setting = GetTimeVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_time_visibility(lua_State *L) {
-  toggle_time_visibility();
+int LuaToggleTimeVisibility(lua_State *L) {
+  ToggleTimeVisibility();
   return 0;
 }
 
 // user settable ticks
-int lua_set_user_ticks_visibility(lua_State *L) {
+int LuaSetUserTicksVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_user_ticks_visibility(setting);
+  SetUserTicksVisibility(setting);
   return 0;
 }
 
-int lua_get_user_ticks_visibility(lua_State *L) {
-  int setting = get_user_ticks_visibility();
+int LuaGetUserTicksVisibility(lua_State *L) {
+  int setting = GetUserTicksVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_user_ticks_visibility(lua_State *L) {
-  toggle_user_ticks_visibility();
+int LuaToggleUserTicksVisibility(lua_State *L) {
+  ToggleUserTicksVisibility();
   return 0;
 }
 
 // version info
-int lua_set_version_info_visibility(lua_State *L) {
+int LuaSetVersionInfoVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_version_info_visibility(setting);
+  SetVersionInfoVisibility(setting);
   return 0;
 }
 
-int lua_get_version_info_visibility(lua_State *L) {
-  int setting = get_version_info_visibility();
+int LuaGetVersionInfoVisibility(lua_State *L) {
+  int setting = GetVersionInfoVisibility();
   lua_pushboolean(L, setting);
   return 1;
 }
 
-int lua_toggle_version_info_visibility(lua_State *L) {
-  toggle_version_info_visibility();
+int LuaToggleVersionInfoVisibility(lua_State *L) {
+  ToggleVersionInfoVisibility();
   return 0;
 }
 
 // set all
-int lua_set_all_label_visibility(lua_State *L) {
+int LuaSetAllLabelVisibility(lua_State *L) {
   int setting = lua_toboolean(L, 1);
-  set_all_label_visibility(setting);
+  SetAllLabelVisibility(setting);
   return 0;
 }
 
 //////////////////////////////////////
 
-int lua_blockage_view_method(lua_State *L) {
+int LuaBlockageViewMethod(lua_State *L) {
   int setting = lua_tonumber(L, 1);
-  int return_code = blockage_view_method(setting);
+  int return_code = BlockageViewMethod(setting);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_blockage_outline_color(lua_State *L) {
+int LuaBlockageOutlineColor(lua_State *L) {
   int setting = lua_tonumber(L, 1);
-  int return_code = blockage_outline_color(setting);
+  int return_code = BlockageOutlineColor(setting);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_blockage_locations(lua_State *L) {
+int LuaBlockageLocations(lua_State *L) {
   int setting = lua_tonumber(L, 1);
-  int return_code = blockage_locations(setting);
+  int return_code = BlockageLocations(setting);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_camera_mod_eyex(lua_State *L) {
+int LuaCameraModEyex(lua_State *L) {
   float delta = lua_tonumber(L, 1);
-  camera_mod_eyex(delta);
+  CameraModEyex(delta);
   return 0;
 }
 
-int lua_camera_set_eyex(lua_State *L) {
+int LuaCameraSetEyex(lua_State *L) {
   float eyex = lua_tonumber(L, 1);
-  camera_set_eyex(eyex);
+  CameraSetEyex(eyex);
   return 0;
 }
 
-int lua_camera_mod_eyey(lua_State *L) {
+int LuaCameraModEyey(lua_State *L) {
   float delta = lua_tonumber(L, 1);
-  camera_mod_eyey(delta);
+  CameraModEyey(delta);
   return 0;
 }
 
-int lua_camera_set_eyey(lua_State *L) {
+int LuaCameraSetEyey(lua_State *L) {
   float eyey = lua_tonumber(L, 1);
-  camera_set_eyey(eyey);
+  CameraSetEyey(eyey);
   return 0;
 }
 
-int lua_camera_mod_eyez(lua_State *L) {
+int LuaCameraModEyez(lua_State *L) {
   float delta = lua_tonumber(L, 1);
-  camera_mod_eyez(delta);
+  CameraModEyez(delta);
   return 0;
 }
 
-int lua_camera_set_eyez(lua_State *L) {
+int LuaCameraSetEyez(lua_State *L) {
   float eyez = lua_tonumber(L, 1);
-  camera_set_eyez(eyez);
+  CameraSetEyez(eyez);
   return 0;
 }
 
-int lua_camera_mod_az(lua_State *L) {
+int LuaCameraModAz(lua_State *L) {
   float delta = lua_tonumber(L, 1);
-  camera_mod_az(delta);
+  CameraModAz(delta);
   return 0;
 }
 
-int lua_camera_set_az(lua_State *L) {
+int LuaCameraSetAz(lua_State *L) {
   float az = lua_tonumber(L, 1);
-  camera_set_az(az);
+  CameraSetAz(az);
   return 0;
 }
 
-int lua_camera_get_az(lua_State *L) {
-  lua_pushnumber(L, camera_get_az());
+int LuaCameraGetAz(lua_State *L) {
+  lua_pushnumber(L, CameraGetAz());
   return 1;
 }
 
-int lua_camera_mod_elev(lua_State *L) {
+int LuaCameraModElev(lua_State *L) {
   float delta = lua_tonumber(L, 1);
-  camera_mod_elev(delta);
+  CameraModElev(delta);
   return 0;
 }
-int lua_camera_zoom_to_fit(lua_State *L) {
-  camera_zoom_to_fit();
+int LuaCameraZoomToFit(lua_State *L) {
+  CameraZoomToFit();
   return 0;
 }
 
-int lua_camera_set_elev(lua_State *L) {
+int LuaCameraSetElev(lua_State *L) {
   float elev = lua_tonumber(L, 1);
-  camera_set_elev(elev);
+  CameraSetElev(elev);
   return 0;
 }
 
-int lua_camera_get_elev(lua_State *L) {
-  lua_pushnumber(L, camera_get_elev());
+int LuaCameraGetElev(lua_State *L) {
+  lua_pushnumber(L, CameraGetElev());
   return 1;
 }
-int lua_camera_get_projection_type(lua_State *L) {
-  float projection_type = camera_get_projection_type();
+int LuaCameraGetProjectionType(lua_State *L) {
+  float projection_type = CameraGetProjectionType();
   lua_pushnumber(L, projection_type);
   return 1;
 }
-int lua_camera_set_projection_type(lua_State *L) {
+int LuaCameraSetProjectionType(lua_State *L) {
   float projection_type = lua_tonumber(L, 1);
-  int return_value = camera_set_projection_type(projection_type);
+  int return_value = CameraSetProjectionType(projection_type);
   lua_pushnumber(L, return_value);
   return 1;
 }
 
-int lua_camera_get_rotation_type(lua_State *L) {
-  float rotation_type = camera_get_rotation_type();
+int LuaCameraGetRotationType(lua_State *L) {
+  float rotation_type = CameraGetRotationType();
   lua_pushnumber(L, rotation_type);
   return 1;
 }
 
-int lua_camera_get_rotation_index(lua_State *L) {
-  float rotation_index = camera_get_rotation_index();
+int LuaCameraGetRotationIndex(lua_State *L) {
+  float rotation_index = CameraGetRotationIndex();
   lua_pushnumber(L, rotation_index);
   return 1;
 }
 
-int lua_camera_set_rotation_type(lua_State *L) {
+int LuaCameraSetRotationType(lua_State *L) {
   int rotation_type = lua_tonumber(L, 1);
-  camera_set_rotation_type(rotation_type);
+  CameraSetRotationType(rotation_type);
   return 0;
 }
 
-int lua_camera_get_zoom(lua_State *L) {
+int LuaCameraGetZoom(lua_State *L) {
   lua_pushnumber(L, zoom);
   return 1;
 }
 
-int lua_camera_set_zoom(lua_State *L) {
+int LuaCameraSetZoom(lua_State *L) {
   float x = lua_tonumber(L, 1);
   zoom = x;
   return 0;
 }
 
-int lua_camera_get_eyex(lua_State *L) {
-  float eyex = camera_get_eyex();
+int LuaCameraGetEyex(lua_State *L) {
+  float eyex = CameraGetEyex();
   lua_pushnumber(L, eyex);
   return 1;
 }
 
-int lua_camera_get_eyey(lua_State *L) {
-  float eyey = camera_get_eyex();
+int LuaCameraGetEyey(lua_State *L) {
+  float eyey = CameraGetEyex();
   lua_pushnumber(L, eyey);
   return 1;
 }
 
-int lua_camera_get_eyez(lua_State *L) {
-  float eyez = camera_get_eyez();
+int LuaCameraGetEyez(lua_State *L) {
+  float eyez = CameraGetEyez();
   lua_pushnumber(L, eyez);
   return 1;
 }
-int lua_camera_set_viewdir(lua_State *L) {
+int LuaCameraSetViewdir(lua_State *L) {
   float xcen = lua_tonumber(L, 1);
   float ycen = lua_tonumber(L, 2);
   float zcen = lua_tonumber(L, 3);
-  camera_set_viewdir(xcen, ycen, zcen);
+  CameraSetViewdir(xcen, ycen, zcen);
   return 0;
 }
 
-int lua_camera_get_viewdir(lua_State *L) {
-  float xcen = camera_get_xcen();
-  float ycen = camera_get_ycen();
-  float zcen = camera_get_zcen();
+int LuaCameraGetViewdir(lua_State *L) {
+  float xcen = CameraGetXcen();
+  float ycen = CameraGetYcen();
+  float zcen = CameraGetZcen();
 
   lua_createtable(L, 0, 3);
 
@@ -2711,27 +2723,27 @@ int lua_camera_get_viewdir(lua_State *L) {
   return 1;
 }
 
-int lua_set_slice_bounds(lua_State *L) {
+int LuaSetSliceBounds(lua_State *L) {
   const char *slice_type = lua_tostring(L, 1);
   int set_min = lua_tonumber(L, 2);
   float value_min = lua_tonumber(L, 3);
   int set_max = lua_tonumber(L, 4);
   float value_max = lua_tonumber(L, 5);
-  set_slice_bounds(slice_type, set_min, value_min, set_max, value_max);
+  CApiSetSliceBounds(slice_type, set_min, value_min, set_max, value_max);
   return 0;
 }
-int lua_set_slice_bound_min(lua_State *L) {
+int LuaSetSliceBoundMin(lua_State *L) {
   const char *slice_type = lua_tostring(L, 1);
   int set = lua_toboolean(L, 2);
   float value = lua_tonumber(L, 3);
-  set_slice_bound_min(slice_type, set, value);
+  SetSliceBoundMin(slice_type, set, value);
   return 0;
 }
 
-int lua_get_slice_bounds(lua_State *L) {
+int LuaGetSliceBounds(lua_State *L) {
   const char *slice_type = lua_tostring(L, 1);
   simple_bounds bounds;
-  if (get_slice_bounds(slice_type, &bounds)) {
+  if (GetSliceBounds(slice_type, &bounds)) {
     luaL_error(L, "Could not get slice bounds for %s", slice_type);
   }
   lua_pushnumber(L, bounds.min);
@@ -2739,24 +2751,24 @@ int lua_get_slice_bounds(lua_State *L) {
   return 2;
 }
 
-int lua_set_slice_bound_max(lua_State *L) {
+int LuaSetSliceBoundMax(lua_State *L) {
   const char *slice_type = lua_tostring(L, 1);
   int set = lua_toboolean(L, 2);
   float value = lua_tonumber(L, 3);
-  set_slice_bound_max(slice_type, set, value);
+  SetSliceBoundMax(slice_type, set, value);
   return 0;
 }
 
-int lua_set_ambientlight(lua_State *L) {
+int LuaSetAmbientlight(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_ambientlight(r, g, b);
+  int return_code = SetAmbientlight(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_get_backgroundcolor(lua_State *L) {
+int LuaGetBackgroundcolor(lua_State *L) {
   lua_createtable(L, 0, 3);
 
   lua_pushnumber(L, backgroundbasecolor[0]);
@@ -2771,45 +2783,45 @@ int lua_get_backgroundcolor(lua_State *L) {
   return 1;
 }
 
-int lua_set_backgroundcolor(lua_State *L) {
+int LuaSetBackgroundcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_backgroundcolor(r, g, b);
+  int return_code = SetBackgroundcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_blockcolor(lua_State *L) {
+int LuaSetBlockcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_blockcolor(r, g, b);
+  int return_code = SetBlockcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_blockshininess(lua_State *L) {
+int LuaSetBlockshininess(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_blockshininess(v);
+  int return_code = SetBlockshininess(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_blockspecular(lua_State *L) {
+int LuaSetBlockspecular(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_blockspecular(r, g, b);
+  int return_code = SetBlockspecular(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_boundcolor(lua_State *L) {
+int LuaSetBoundcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_boundcolor(r, g, b);
+  int return_code = SetBoundcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -2821,7 +2833,7 @@ int lua_set_boundcolor(lua_State *L) {
 //   return 1;
 // }
 
-float getcolorfield(lua_State *L, int stack_index, const char *key) {
+float Getcolorfield(lua_State *L, int stack_index, const char *key) {
   if (!lua_istable(L, stack_index)) {
     fprintf(stderr,
             "stack is not a table at index, cannot use getcolorfield\n");
@@ -2838,20 +2850,20 @@ float getcolorfield(lua_State *L, int stack_index, const char *key) {
   return result;
 }
 
-int get_color(lua_State *L, int stack_index, float *color) {
+int GetColor(lua_State *L, int stack_index, float *color) {
   if (!lua_istable(L, stack_index)) {
     fprintf(stderr, "color table is not present\n");
     return 1;
   }
-  float r = getcolorfield(L, stack_index, "r");
-  float g = getcolorfield(L, stack_index, "g");
-  float b = getcolorfield(L, stack_index, "b");
+  float r = Getcolorfield(L, stack_index, "r");
+  float g = Getcolorfield(L, stack_index, "g");
+  float b = Getcolorfield(L, stack_index, "b");
   color[0] = r;
   color[1] = g;
   color[2] = b;
   return 0;
 }
-int lua_set_colorbar_colors(lua_State *L) {
+int LuaSetColorbarColors(lua_State *L) {
   printf("running: lua_set_colorbar_colors\n");
   if (!lua_istable(L, 1)) {
     fprintf(stderr, "colorbar table is not present\n");
@@ -2868,19 +2880,20 @@ int lua_set_colorbar_colors(lua_State *L) {
     for (int i = 1; i <= ncolors; i++) {
       lua_pushnumber(L, i);
       lua_gettable(L, 1);
-      get_color(L, -1, &colors[i - 1]);
+      GetColor(L, -1, &colors[i - 1]);
     }
 
-    int return_code = set_colorbar_colors(ncolors, colors);
+    int return_code = SetColorbarColors(ncolors, colors);
     lua_pushnumber(L, return_code);
     free(colors);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_get_colorbar_colors(lua_State *L) {
+int LuaGetColorbarColors(lua_State *L) {
   int i;
   float *rgb_ini_copy_p = rgb_ini;
   lua_createtable(L, 0, nrgb_ini);
@@ -2904,7 +2917,7 @@ int lua_get_colorbar_colors(lua_State *L) {
   return 1;
 }
 
-int lua_set_color2bar_colors(lua_State *L) {
+int LuaSetColor2barColors(lua_State *L) {
   int ncolors = lua_tonumber(L, 1);
   if (!lua_istable(L, -1)) {
     fprintf(stderr, "colorbar table is not present\n");
@@ -2915,19 +2928,20 @@ int lua_set_color2bar_colors(lua_State *L) {
     for (size_t i = 1; i <= ncolors; i++) {
       lua_pushnumber(L, i);
       lua_gettable(L, -2);
-      get_color(L, -1, &colors[i - 1]);
+      GetColor(L, -1, &colors[i - 1]);
     }
 
-    int return_code = set_color2bar_colors(ncolors, colors);
+    int return_code = SetColor2barColors(ncolors, colors);
     lua_pushnumber(L, return_code);
     free(colors);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_get_color2bar_colors(lua_State *L) {
+int LuaGetColor2barColors(lua_State *L) {
   int i;
   float *rgb_ini_copy_p = rgb2_ini;
   lua_createtable(L, 0, nrgb2_ini);
@@ -2951,37 +2965,37 @@ int lua_get_color2bar_colors(lua_State *L) {
   return 1;
 }
 
-int lua_set_diffuselight(lua_State *L) {
+int LuaSetDiffuselight(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_diffuselight(r, g, b);
+  int return_code = SetDiffuselight(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_directioncolor(lua_State *L) {
+int LuaSetDirectioncolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_directioncolor(r, g, b);
+  int return_code = SetDirectioncolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_flip(lua_State *L) {
+int LuaSetFlip(lua_State *L) {
   int v = lua_toboolean(L, 1);
-  int return_code = set_flip(v);
+  int return_code = SetFlip(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_get_flip(lua_State *L) {
-  lua_pushboolean(L, get_flip());
+int LuaGetFlip(lua_State *L) {
+  lua_pushboolean(L, GetFlip());
   return 1;
 }
 
-int lua_get_foregroundcolor(lua_State *L) {
+int LuaGetForegroundcolor(lua_State *L) {
   lua_createtable(L, 0, 3);
 
   lua_pushnumber(L, foregroundbasecolor[0]);
@@ -2996,40 +3010,40 @@ int lua_get_foregroundcolor(lua_State *L) {
   return 1;
 }
 
-int lua_set_foregroundcolor(lua_State *L) {
+int LuaSetForegroundcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_foregroundcolor(r, g, b);
+  int return_code = SetForegroundcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_heatoffcolor(lua_State *L) {
+int LuaSetHeatoffcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_heatoffcolor(r, g, b);
+  int return_code = SetHeatoffcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_heatoncolor(lua_State *L) {
+int LuaSetHeatoncolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_heatoncolor(r, g, b);
+  int return_code = SetHeatoncolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_isocolors(lua_State *L) {
+int LuaSetIsocolors(lua_State *L) {
   float shininess = lua_tonumber(L, 1);
   float transparency = lua_tonumber(L, 2);
   int transparency_option = lua_tonumber(L, 3);
   int opacity_change = lua_tonumber(L, 4);
   float specular[3];
-  get_color(L, 5, specular);
+  GetColor(L, 5, specular);
   int n_colors = 0;
   // count the number of colours
   lua_pushnil(L); /* first key */
@@ -3046,15 +3060,15 @@ int lua_set_isocolors(lua_State *L) {
     }
     lua_pushnumber(L, i);
     lua_gettable(L, 6);
-    get_color(L, -1, colors[i - 1]);
+    GetColor(L, -1, colors[i - 1]);
   }
-  int return_code = set_isocolors(shininess, transparency, transparency_option,
+  int return_code = SetIsocolors(shininess, transparency, transparency_option,
                                   opacity_change, specular, n_colors, colors);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_colortable(lua_State *L) {
+int LuaSetColortable(lua_State *L) {
   // int ncolors = lua_tonumber(L, 1);
   int ncolors = 0;
   int i = 0;
@@ -3074,7 +3088,7 @@ int lua_set_colortable(lua_State *L) {
     while (lua_next(L, 1) != 0) {
       /* uses 'key' (at index -2) and 'value' (at index -1) */
       // strncpy(names[i], lua_tostring(L, -2), 255);
-      get_color(L, -1, &colors[i]);
+      GetColor(L, -1, &colors[i]);
       /* removes 'value'; keeps 'key' for next iteration */
       lua_pop(L, 1);
       i++;
@@ -3085,489 +3099,489 @@ int lua_set_colortable(lua_State *L) {
   return 0;
 }
 
-int lua_set_lightpos0(lua_State *L) {
+int LuaSetLightpos0(lua_State *L) {
   float a = lua_tonumber(L, 1);
   float b = lua_tonumber(L, 2);
   float c = lua_tonumber(L, 3);
   float d = lua_tonumber(L, 4);
-  int return_code = set_lightpos0(a, b, c, d);
+  int return_code = SetLightpos0(a, b, c, d);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_lightpos1(lua_State *L) {
+int LuaSetLightpos1(lua_State *L) {
   float a = lua_tonumber(L, 1);
   float b = lua_tonumber(L, 2);
   float c = lua_tonumber(L, 3);
   float d = lua_tonumber(L, 4);
-  int return_code = set_lightpos1(a, b, c, d);
+  int return_code = SetLightpos1(a, b, c, d);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sensorcolor(lua_State *L) {
+int LuaSetSensorcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_sensorcolor(r, g, b);
+  int return_code = SetSensorcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sensornormcolor(lua_State *L) {
+int LuaSetSensornormcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_sensornormcolor(r, g, b);
+  int return_code = SetSensornormcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_bw(lua_State *L) {
+int LuaSetBw(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 2);
-  int return_code = set_bw(a, b);
+  int return_code = SetBw(a, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sprinkleroffcolor(lua_State *L) {
+int LuaSetSprinkleroffcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_sprinkleroffcolor(r, g, b);
+  int return_code = SetSprinkleroffcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sprinkleroncolor(lua_State *L) {
+int LuaSetSprinkleroncolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_sprinkleroncolor(r, g, b);
+  int return_code = SetSprinkleroncolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_staticpartcolor(lua_State *L) {
+int LuaSetStaticpartcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_staticpartcolor(r, g, b);
+  int return_code = SetStaticpartcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_timebarcolor(lua_State *L) {
+int LuaSetTimebarcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_timebarcolor(r, g, b);
+  int return_code = SetTimebarcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_ventcolor(lua_State *L) {
+int LuaSetVentcolor(lua_State *L) {
   float r = lua_tonumber(L, 1);
   float g = lua_tonumber(L, 2);
   float b = lua_tonumber(L, 3);
-  int return_code = set_ventcolor(r, g, b);
+  int return_code = SetVentcolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_gridlinewidth(lua_State *L) {
+int LuaSetGridlinewidth(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_gridlinewidth(v);
+  int return_code = SetGridlinewidth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_isolinewidth(lua_State *L) {
+int LuaSetIsolinewidth(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_isolinewidth(v);
+  int return_code = SetIsolinewidth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_isopointsize(lua_State *L) {
+int LuaSetIsopointsize(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_isopointsize(v);
+  int return_code = SetIsopointsize(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_linewidth(lua_State *L) {
+int LuaSetLinewidth(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_linewidth(v);
+  int return_code = SetLinewidth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_partpointsize(lua_State *L) {
+int LuaSetPartpointsize(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_partpointsize(v);
+  int return_code = SetPartpointsize(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_plot3dlinewidth(lua_State *L) {
+int LuaSetPlot3dlinewidth(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_plot3dlinewidth(v);
+  int return_code = SetPlot3dlinewidth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_plot3dpointsize(lua_State *L) {
+int LuaSetPlot3dpointsize(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_plot3dpointsize(v);
+  int return_code = SetPlot3dpointsize(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sensorabssize(lua_State *L) {
+int LuaSetSensorabssize(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_sensorabssize(v);
+  int return_code = SetSensorabssize(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sensorrelsize(lua_State *L) {
+int LuaSetSensorrelsize(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_sensorrelsize(v);
+  int return_code = SetSensorrelsize(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sliceoffset(lua_State *L) {
+int LuaSetSliceoffset(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_sliceoffset(v);
+  int return_code = SetSliceoffset(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_smoothlines(lua_State *L) {
+int LuaSetSmoothlines(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_smoothlines(v);
+  int return_code = SetSmoothlines(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_spheresegs(lua_State *L) {
+int LuaSetSpheresegs(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_spheresegs(v);
+  int return_code = SetSpheresegs(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sprinklerabssize(lua_State *L) {
+int LuaSetSprinklerabssize(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_sprinklerabssize(v);
+  int return_code = SetSprinklerabssize(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_streaklinewidth(lua_State *L) {
+int LuaSetStreaklinewidth(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_streaklinewidth(v);
+  int return_code = SetStreaklinewidth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_ticklinewidth(lua_State *L) {
+int LuaSetTicklinewidth(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_ticklinewidth(v);
+  int return_code = SetTicklinewidth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_usenewdrawface(lua_State *L) {
+int LuaSetUsenewdrawface(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_usenewdrawface(v);
+  int return_code = SetUsenewdrawface(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_veclength(lua_State *L) {
+int LuaSetVeclength(lua_State *L) {
   float vf = lua_tonumber(L, 1);
   int vec_uniform_length = lua_tonumber(L, 2);
   int vec_uniform_spacing = lua_tonumber(L, 3);
-  int return_code = set_veclength(vf, vec_uniform_length, vec_uniform_spacing);
+  int return_code = SetVeclength(vf, vec_uniform_length, vec_uniform_spacing);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_vectorlinewidth(lua_State *L) {
+int LuaSetVectorlinewidth(lua_State *L) {
   float a = lua_tonumber(L, 1);
   float b = lua_tonumber(L, 2);
-  int return_code = set_vectorlinewidth(a, b);
+  int return_code = SetVectorlinewidth(a, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_vectorpointsize(lua_State *L) {
+int LuaSetVectorpointsize(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_vectorpointsize(v);
+  int return_code = SetVectorpointsize(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_ventlinewidth(lua_State *L) {
+int LuaSetVentlinewidth(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_ventlinewidth(v);
+  int return_code = SetVentlinewidth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_ventoffset(lua_State *L) {
+int LuaSetVentoffset(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_ventoffset(v);
+  int return_code = SetVentoffset(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_windowoffset(lua_State *L) {
+int LuaSetWindowoffset(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_windowoffset(v);
+  int return_code = SetWindowoffset(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_windowwidth(lua_State *L) {
+int LuaSetWindowwidth(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_windowwidth(v);
+  int return_code = SetWindowwidth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_windowheight(lua_State *L) {
+int LuaSetWindowheight(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_windowheight(v);
+  int return_code = SetWindowheight(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
 // --  *** DATA LOADING ***
 
-int lua_set_boundzipstep(lua_State *L) {
+int LuaSetBoundzipstep(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_boundzipstep(v);
+  int return_code = SetBoundzipstep(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_fed(lua_State *L) {
+int LuaSetFed(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_fed(v);
+  int return_code = SetFed(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_fedcolorbar(lua_State *L) {
+int LuaSetFedcolorbar(lua_State *L) {
   const char *name = lua_tostring(L, 1);
-  int return_code = set_fedcolorbar(name);
+  int return_code = SetFedcolorbar(name);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_isozipstep(lua_State *L) {
+int LuaSetIsozipstep(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_isozipstep(v);
+  int return_code = SetIsozipstep(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_nopart(lua_State *L) {
+int LuaSetNopart(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_nopart(v);
+  int return_code = SetNopart(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showfedarea(lua_State *L) {
+int LuaSetShowfedarea(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showfedarea(v);
+  int return_code = SetShowfedarea(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sliceaverage(lua_State *L) {
+int LuaSetSliceaverage(lua_State *L) {
   int flag = lua_tonumber(L, 1);
   float interval = lua_tonumber(L, 2);
   int vis = lua_tonumber(L, 3);
-  int return_code = set_sliceaverage(flag, interval, vis);
+  int return_code = SetSliceaverage(flag, interval, vis);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_slicedataout(lua_State *L) {
+int LuaSetSlicedataout(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_slicedataout(v);
+  int return_code = SetSlicedataout(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_slicezipstep(lua_State *L) {
+int LuaSetSlicezipstep(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_slicezipstep(v);
+  int return_code = SetSlicezipstep(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_smoke3dzipstep(lua_State *L) {
+int LuaSetSmoke3dzipstep(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_smoke3dzipstep(v);
+  int return_code = SetSmoke3dzipstep(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_userrotate(lua_State *L) {
+int LuaSetUserrotate(lua_State *L) {
   int index = lua_tonumber(L, 1);
   int show_center = lua_tonumber(L, 2);
   float x = lua_tonumber(L, 3);
   float y = lua_tonumber(L, 4);
   float z = lua_tonumber(L, 5);
-  int return_code = set_userrotate(index, show_center, x, y, z);
+  int return_code = SetUserrotate(index, show_center, x, y, z);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
 // --  *** VIEW PARAMETERS ***
-int lua_set_aperture(lua_State *L) {
+int LuaSetAperture(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_aperture(v);
+  int return_code = SetAperture(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_blocklocation(lua_State *L) {
+int LuaSetBlocklocation(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_blocklocation(v);
+  int return_code = SetBlocklocation(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_boundarytwoside(lua_State *L) {
+int LuaSetBoundarytwoside(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_boundarytwoside(v);
+  int return_code = SetBoundarytwoside(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_clip(lua_State *L) {
+int LuaSetClip(lua_State *L) {
   float v_near = lua_tonumber(L, 1);
   float v_far = lua_tonumber(L, 2);
-  int return_code = set_clip(v_near, v_far);
+  int return_code = SetClip(v_near, v_far);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_contourtype(lua_State *L) {
+int LuaSetContourtype(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_contourtype(v);
+  int return_code = SetContourtype(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_cullfaces(lua_State *L) {
+int LuaSetCullfaces(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_cullfaces(v);
+  int return_code = SetCullfaces(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_texturelighting(lua_State *L) {
+int LuaSetTexturelighting(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_texturelighting(v);
+  int return_code = SetTexturelighting(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_eyeview(lua_State *L) {
+int LuaSetEyeview(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_eyeview(v);
+  int return_code = SetEyeview(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_eyex(lua_State *L) {
+int LuaSetEyex(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_eyex(v);
+  int return_code = SetEyex(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_eyey(lua_State *L) {
+int LuaSetEyey(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_eyey(v);
+  int return_code = SetEyey(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_eyez(lua_State *L) {
+int LuaSetEyez(lua_State *L) {
   float v = lua_tonumber(L, 1);
-  int return_code = set_eyez(v);
+  int return_code = SetEyez(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_fontsize(lua_State *L) {
+int LuaSetFontsize(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_fontsize(v);
+  int return_code = SetFontsize(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_frameratevalue(lua_State *L) {
+int LuaSetFrameratevalue(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_frameratevalue(v);
+  int return_code = SetFrameratevalue(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showfaces_solid(lua_State *L) {
+int LuaSetShowfacesSolid(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showfaces_solid(v);
+  int return_code = SetShowfacesSolid(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showfaces_outline(lua_State *L) {
+int LuaSetShowfacesOutline(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showfaces_outline(v);
+  int return_code = SetShowfacesOutline(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_smoothgeomnormal(lua_State *L) {
+int LuaSetSmoothgeomnormal(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_smoothgeomnormal(v);
+  int return_code = SetSmoothgeomnormal(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_geomvertexag(lua_State *L) {
+int LuaSetGeomvertexag(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_geomvertexag(v);
+  int return_code = SetGeomvertexag(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_gversion(lua_State *L) {
+int LuaSetGversion(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_gversion(v);
+  int return_code = SetGversion(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_isotran2(lua_State *L) {
+int LuaSetIsotran2(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_isotran2(v);
+  int return_code = SetIsotran2(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_meshvis(lua_State *L) {
+int LuaSetMeshvis(lua_State *L) {
   int n = 0;
   int i = 0;
   // count the number of values
@@ -3587,76 +3601,77 @@ int lua_set_meshvis(lua_State *L) {
       lua_pop(L, 1);
       i++;
     }
-    int return_code = set_meshvis(n, vals);
+    int return_code = SetMeshvis(n, vals);
     lua_pushnumber(L, return_code);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_set_meshoffset(lua_State *L) {
+int LuaSetMeshoffset(lua_State *L) {
   int meshnum = lua_tonumber(L, 1);
   int value = lua_tonumber(L, 2);
-  int return_code = set_meshoffset(meshnum, value);
+  int return_code = SetMeshoffset(meshnum, value);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_northangle(lua_State *L) {
+int LuaSetNorthangle(lua_State *L) {
   int vis = lua_tonumber(L, 1);
   float x = lua_tonumber(L, 2);
   float y = lua_tonumber(L, 3);
   float z = lua_tonumber(L, 4);
-  int return_code = set_northangle(vis, x, y, z);
+  int return_code = SetNorthangle(vis, x, y, z);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_offsetslice(lua_State *L) {
+int LuaSetOffsetslice(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_offsetslice(v);
+  int return_code = SetOffsetslice(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_outlinemode(lua_State *L) {
+int LuaSetOutlinemode(lua_State *L) {
   int highlight = lua_tonumber(L, 1);
   int outline = lua_tonumber(L, 2);
-  int return_code = set_outlinemode(highlight, outline);
+  int return_code = SetOutlinemode(highlight, outline);
   lua_pushnumber(L, return_code);
   ;
   return 1;
 }
 
-int lua_set_p3dsurfacetype(lua_State *L) {
+int LuaSetP3dsurfacetype(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_p3dsurfacetype(v);
+  int return_code = SetP3dsurfacetype(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_p3dsurfacesmooth(lua_State *L) {
+int LuaSetP3dsurfacesmooth(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_p3dsurfacesmooth(v);
+  int return_code = SetP3dsurfacesmooth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_scaledfont(lua_State *L) {
+int LuaSetScaledfont(lua_State *L) {
   int height2d = lua_tonumber(L, 1);
   int height2dwidth = lua_tonumber(L, 2);
   int thickness2d = lua_tonumber(L, 3);
   int height3d = lua_tonumber(L, 3);
   int height3dwidth = lua_tonumber(L, 5);
   int thickness3d = lua_tonumber(L, 6);
-  int return_code = set_scaledfont(height2d, height2dwidth, thickness2d,
+  int return_code = SetScaledfont(height2d, height2dwidth, thickness2d,
                                    height3d, height3dwidth, thickness3d);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_get_fontsize(lua_State *L) {
+int LuaGetFontsize(lua_State *L) {
   switch (fontindex) {
   case SMALL_FONT:
     lua_pushstring(L, "small");
@@ -3676,336 +3691,336 @@ int lua_get_fontsize(lua_State *L) {
   }
 }
 
-int lua_set_scaledfont_height2d(lua_State *L) {
+int LuaSetScaledfontHeight2d(lua_State *L) {
   int height2d = lua_tonumber(L, 1);
-  int return_code = set_scaledfont_height2d(height2d);
+  int return_code = SetScaledfontHeight2d(height2d);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showalltextures(lua_State *L) {
+int LuaSetShowalltextures(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showalltextures(v);
+  int return_code = SetShowalltextures(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showaxislabels(lua_State *L) {
+int LuaSetShowaxislabels(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showaxislabels(v);
+  int return_code = SetShowaxislabels(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showblocklabel(lua_State *L) {
+int LuaSetShowblocklabel(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showblocklabel(v);
+  int return_code = SetShowblocklabel(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showblocks(lua_State *L) {
+int LuaSetShowblocks(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showblocks(v);
+  int return_code = SetShowblocks(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showcadandgrid(lua_State *L) {
+int LuaSetShowcadandgrid(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showcadandgrid(v);
+  int return_code = SetShowcadandgrid(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showcadopaque(lua_State *L) {
+int LuaSetShowcadopaque(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showcadopaque(v);
+  int return_code = SetShowcadopaque(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showceiling(lua_State *L) {
+int LuaSetShowceiling(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showceiling(v);
+  int return_code = SetShowceiling(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showcolorbars(lua_State *L) {
+int LuaSetShowcolorbars(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showcolorbars(v);
+  int return_code = SetShowcolorbars(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showcvents(lua_State *L) {
+int LuaSetShowcvents(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 1);
-  int return_code = set_showcvents(a, b);
+  int return_code = SetShowcvents(a, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showdummyvents(lua_State *L) {
+int LuaSetShowdummyvents(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showdummyvents(v);
+  int return_code = SetShowdummyvents(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showfloor(lua_State *L) {
+int LuaSetShowfloor(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showfloor(v);
+  int return_code = SetShowfloor(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showframe(lua_State *L) {
+int LuaSetShowframe(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showframe(v);
+  int return_code = SetShowframe(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showframelabel(lua_State *L) {
+int LuaSetShowframelabel(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showframelabel(v);
+  int return_code = SetShowframelabel(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showframerate(lua_State *L) {
+int LuaSetShowframerate(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showframerate(v);
+  int return_code = SetShowframerate(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showgrid(lua_State *L) {
+int LuaSetShowgrid(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showgrid(v);
+  int return_code = SetShowgrid(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showgridloc(lua_State *L) {
+int LuaSetShowgridloc(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showgridloc(v);
+  int return_code = SetShowgridloc(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showhmstimelabel(lua_State *L) {
+int LuaSetShowhmstimelabel(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showhmstimelabel(v);
+  int return_code = SetShowhmstimelabel(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showhrrcutoff(lua_State *L) {
+int LuaSetShowhrrcutoff(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showhrrcutoff(v);
+  int return_code = SetShowhrrcutoff(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showiso(lua_State *L) {
+int LuaSetShowiso(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showiso(v);
+  int return_code = SetShowiso(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showisonormals(lua_State *L) {
+int LuaSetShowisonormals(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showisonormals(v);
+  int return_code = SetShowisonormals(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showlabels(lua_State *L) {
+int LuaSetShowlabels(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showlabels(v);
+  int return_code = SetShowlabels(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
 #ifdef pp_memstatus
-int lua_set_showmemload(lua_State *L) {
+int LuaSetShowmemload(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showmemload(v);
+  int return_code = SetShowmemload(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 #endif
 
-int lua_set_showopenvents(lua_State *L) {
+int LuaSetShowopenvents(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 1);
-  int return_code = set_showopenvents(a, b);
+  int return_code = SetShowopenvents(a, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showothervents(lua_State *L) {
+int LuaSetShowothervents(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showothervents(v);
+  int return_code = SetShowothervents(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showsensors(lua_State *L) {
+int LuaSetShowsensors(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 2);
-  int return_code = set_showsensors(a, b);
+  int return_code = SetShowsensors(a, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showsliceinobst(lua_State *L) {
+int LuaSetShowsliceinobst(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showsliceinobst(v);
+  int return_code = SetShowsliceinobst(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showsmokepart(lua_State *L) {
+int LuaSetShowsmokepart(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showsmokepart(v);
+  int return_code = SetShowsmokepart(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showsprinkpart(lua_State *L) {
+int LuaSetShowsprinkpart(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showsprinkpart(v);
+  int return_code = SetShowsprinkpart(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showstreak(lua_State *L) {
+int LuaSetShowstreak(lua_State *L) {
   int show = lua_tonumber(L, 1);
   int step = lua_tonumber(L, 2);
   int showhead = lua_tonumber(L, 3);
   int index = lua_tonumber(L, 4);
-  int return_code = set_showstreak(show, step, showhead, index);
+  int return_code = SetShowstreak(show, step, showhead, index);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showterrain(lua_State *L) {
+int LuaSetShowterrain(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showterrain(v);
+  int return_code = SetShowterrain(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showthreshold(lua_State *L) {
+int LuaSetShowthreshold(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 2);
   float c = lua_tonumber(L, 3);
-  int return_code = set_showthreshold(a, b, c);
+  int return_code = SetShowthreshold(a, b, c);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showticks(lua_State *L) {
+int LuaSetShowticks(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showticks(v);
+  int return_code = SetShowticks(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showtimebar(lua_State *L) {
+int LuaSetShowtimebar(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showtimebar(v);
+  int return_code = SetShowtimebar(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showtimelabel(lua_State *L) {
+int LuaSetShowtimelabel(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showtimelabel(v);
+  int return_code = SetShowtimelabel(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showtitle(lua_State *L) {
+int LuaSetShowtitle(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showtitle(v);
+  int return_code = SetShowtitle(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showtracersalways(lua_State *L) {
+int LuaSetShowtracersalways(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showtracersalways(v);
+  int return_code = SetShowtracersalways(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showtriangles(lua_State *L) {
+int LuaSetShowtriangles(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 2);
   int c = lua_tonumber(L, 3);
   int d = lua_tonumber(L, 4);
   int e = lua_tonumber(L, 5);
   int f = lua_tonumber(L, 6);
-  int return_code = set_showtriangles(a, b, c, d, e, f);
+  int return_code = SetShowtriangles(a, b, c, d, e, f);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showtransparent(lua_State *L) {
+int LuaSetShowtransparent(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showtransparent(v);
+  int return_code = SetShowtransparent(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showtranparentvents(lua_State *L) {
+int LuaSetShowtranparentvents(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showtransparentvents(v);
+  int return_code = SetShowtransparentvents(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showtrianglecount(lua_State *L) {
+int LuaSetShowtrianglecount(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showtrianglecount(v);
+  int return_code = SetShowtrianglecount(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showventflow(lua_State *L) {
+int LuaSetShowventflow(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 2);
   int c = lua_tonumber(L, 3);
   int d = lua_tonumber(L, 4);
   int e = lua_tonumber(L, 5);
-  int return_code = set_showventflow(a, b, c, d, e);
+  int return_code = SetShowventflow(a, b, c, d, e);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showvents(lua_State *L) {
+int LuaSetShowvents(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showvents(v);
+  int return_code = SetShowvents(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showwalls(lua_State *L) {
+int LuaSetShowwalls(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showwalls(v);
+  int return_code = SetShowwalls(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_skipembedslice(lua_State *L) {
+int LuaSetSkipembedslice(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_skipembedslice(v);
+  int return_code = SetSkipembedslice(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -4020,10 +4035,10 @@ int lua_set_slicedup(lua_State *L) {
 }
 #endif
 
-int lua_set_smokesensors(lua_State *L) {
+int LuaSetSmokesensors(lua_State *L) {
   int show = lua_tonumber(L, 1);
   int test = lua_tonumber(L, 2);
-  int return_code = set_smokesensors(show, test);
+  int return_code = SetSmokesensors(show, test);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -4038,21 +4053,21 @@ int lua_set_startuplang(lua_State *L) {
 }
 #endif
 
-int lua_set_stereo(lua_State *L) {
+int LuaSetStereo(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_stereo(v);
+  int return_code = SetStereo(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_surfinc(lua_State *L) {
+int LuaSetSurfinc(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_surfinc(v);
+  int return_code = SetSurfinc(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_terrainparams(lua_State *L) {
+int LuaSetTerrainparams(lua_State *L) {
   int r_min = lua_tonumber(L, 1);
   int g_min = lua_tonumber(L, 2);
   int b_min = lua_tonumber(L, 3);
@@ -4061,66 +4076,66 @@ int lua_set_terrainparams(lua_State *L) {
   int b_max = lua_tonumber(L, 6);
   int vert_factor = lua_tonumber(L, 7);
   int return_code =
-      set_terrainparams(r_min, g_min, b_min, r_max, g_max, b_max, vert_factor);
+      SetTerrainparams(r_min, g_min, b_min, r_max, g_max, b_max, vert_factor);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_titlesafe(lua_State *L) {
+int LuaSetTitlesafe(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_titlesafe(v);
+  int return_code = SetTitlesafe(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_trainermode(lua_State *L) {
+int LuaSetTrainermode(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_trainermode(v);
+  int return_code = SetTrainermode(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_trainerview(lua_State *L) {
+int LuaSetTrainerview(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_trainerview(v);
+  int return_code = SetTrainerview(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_transparent(lua_State *L) {
+int LuaSetTransparent(lua_State *L) {
   int use_flag = lua_tonumber(L, 1);
   float level = lua_tonumber(L, 2);
-  int return_code = set_transparent(use_flag, level);
+  int return_code = SetTransparent(use_flag, level);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_treeparms(lua_State *L) {
+int LuaSetTreeparms(lua_State *L) {
   int minsize = lua_tonumber(L, 1);
   int visx = lua_tonumber(L, 2);
   int visy = lua_tonumber(L, 3);
   int visz = lua_tonumber(L, 4);
-  int return_code = set_treeparms(minsize, visx, visy, visz);
+  int return_code = SetTreeparms(minsize, visx, visy, visz);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_twosidedvents(lua_State *L) {
+int LuaSetTwosidedvents(lua_State *L) {
   int internal = lua_tonumber(L, 1);
   int external = lua_tonumber(L, 2);
-  int return_code = set_twosidedvents(internal, external);
+  int return_code = SetTwosidedvents(internal, external);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_vectorskip(lua_State *L) {
+int LuaSetVectorskip(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_vectorskip(v);
+  int return_code = SetVectorskip(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_volsmoke(lua_State *L) {
+int LuaSetVolsmoke(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 2);
   int c = lua_tonumber(L, 3);
@@ -4133,37 +4148,37 @@ int lua_set_volsmoke(lua_State *L) {
   float j = lua_tonumber(L, 10);
   float k = lua_tonumber(L, 11);
   float l = lua_tonumber(L, 12);
-  int return_code = set_volsmoke(a, b, c, d, e, f, g, h, i, j, k, l);
+  int return_code = SetVolsmoke(a, b, c, d, e, f, g, h, i, j, k, l);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_zoom(lua_State *L) {
+int LuaSetZoom(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 2);
-  int return_code = set_zoom(a, b);
+  int return_code = SetZoom(a, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
 // *** MISC ***
-int lua_set_cellcentertext(lua_State *L) {
+int LuaSetCellcentertext(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_cellcentertext(v);
+  int return_code = SetCellcentertext(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_inputfile(lua_State *L) {
+int LuaSetInputfile(lua_State *L) {
   const char *inputfile = lua_tostring(L, 1);
-  int return_code = set_inputfile(inputfile);
+  int return_code = SetInputfile(inputfile);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_labelstartupview(lua_State *L) {
+int LuaSetLabelstartupview(lua_State *L) {
   const char *viewname = lua_tostring(L, 1);
-  int return_code = set_labelstartupview(viewname);
+  int return_code = SetLabelstartupview(viewname);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -4176,13 +4191,13 @@ int lua_set_labelstartupview(lua_State *L) {
 //   return 1;
 // }
 
-int lua_set_renderclip(lua_State *L) {
+int LuaSetRenderclip(lua_State *L) {
   int use_flag = lua_tonumber(L, 1);
   int left = lua_tonumber(L, 2);
   int right = lua_tonumber(L, 3);
   int bottom = lua_tonumber(L, 4);
   int top = lua_tonumber(L, 5);
-  int return_code = set_renderclip(use_flag, left, right, bottom, top);
+  int return_code = SetRenderclip(use_flag, left, right, bottom, top);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -4195,10 +4210,10 @@ int lua_set_renderclip(lua_State *L) {
 //   return 1;
 // }
 
-int lua_set_renderfiletype(lua_State *L) {
+int LuaSetRenderfiletype(lua_State *L) {
   int render = lua_tonumber(L, 1);
   int movie = lua_tonumber(L, 2);
-  int return_code = set_renderfiletype(render, movie);
+  int return_code = SetRenderfiletype(render, movie);
   lua_pushnumber(L, return_code);
   return 1;
 }
@@ -4216,7 +4231,7 @@ int lua_set_renderfiletype(lua_State *L) {
 //   return 1;
 // }
 
-int lua_get_unit_defs(lua_State *L, f_units unitclass) {
+int LuaGetUnitDefs(lua_State *L, f_units unitclass) {
   lua_createtable(L, 0, 4);
   // Loop through all of the units
   int j;
@@ -4247,7 +4262,7 @@ int lua_get_unit_defs(lua_State *L, f_units unitclass) {
 }
 
 // TODO: implement iterators for this table
-int lua_get_unitclass(lua_State *L) {
+int LuaGetUnitclass(lua_State *L) {
   const char *classname = lua_tostring(L, 1);
   int i;
   for (i = 0; i < nunitclasses_default; i++) {
@@ -4255,14 +4270,14 @@ int lua_get_unitclass(lua_State *L) {
     if (strcmp(classname, unitclasses_default[i].unitclass) == 0) {
       lua_createtable(L, 0, 4);
       // Loop through all of the units
-      lua_get_unit_defs(L, unitclasses_default[i]);
+      LuaGetUnitDefs(L, unitclasses_default[i]);
       return 1;
     }
   }
   return 0;
 }
 
-int lua_get_units(lua_State *L) {
+int LuaGetUnits(lua_State *L) {
   const char *classname = lua_tostring(L, 1);
   int i;
   for (i = 0; i < nunitclasses_default; i++) {
@@ -4280,7 +4295,7 @@ int lua_get_units(lua_State *L) {
   return 0;
 }
 
-int lua_set_units(lua_State *L) {
+int LuaSetUnits(lua_State *L) {
   const char *unitclassname = lua_tostring(L, 1);
   const char *unitname = lua_tostring(L, 2);
 
@@ -4308,11 +4323,11 @@ int lua_set_units(lua_State *L) {
   if (!unit_index_found) {
     return luaL_error(L, "unit index not found");
   }
-  set_units(unitclass_index, unit_index);
+  SetUnits(unitclass_index, unit_index);
   return 0;
 }
 
-int lua_set_unitclasses(lua_State *L) {
+int LuaSetUnitclasses(lua_State *L) {
   int i = 0;
   int n = 0;
   if (!lua_istable(L, -1)) {
@@ -4332,296 +4347,297 @@ int lua_set_unitclasses(lua_State *L) {
       lua_pop(L, 1);
       i++;
     }
-    int return_code = set_unitclasses(n, indices);
+    int return_code = SetUnitclasses(n, indices);
     lua_pushnumber(L, return_code);
     free(indices);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_set_zaxisangles(lua_State *L) {
+int LuaSetZaxisangles(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 2);
   int c = lua_tonumber(L, 3);
-  int return_code = set_zaxisangles(a, b, c);
+  int return_code = SetZaxisangles(a, b, c);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_colorbartype(lua_State *L) {
+int LuaSetColorbartype(lua_State *L) {
   int type = lua_tonumber(L, 1);
   const char *label = lua_tostring(L, 2);
-  int return_code = set_colorbartype(type, label);
+  int return_code = SetColorbartype(type, label);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_extremecolors(lua_State *L) {
+int LuaSetExtremecolors(lua_State *L) {
   int rmin = lua_tonumber(L, 1);
   int gmin = lua_tonumber(L, 2);
   int bmin = lua_tonumber(L, 3);
   int rmax = lua_tonumber(L, 4);
   int gmax = lua_tonumber(L, 5);
   int bmax = lua_tonumber(L, 6);
-  int return_code = set_extremecolors(rmin, gmin, bmin, rmax, gmax, bmax);
+  int return_code = SetExtremecolors(rmin, gmin, bmin, rmax, gmax, bmax);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_firecolor(lua_State *L) {
+int LuaSetFirecolor(lua_State *L) {
   int r = lua_tonumber(L, 1);
   int g = lua_tonumber(L, 2);
   int b = lua_tonumber(L, 3);
-  int return_code = set_firecolor(r, g, b);
+  int return_code = SetFirecolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_firecolormap(lua_State *L) {
+int LuaSetFirecolormap(lua_State *L) {
   int type = lua_tonumber(L, 1);
   int index = lua_tonumber(L, 2);
-  int return_code = set_firecolormap(type, index);
+  int return_code = SetFirecolormap(type, index);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_firedepth(lua_State *L) {
+int LuaSetFiredepth(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_firedepth(v);
+  int return_code = SetFiredepth(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showextremedata(lua_State *L) {
+int LuaSetShowextremedata(lua_State *L) {
   int show_extremedata = lua_tonumber(L, 1);
   int below = lua_tonumber(L, 2);
   int above = lua_tonumber(L, 3);
-  int return_code = set_showextremedata(show_extremedata, below, above);
+  int return_code = SetShowextremedata(show_extremedata, below, above);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_smokecolor(lua_State *L) {
+int LuaSetSmokecolor(lua_State *L) {
   int r = lua_tonumber(L, 1);
   int g = lua_tonumber(L, 2);
   int b = lua_tonumber(L, 3);
-  int return_code = set_smokecolor(r, g, b);
+  int return_code = SetSmokecolor(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_smokecull(lua_State *L) {
+int LuaSetSmokecull(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_smokecull(v);
+  int return_code = SetSmokecull(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_smokeskip(lua_State *L) {
+int LuaSetSmokeskip(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_smokeskip(v);
+  int return_code = SetSmokeskip(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_smokealbedo(lua_State *L) {
+int LuaSetSmokealbedo(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_smokealbedo(v);
+  int return_code = SetSmokealbedo(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
 #ifdef pp_GPU
-int lua_set_smokerthick(lua_State *L) {
+int LuaSetSmokerthick(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_smokerthick(v);
+  int return_code = SetSmokerthick(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 #endif
 
 #ifdef pp_GPU
-int lua_set_usegpu(lua_State *L) {
+int LuaSetUsegpu(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_usegpu(v);
+  int return_code = SetUsegpu(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 #endif
 
 // *** ZONE FIRE PARAMETRES ***
-int lua_set_showhazardcolors(lua_State *L) {
+int LuaSetShowhazardcolors(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showhazardcolors(v);
+  int return_code = SetShowhazardcolors(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showhzone(lua_State *L) {
+int LuaSetShowhzone(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showhzone(v);
+  int return_code = SetShowhzone(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showszone(lua_State *L) {
+int LuaSetShowszone(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showszone(v);
+  int return_code = SetShowszone(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showvzone(lua_State *L) {
+int LuaSetShowvzone(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showvzone(v);
+  int return_code = SetShowvzone(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showzonefire(lua_State *L) {
+int LuaSetShowzonefire(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showzonefire(v);
+  int return_code = SetShowzonefire(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
 // *** TOUR INFO ***
-int lua_set_showpathnodes(lua_State *L) {
+int LuaSetShowpathnodes(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showpathnodes(v);
+  int return_code = SetShowpathnodes(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_showtourroute(lua_State *L) {
+int LuaSetShowtourroute(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showtourroute(v);
+  int return_code = SetShowtourroute(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_tourcolors_selectedpathline(lua_State *L) {
+int LuaSetTourcolorsSelectedpathline(lua_State *L) {
   int r = lua_tonumber(L, 1);
   int g = lua_tonumber(L, 2);
   int b = lua_tonumber(L, 3);
-  int return_code = set_tourcolors_selectedpathline(r, g, b);
+  int return_code = SetTourcolorsSelectedpathline(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
-int lua_set_tourcolors_selectedpathlineknots(lua_State *L) {
+int LuaSetTourcolorsSelectedpathlineknots(lua_State *L) {
   int r = lua_tonumber(L, 1);
   int g = lua_tonumber(L, 2);
   int b = lua_tonumber(L, 3);
-  int return_code = set_tourcolors_selectedpathlineknots(r, g, b);
+  int return_code = SetTourcolorsSelectedpathlineknots(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
-int lua_set_tourcolors_selectedknot(lua_State *L) {
+int LuaSetTourcolorsSelectedknot(lua_State *L) {
   int r = lua_tonumber(L, 1);
   int g = lua_tonumber(L, 2);
   int b = lua_tonumber(L, 3);
-  int return_code = set_tourcolors_selectedknot(r, g, b);
+  int return_code = SetTourcolorsSelectedknot(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
-int lua_set_tourcolors_pathline(lua_State *L) {
+int LuaSetTourcolorsPathline(lua_State *L) {
   int r = lua_tonumber(L, 1);
   int g = lua_tonumber(L, 2);
   int b = lua_tonumber(L, 3);
-  int return_code = set_tourcolors_selectedpathline(r, g, b);
+  int return_code = SetTourcolorsSelectedpathline(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
-int lua_set_tourcolors_pathknots(lua_State *L) {
+int LuaSetTourcolorsPathknots(lua_State *L) {
   int r = lua_tonumber(L, 1);
   int g = lua_tonumber(L, 2);
   int b = lua_tonumber(L, 3);
-  int return_code = set_tourcolors_pathknots(r, g, b);
+  int return_code = SetTourcolorsPathknots(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
-int lua_set_tourcolors_text(lua_State *L) {
+int LuaSetTourcolorsText(lua_State *L) {
   int r = lua_tonumber(L, 1);
   int g = lua_tonumber(L, 2);
   int b = lua_tonumber(L, 3);
-  int return_code = set_tourcolors_text(r, g, b);
+  int return_code = SetTourcolorsText(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
-int lua_set_tourcolors_avatar(lua_State *L) {
+int LuaSetTourcolorsAvatar(lua_State *L) {
   int r = lua_tonumber(L, 1);
   int g = lua_tonumber(L, 2);
   int b = lua_tonumber(L, 3);
-  int return_code = set_tourcolors_avatar(r, g, b);
+  int return_code = SetTourcolorsAvatar(r, g, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_viewalltours(lua_State *L) {
+int LuaSetViewalltours(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_viewalltours(v);
+  int return_code = SetViewalltours(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_viewtimes(lua_State *L) {
+int LuaSetViewtimes(lua_State *L) {
   float start = lua_tonumber(L, 1);
   float stop = lua_tonumber(L, 2);
   int ntimes = lua_tonumber(L, 3);
-  int return_code = set_viewtimes(start, stop, ntimes);
+  int return_code = SetViewtimes(start, stop, ntimes);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_viewtourfrompath(lua_State *L) {
+int LuaSetViewtourfrompath(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_viewtourfrompath(v);
+  int return_code = SetViewtourfrompath(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_devicevectordimensions(lua_State *L) {
+int LuaSetDevicevectordimensions(lua_State *L) {
   float baselength = lua_tonumber(L, 1);
   float basediameter = lua_tonumber(L, 2);
   float headlength = lua_tonumber(L, 3);
   float headdiameter = lua_tonumber(L, 4);
-  int return_code = set_devicevectordimensions(baselength, basediameter,
+  int return_code = SetDevicevectordimensions(baselength, basediameter,
                                                headlength, headdiameter);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_devicebounds(lua_State *L) {
+int LuaSetDevicebounds(lua_State *L) {
   float min = lua_tonumber(L, 1);
   float max = lua_tonumber(L, 2);
-  int return_code = set_devicebounds(min, max);
+  int return_code = SetDevicebounds(min, max);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_deviceorientation(lua_State *L) {
+int LuaSetDeviceorientation(lua_State *L) {
   int a = lua_tonumber(L, 1);
   float b = lua_tonumber(L, 2);
-  int return_code = set_deviceorientation(a, b);
+  int return_code = SetDeviceorientation(a, b);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_gridparms(lua_State *L) {
+int LuaSetGridparms(lua_State *L) {
   int vx = lua_tonumber(L, 1);
   int vy = lua_tonumber(L, 2);
   int vz = lua_tonumber(L, 3);
   int px = lua_tonumber(L, 4);
   int py = lua_tonumber(L, 5);
   int pz = lua_tonumber(L, 6);
-  int return_code = set_gridparms(vx, vy, vz, px, py, pz);
+  int return_code = SetGridparms(vx, vy, vz, px, py, pz);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_gsliceparms(lua_State *L) {
+int LuaSetGsliceparms(lua_State *L) {
   int i;
   int vis_data = lua_tonumber(L, 1);
   int vis_triangles = lua_tonumber(L, 2);
@@ -4644,29 +4660,29 @@ int lua_set_gsliceparms(lua_State *L) {
     lua_pop(L, 1);
     i++;
   }
-  int return_code = set_gsliceparms(vis_data, vis_triangles, vis_triangulation,
+  int return_code = SetGsliceparms(vis_data, vis_triangles, vis_triangulation,
                                     vis_normal, xyz, azelev);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_loadfilesatstartup(lua_State *L) {
+int LuaSetLoadfilesatstartup(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_loadfilesatstartup(v);
+  int return_code = SetLoadfilesatstartup(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_mscale(lua_State *L) {
+int LuaSetMscale(lua_State *L) {
   float a = lua_tonumber(L, 1);
   float b = lua_tonumber(L, 2);
   float c = lua_tonumber(L, 3);
-  int return_code = set_mscale(a, b, c);
+  int return_code = SetMscale(a, b, c);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_sliceauto(lua_State *L) {
+int LuaSetSliceauto(lua_State *L) {
   lua_pushnil(L);
   int n = 0;
   while (lua_next(L, -2) != 0) {
@@ -4682,16 +4698,17 @@ int lua_set_sliceauto(lua_State *L) {
       lua_pop(L, 1);
       i++;
     }
-    int return_code = set_sliceauto(n, vals);
+    int return_code = SetSliceauto(n, vals);
     lua_pushnumber(L, return_code);
     free(vals);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_set_msliceauto(lua_State *L) {
+int LuaSetMsliceauto(lua_State *L) {
   lua_pushnil(L);
   int n = 0;
   while (lua_next(L, -2) != 0) {
@@ -4707,23 +4724,24 @@ int lua_set_msliceauto(lua_State *L) {
       lua_pop(L, 1);
       i++;
     }
-    int return_code = set_msliceauto(n, vals);
+    int return_code = SetMsliceauto(n, vals);
     lua_pushnumber(L, return_code);
     free(vals);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_set_compressauto(lua_State *L) {
+int LuaSetCompressauto(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_compressauto(v);
+  int return_code = SetCompressauto(v);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_propindex(lua_State *L) {
+int LuaSetPropindex(lua_State *L) {
   lua_pushnil(L);
   int n = 0;
   while (lua_next(L, -2) != 0) {
@@ -4748,15 +4766,16 @@ int lua_set_propindex(lua_State *L) {
       lua_pop(L, 1);
       i++;
     }
-    int return_code = set_propindex(n, vals);
+    int return_code = SetPropindex(n, vals);
     lua_pushnumber(L, return_code);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int lua_set_showdevices(lua_State *L) {
+int LuaSetShowdevices(lua_State *L) {
   lua_pushnil(L);
   int n = 0;
   while (lua_next(L, -2) != 0) {
@@ -4772,16 +4791,17 @@ int lua_set_showdevices(lua_State *L) {
       lua_pop(L, 1);
       i++;
     }
-    int return_code = set_showdevices(n, names);
+    int return_code = SetShowdevices(n, names);
     lua_pushnumber(L, return_code);
     free(names);
     return 1;
-  } else {
+  }
+  else {
     return 0;
   }
 } // SHOWDEVICES
 
-int lua_set_showdevicevals(lua_State *L) {
+int LuaSetShowdevicevals(lua_State *L) {
   int a = lua_tonumber(L, 1);
   int b = lua_tonumber(L, 2);
   int c = lua_tonumber(L, 3);
@@ -4790,113 +4810,114 @@ int lua_set_showdevicevals(lua_State *L) {
   int f = lua_tonumber(L, 6);
   int g = lua_tonumber(L, 7);
   int h = lua_tonumber(L, 8);
-  int return_code = set_showdevicevals(a, b, c, d, e, f, g, h);
+  int return_code = SetShowdevicevals(a, b, c, d, e, f, g, h);
   lua_pushnumber(L, return_code);
   return 1;
 } // SHOWDEVICEVALS
 
-int lua_set_showmissingobjects(lua_State *L) {
+int LuaSetShowmissingobjects(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_showmissingobjects(v);
+  int return_code = SetShowmissingobjects(v);
   lua_pushnumber(L, return_code);
   return 1;
 } // SHOWMISSINGOBJECTS
 
-int lua_set_tourindex(lua_State *L) {
+int LuaSetTourindex(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_tourindex(v);
+  int return_code = SetTourindex(v);
   lua_pushnumber(L, return_code);
   return 1;
 } // TOURINDEX
 
-int lua_set_c_particles(lua_State *L) {
-  int minFlag = lua_tonumber(L, 1);
-  float minValue = lua_tonumber(L, 2);
-  int maxFlag = lua_tonumber(L, 3);
-  float maxValue = lua_tonumber(L, 4);
+int LuaSetCParticles(lua_State *L) {
+  int min_flag = lua_tonumber(L, 1);
+  float min_value = lua_tonumber(L, 2);
+  int max_flag = lua_tonumber(L, 3);
+  float max_value = lua_tonumber(L, 4);
   const char *label = NULL;
   if (lua_gettop(L) == 5) {
     label = lua_tostring(L, 5);
   }
   int return_code =
-      set_c_particles(minFlag, minValue, maxFlag, maxValue, label);
+      SetCParticles(min_flag, min_value, max_flag, max_value, label);
   lua_pushnumber(L, return_code);
   return 1;
 } // C_PARTICLES
 
-int lua_set_c_slice(lua_State *L) {
-  int minFlag = lua_tonumber(L, 1);
-  float minValue = lua_tonumber(L, 2);
-  int maxFlag = lua_tonumber(L, 3);
-  float maxValue = lua_tonumber(L, 4);
+int LuaSetCSlice(lua_State *L) {
+  int min_flag = lua_tonumber(L, 1);
+  float min_value = lua_tonumber(L, 2);
+  int max_flag = lua_tonumber(L, 3);
+  float max_value = lua_tonumber(L, 4);
   const char *label = NULL;
   if (lua_gettop(L) == 5) {
     label = lua_tostring(L, 5);
   }
-  int return_code = set_c_slice(minFlag, minValue, maxFlag, maxValue, label);
+  int return_code =
+      SetCSlice(min_flag, min_value, max_flag, max_value, label);
   lua_pushnumber(L, return_code);
   return 1;
 } // C_SLICE
 
-int lua_set_cache_boundarydata(lua_State *L) {
+int LuaSetCacheBoundarydata(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_cache_boundarydata(v);
+  int return_code = SetCacheBoundarydata(v);
   lua_pushnumber(L, return_code);
   return 1;
 } // CACHE_BOUNDARYDATA
 
-int lua_set_cache_qdata(lua_State *L) {
+int LuaSetCacheQdata(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_cache_qdata(v);
+  int return_code = SetCacheQdata(v);
   lua_pushnumber(L, return_code);
   return 1;
 } // CACHE_QDATA
 
-int lua_set_percentilelevel(lua_State *L) {
+int LuaSetPercentilelevel(lua_State *L) {
   float p_level_min = lua_tonumber(L, 1);
   float p_level_max = lua_tonumber(L, 2);
-  int return_code = set_percentilelevel(p_level_min, p_level_max);
+  int return_code = SetPercentilelevel(p_level_min, p_level_max);
   lua_pushnumber(L, return_code);
   return 1;
 } // PERCENTILELEVEL
 
-int lua_set_timeoffset(lua_State *L) {
+int LuaSetTimeoffset(lua_State *L) {
   int v = lua_tonumber(L, 1);
-  int return_code = set_timeoffset(v);
+  int return_code = SetTimeoffset(v);
   lua_pushnumber(L, return_code);
   return 1;
 } // TIMEOFFSET
 
-int lua_set_tload(lua_State *L) {
-  int beginFlag = lua_tonumber(L, 1);
-  float beginVal = lua_tonumber(L, 2);
-  int endFlag = lua_tonumber(L, 3);
-  float endVal = lua_tonumber(L, 4);
-  int skipFlag = lua_tonumber(L, 5);
-  float skipVal = lua_tonumber(L, 6);
+int LuaSetTload(lua_State *L) {
+  int begin_flag = lua_tonumber(L, 1);
+  float begin_val = lua_tonumber(L, 2);
+  int end_flag = lua_tonumber(L, 3);
+  float end_val = lua_tonumber(L, 4);
+  int skip_flag = lua_tonumber(L, 5);
+  float skip_val = lua_tonumber(L, 6);
   int return_code =
-      set_tload(beginFlag, beginVal, endFlag, endVal, skipFlag, skipVal);
+      SetTload(begin_flag, begin_val, end_flag, end_val, skip_flag, skip_val);
   lua_pushnumber(L, return_code);
   return 1;
 } // TLOAD
 
-int lua_set_v_slice(lua_State *L) {
-  int minFlag = lua_tonumber(L, 1);
-  float minValue = lua_tonumber(L, 2);
-  int maxFlag = lua_tonumber(L, 3);
-  float maxValue = lua_tonumber(L, 4);
+int LuaSetVSlice(lua_State *L) {
+  int min_flag = lua_tonumber(L, 1);
+  float min_value = lua_tonumber(L, 2);
+  int max_flag = lua_tonumber(L, 3);
+  float max_value = lua_tonumber(L, 4);
   const char *label = lua_tostring(L, 5);
-  float lineMin = lua_tonumber(L, 6);
-  float lineMax = lua_tonumber(L, 7);
-  int lineNum = lua_tonumber(L, 8);
-  int return_code = set_v_slice(minFlag, minValue, maxFlag, maxValue, label,
-                                lineMin, lineMax, lineNum);
+  float line_min = lua_tonumber(L, 6);
+  float line_max = lua_tonumber(L, 7);
+  int line_num = lua_tonumber(L, 8);
+  int return_code = SetVSlice(min_flag, min_value, max_flag, max_value, label,
+                                line_min, line_max, line_num);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_set_patchdataout(lua_State *L) {
-  int outputFlag = lua_tonumber(L, 1);
+int LuaSetPatchdataout(lua_State *L) {
+  int output_flag = lua_tonumber(L, 1);
   int tmin = lua_tonumber(L, 1);
   int tmax = lua_tonumber(L, 2);
   int xmin = lua_tonumber(L, 3);
@@ -4905,44 +4926,44 @@ int lua_set_patchdataout(lua_State *L) {
   int ymax = lua_tonumber(L, 6);
   int zmin = lua_tonumber(L, 7);
   int zmax = lua_tonumber(L, 8);
-  int return_code = set_patchdataout(outputFlag, tmin, tmax, xmin, xmax, ymin,
+  int return_code = SetPatchdataout(output_flag, tmin, tmax, xmin, xmax, ymin,
                                      ymax, zmin, zmax);
   lua_pushnumber(L, return_code);
   return 1;
 } // PATCHDATAOUT
 
-int lua_show_smoke3d_showall(lua_State *L) {
-  int return_code = show_smoke3d_showall();
+int LuaShowSmoke3dShowall(lua_State *L) {
+  int return_code = ShowSmoke3dShowall();
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_show_smoke3d_hideall(lua_State *L) {
-  int return_code = show_smoke3d_hideall();
+int LuaShowSmoke3dHideall(lua_State *L) {
+  int return_code = ShowSmoke3dHideall();
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_show_slices_showall(lua_State *L) {
-  int return_code = show_slices_showall();
+int LuaShowSlicesShowall(lua_State *L) {
+  int return_code = ShowSlicesShowall();
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_show_slices_hideall(lua_State *L) {
-  int return_code = show_slices_hideall();
+int LuaShowSlicesHideall(lua_State *L) {
+  int return_code = ShowSlicesHideall();
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_add_title_line(lua_State *L) {
+int LuaAddTitleLine(lua_State *L) {
   const char *string = lua_tostring(L, 1);
   int return_code = addTitleLine(&titleinfo, string);
   lua_pushnumber(L, return_code);
   return 1;
 }
 
-int lua_clear_title_lines(lua_State *L) {
+int LuaClearTitleLines(lua_State *L) {
   int return_code = clearTitleLines(&titleinfo);
   lua_pushnumber(L, return_code);
   return 1;
@@ -4951,7 +4972,7 @@ int lua_clear_title_lines(lua_State *L) {
 /// @brief Add paths for the Lua interpreter to find scripts and libraries that
 /// are written in Lua.
 /// @param L The Lua interpreter state
-void addScriptPath(lua_State *L) {
+void AddScriptPath(lua_State *L) {
   // package.path is a path variable where Lua scripts and modules may be
   // found, typically text based files with the .lua extension.
   lua_getglobal(L, "package");
@@ -4986,7 +5007,7 @@ void addScriptPath(lua_State *L) {
 /// @brief Add paths for the Lua interpreter to find libraries that are compiled
 /// to shared libraries.
 /// @param L The Lua interpreter state
-void addCPath(lua_State *L) {
+void AddCPath(lua_State *L) {
   // package.path is a path variable where Lua scripts and modules may be
   // found, typically text based files with the .lua extension.
   lua_getglobal(L, "package");
@@ -5017,574 +5038,572 @@ void addCPath(lua_State *L) {
 
 /// @brief Add paths for the Lua interpreter to find scripts and libraries.
 /// @param L The Lua interpreter state
-void addLuaPaths(lua_State *L) {
+void AddLuaPaths(lua_State *L) {
   // Add the paths for *.lua files.
-  addScriptPath(L);
+  AddScriptPath(L);
   // Ad the path for native (*.dll, and *.so) libs
-  addCPath(L);
+  AddCPath(L);
   return;
 }
 
-static luaL_Reg const smvlib[] = {
-    {"set_slice_bounds", lua_set_slice_bounds},
-    {"set_slice_bound_min", lua_set_slice_bound_min},
-    {"set_slice_bound_max", lua_set_slice_bound_max},
-    {"get_slice_bounds", lua_get_slice_bounds},
-    {"loadsmvall", lua_loadsmvall},
-    {"hidewindow", lua_hidewindow},
-    {"yieldscript", lua_yieldscript},
-    {"tempyieldscript", lua_tempyieldscript},
-    {"displayCB", lua_displayCB},
-    {"renderclip", lua_renderclip},
-    {"renderC", lua_render},
-    {"render_var", lua_render_var},
-    {"gsliceview", lua_gsliceview},
-    {"showplot3ddata", lua_showplot3ddata},
-    {"gslicepos", lua_gslicepos},
-    {"gsliceorien", lua_gsliceorien},
-    {"settourkeyframe", lua_settourkeyframe},
-    {"settourview", lua_settourview},
-    {"getframe", lua_getframe},
-    {"setframe", lua_setframe},
-    {"gettime", lua_gettime},
-    {"settime", lua_settime},
-    {"loaddatafile", lua_loaddatafile},
-    {"loadinifile", lua_loadinifile},
-    {"loadvdatafile", lua_loadvdatafile},
-    {"loadboundaryfile", lua_loadboundaryfile},
-    {"load3dsmoke", lua_load3dsmoke},
-    {"loadvolsmoke", lua_loadvolsmoke},
-    {"loadvolsmokeframe", lua_loadvolsmokeframe},
-    {"set_rendertype", lua_set_rendertype},
-    {"get_rendertype", lua_get_rendertype},
-    {"set_movietype", lua_set_movietype},
-    {"get_movietype", lua_get_movietype},
-    {"makemovie", lua_makemovie},
-    {"loadtour", lua_loadtour},
-    {"loadparticles", lua_loadparticles},
-    {"partclasscolor", lua_partclasscolor},
-    {"partclasstype", lua_partclasstype},
-    {"plot3dprops", lua_plot3dprops},
-    {"loadplot3d", lua_loadplot3d},
-    {"loadslice", lua_loadslice},
-    {"loadsliceindex", lua_loadsliceindex},
-    {"loadvslice", lua_loadvslice},
-    {"loadiso", lua_loadiso},
-    {"unloadall", lua_unloadall},
-    {"unloadtour", lua_unloadtour},
-    {"setrenderdir", lua_setrenderdir},
-    {"getrenderdir", lua_getrenderdir},
-    {"set_ortho_preset", lua_set_ortho_preset},
-    {"setviewpoint", lua_setviewpoint},
-    {"getviewpoint", lua_getviewpoint},
-    {"exit", lua_exit_smokeview},
-    {"getcolorbarflip", lua_getcolorbarflip},
-    {"setcolorbarflip", lua_setcolorbarflip},
-    {"setwindowsize", lua_setwindowsize},
+static luaL_Reg const SMVLIB[] = {
+    {"set_slice_bounds", LuaSetSliceBounds},
+    {"set_slice_bound_min", LuaSetSliceBoundMin},
+    {"set_slice_bound_max", LuaSetSliceBoundMax},
+    {"get_slice_bounds", LuaGetSliceBounds},
+    {"loadsmvall", LuaLoadsmvall},
+    {"hidewindow", LuaHidewindow},
+    {"yieldscript", LuaYieldscript},
+    {"tempyieldscript", LuaTempyieldscript},
+    {"displayCB", LuaDisplayCb},
+    {"renderclip", LuaRenderclip},
+    {"renderC", LuaRender},
+    {"render_var", LuaRenderVar},
+    {"gsliceview", LuaGsliceview},
+    {"showplot3ddata", LuaShowplot3ddata},
+    {"gslicepos", LuaGslicepos},
+    {"gsliceorien", LuaGsliceorien},
+    {"settourkeyframe", LuaSettourkeyframe},
+    {"settourview", LuaSettourview},
+    {"getframe", LuaGetframe},
+    {"setframe", LuaSetframe},
+    {"gettime", LuaGettime},
+    {"settime", LuaSettime},
+    {"loaddatafile", LuaLoaddatafile},
+    {"loadinifile", LuaLoadinifile},
+    {"loadvdatafile", LuaLoadvdatafile},
+    {"loadboundaryfile", LuaLoadboundaryfile},
+    {"load3dsmoke", LuaLoad3dsmoke},
+    {"loadvolsmoke", LuaLoadvolsmoke},
+    {"loadvolsmokeframe", LuaLoadvolsmokeframe},
+    {"set_rendertype", LuaSetRendertype},
+    {"get_rendertype", LuaGetRendertype},
+    {"set_movietype", LuaSetMovietype},
+    {"get_movietype", LuaGetMovietype},
+    {"makemovie", LuaMakemovie},
+    {"loadtour", LuaLoadtour},
+    {"loadparticles", LuaLoadparticles},
+    {"partclasscolor", LuaPartclasscolor},
+    {"partclasstype", LuaPartclasstype},
+    {"plot3dprops", LuaPlot3dprops},
+    {"loadplot3d", LuaLoadplot3d},
+    {"loadslice", LuaLoadslice},
+    {"loadsliceindex", LuaLoadsliceindex},
+    {"loadvslice", LuaLoadvslice},
+    {"loadiso", LuaLoadiso},
+    {"unloadall", LuaUnloadall},
+    {"unloadtour", LuaUnloadtour},
+    {"setrenderdir", LuaSetrenderdir},
+    {"getrenderdir", LuaGetrenderdir},
+    {"set_ortho_preset", LuaSetOrthoPreset},
+    {"setviewpoint", LuaSetviewpoint},
+    {"getviewpoint", LuaGetviewpoint},
+    {"exit", LuaExitSmokeview},
+    {"getcolorbarflip", LuaGetcolorbarflip},
+    {"setcolorbarflip", LuaSetcolorbarflip},
+    {"setwindowsize", LuaSetwindowsize},
     // {"window.setwindowsize", lua_setwindowsize},
-    {"setgridvisibility", lua_setgridvisibility},
-    {"setgridparms", lua_setgridparms},
-    {"setcolorbarindex", lua_setcolorbarindex},
-    {"getcolorbarindex", lua_getcolorbarindex},
+    {"setgridvisibility", LuaSetgridvisibility},
+    {"setgridparms", LuaSetgridparms},
+    {"setcolorbarindex", LuaSetcolorbarindex},
+    {"getcolorbarindex", LuaGetcolorbarindex},
 
-    {"set_slice_in_obst", lua_set_slice_in_obst},
-    {"get_slice_in_obst", lua_get_slice_in_obst},
+    {"set_slice_in_obst", LuaSetSliceInObst},
+    {"get_slice_in_obst", LuaGetSliceInObst},
 
     // colorbar
-    {"set_colorbar", lua_set_colorbar},
-    {"set_named_colorbar", lua_set_named_colorbar},
+    {"set_colorbar", LuaSetColorbar},
+    {"set_named_colorbar", LuaSetNamedColorbar},
     // {"get_named_colorbar", lua_get_named_colorbar},
 
-    {"set_colorbar_visibility", lua_set_colorbar_visibility},
-    {"get_colorbar_visibility", lua_get_colorbar_visibility},
-    {"toggle_colorbar_visibility", lua_toggle_colorbar_visibility},
+    {"set_colorbar_visibility", LuaSetColorbarVisibility},
+    {"get_colorbar_visibility", LuaGetColorbarVisibility},
+    {"toggle_colorbar_visibility", LuaToggleColorbarVisibility},
 
-    {"set_colorbar_visibility_horizontal",
-     lua_set_colorbar_visibility_horizontal},
-    {"get_colorbar_visibility_horizontal",
-     lua_get_colorbar_visibility_horizontal},
+    {"set_colorbar_visibility_horizontal", LuaSetColorbarVisibilityHorizontal},
+    {"get_colorbar_visibility_horizontal", LuaGetColorbarVisibilityHorizontal},
     {"toggle_colorbar_visibility_horizontal",
-     lua_toggle_colorbar_visibility_horizontal},
+     LuaToggleColorbarVisibilityHorizontal},
 
-    {"set_colorbar_visibility_vertical", lua_set_colorbar_visibility_vertical},
-    {"get_colorbar_visibility_vertical", lua_get_colorbar_visibility_vertical},
+    {"set_colorbar_visibility_vertical", LuaSetColorbarVisibilityVertical},
+    {"get_colorbar_visibility_vertical", LuaGetColorbarVisibilityVertical},
     {"toggle_colorbar_visibility_vertical",
-     lua_toggle_colorbar_visibility_vertical},
+     LuaToggleColorbarVisibilityVertical},
 
     // timebar
-    {"set_timebar_visibility", lua_set_timebar_visibility},
-    {"get_timebar_visibility", lua_get_timebar_visibility},
-    {"toggle_timebar_visibility", lua_toggle_timebar_visibility},
+    {"set_timebar_visibility", LuaSetTimebarVisibility},
+    {"get_timebar_visibility", LuaGetTimebarVisibility},
+    {"toggle_timebar_visibility", LuaToggleTimebarVisibility},
 
     // title
-    {"set_title_visibility", lua_set_title_visibility},
-    {"get_title_visibility", lua_get_title_visibility},
-    {"toggle_title_visibility", lua_toggle_title_visibility},
+    {"set_title_visibility", LuaSetTitleVisibility},
+    {"get_title_visibility", LuaGetTitleVisibility},
+    {"toggle_title_visibility", LuaToggleTitleVisibility},
 
     // smv_version
-    {"set_smv_version_visibility", lua_set_smv_version_visibility},
-    {"get_smv_version_visibility", lua_get_smv_version_visibility},
-    {"toggle_smv_version_visibility", lua_toggle_smv_version_visibility},
+    {"set_smv_version_visibility", LuaSetSmvVersionVisibility},
+    {"get_smv_version_visibility", LuaGetSmvVersionVisibility},
+    {"toggle_smv_version_visibility", LuaToggleSmvVersionVisibility},
 
     // chid
-    {"set_chid_visibility", lua_set_chid_visibility},
-    {"get_chid_visibility", lua_get_chid_visibility},
-    {"toggle_chid_visibility", lua_toggle_chid_visibility},
+    {"set_chid_visibility", LuaSetChidVisibility},
+    {"get_chid_visibility", LuaGetChidVisibility},
+    {"toggle_chid_visibility", LuaToggleChidVisibility},
 
     // blockages
-    {"blockages_hide_all", lua_blockages_hide_all},
+    {"blockages_hide_all", LuaBlockagesHideAll},
     // {"get_chid_visibility", lua_get_chid_visibility},
     // {"toggle_chid_visibility", lua_toggle_chid_visibility},
 
     // outlines
-    {"outlines_show", lua_outlines_show},
-    {"outlines_hide", lua_outlines_hide},
+    {"outlines_show", LuaOutlinesShow},
+    {"outlines_hide", LuaOutlinesHide},
 
     // surfaces
-    {"surfaces_hide_all", lua_surfaces_hide_all},
+    {"surfaces_hide_all", LuaSurfacesHideAll},
     // devices
-    {"devices_hide_all", lua_devices_hide_all},
+    {"devices_hide_all", LuaDevicesHideAll},
 
     // axis
-    {"set_axis_visibility", lua_set_axis_visibility},
-    {"get_axis_visibility", lua_get_axis_visibility},
-    {"toggle_axis_visibility", lua_toggle_axis_visibility},
+    {"set_axis_visibility", LuaSetAxisVisibility},
+    {"get_axis_visibility", LuaGetAxisVisibility},
+    {"toggle_axis_visibility", LuaToggleAxisVisibility},
 
     // frame label
-    {"set_framelabel_visibility", lua_set_framelabel_visibility},
-    {"get_framelabel_visibility", lua_get_framelabel_visibility},
-    {"toggle_framelabel_visibility", lua_toggle_framelabel_visibility},
+    {"set_framelabel_visibility", LuaSetFramelabelVisibility},
+    {"get_framelabel_visibility", LuaGetFramelabelVisibility},
+    {"toggle_framelabel_visibility", LuaToggleFramelabelVisibility},
 
     // framerate
-    {"set_framerate_visibility", lua_set_framerate_visibility},
-    {"get_framerate_visibility", lua_get_framerate_visibility},
-    {"toggle_framerate_visibility", lua_toggle_framerate_visibility},
+    {"set_framerate_visibility", LuaSetFramerateVisibility},
+    {"get_framerate_visibility", LuaGetFramerateVisibility},
+    {"toggle_framerate_visibility", LuaToggleFramerateVisibility},
 
     // grid locations
-    {"set_gridloc_visibility", lua_set_gridloc_visibility},
-    {"get_gridloc_visibility", lua_get_gridloc_visibility},
-    {"toggle_gridloc_visibility", lua_toggle_gridloc_visibility},
+    {"set_gridloc_visibility", LuaSetGridlocVisibility},
+    {"get_gridloc_visibility", LuaGetGridlocVisibility},
+    {"toggle_gridloc_visibility", LuaToggleGridlocVisibility},
 
     // hrrpuv cutoff
-    {"set_hrrcutoff_visibility", lua_set_hrrcutoff_visibility},
-    {"get_hrrcutoff_visibility", lua_get_hrrcutoff_visibility},
-    {"toggle_hrrcutoff_visibility", lua_toggle_hrrcutoff_visibility},
+    {"set_hrrcutoff_visibility", LuaSetHrrcutoffVisibility},
+    {"get_hrrcutoff_visibility", LuaGetHrrcutoffVisibility},
+    {"toggle_hrrcutoff_visibility", LuaToggleHrrcutoffVisibility},
 
     // hrr label
-    {"set_hrrlabel_visibility", lua_set_hrrlabel_visibility},
-    {"get_hrrlabel_visibility", lua_get_hrrlabel_visibility},
-    {"toggle_hrrlabel_visibility", lua_toggle_hrrlabel_visibility},
+    {"set_hrrlabel_visibility", LuaSetHrrlabelVisibility},
+    {"get_hrrlabel_visibility", LuaGetHrrlabelVisibility},
+    {"toggle_hrrlabel_visibility", LuaToggleHrrlabelVisibility},
 
 // memory load
 #ifdef pp_memstatus
-    {"set_memload_visibility", lua_set_memload_visibility},
-    {"get_memload_visibility", lua_get_memload_visibility},
-    {"toggle_memload_visibility", lua_toggle_memload_visibility},
+    {"set_memload_visibility", LuaSetMemloadVisibility},
+    {"get_memload_visibility", LuaGetMemloadVisibility},
+    {"toggle_memload_visibility", LuaToggleMemloadVisibility},
 #endif
 
     // mesh label
-    {"set_meshlabel_visibility", lua_set_meshlabel_visibility},
-    {"get_meshlabel_visibility", lua_get_meshlabel_visibility},
-    {"toggle_meshlabel_visibility", lua_toggle_meshlabel_visibility},
+    {"set_meshlabel_visibility", LuaSetMeshlabelVisibility},
+    {"get_meshlabel_visibility", LuaGetMeshlabelVisibility},
+    {"toggle_meshlabel_visibility", LuaToggleMeshlabelVisibility},
 
     // slice average
-    {"set_slice_average_visibility", lua_set_slice_average_visibility},
-    {"get_slice_average_visibility", lua_get_slice_average_visibility},
-    {"toggle_slice_average_visibility", lua_toggle_slice_average_visibility},
+    {"set_slice_average_visibility", LuaSetSliceAverageVisibility},
+    {"get_slice_average_visibility", LuaGetSliceAverageVisibility},
+    {"toggle_slice_average_visibility", LuaToggleSliceAverageVisibility},
 
     // time
-    {"set_time_visibility", lua_set_time_visibility},
-    {"get_time_visibility", lua_get_time_visibility},
-    {"toggle_time_visibility", lua_toggle_time_visibility},
+    {"set_time_visibility", LuaSetTimeVisibility},
+    {"get_time_visibility", LuaGetTimeVisibility},
+    {"toggle_time_visibility", LuaToggleTimeVisibility},
 
     // user settable ticks
-    {"set_user_ticks_visibility", lua_set_user_ticks_visibility},
-    {"get_user_ticks_visibility", lua_get_user_ticks_visibility},
-    {"toggle_user_ticks_visibility", lua_toggle_user_ticks_visibility},
+    {"set_user_ticks_visibility", LuaSetUserTicksVisibility},
+    {"get_user_ticks_visibility", LuaGetUserTicksVisibility},
+    {"toggle_user_ticks_visibility", LuaToggleUserTicksVisibility},
 
     // version info
-    {"set_version_info_visibility", lua_set_version_info_visibility},
-    {"get_version_info_visibility", lua_get_version_info_visibility},
-    {"toggle_version_info_visibility", lua_toggle_version_info_visibility},
+    {"set_version_info_visibility", LuaSetVersionInfoVisibility},
+    {"get_version_info_visibility", LuaGetVersionInfoVisibility},
+    {"toggle_version_info_visibility", LuaToggleVersionInfoVisibility},
 
     // set all
-    {"set_all_label_visibility", lua_set_all_label_visibility},
+    {"set_all_label_visibility", LuaSetAllLabelVisibility},
 
     // set the blockage view method
-    {"blockage_view_method", lua_blockage_view_method},
-    {"blockage_outline_color", lua_blockage_outline_color},
-    {"blockage_locations", lua_blockage_locations},
+    {"blockage_view_method", LuaBlockageViewMethod},
+    {"blockage_outline_color", LuaBlockageOutlineColor},
+    {"blockage_locations", LuaBlockageLocations},
 
-    {"set_colorbar_colors", lua_set_colorbar_colors},
-    {"get_colorbar_colors", lua_get_colorbar_colors},
-    {"set_color2bar_colors", lua_set_color2bar_colors},
-    {"get_color2bar_colors", lua_get_color2bar_colors},
+    {"set_colorbar_colors", LuaSetColorbarColors},
+    {"get_colorbar_colors", LuaGetColorbarColors},
+    {"set_color2bar_colors", LuaSetColor2barColors},
+    {"get_color2bar_colors", LuaGetColor2barColors},
 
     // Camera API
-    {"camera_mod_eyex", lua_camera_mod_eyex},
-    {"camera_set_eyex", lua_camera_set_eyex},
-    {"camera_get_eyex", lua_camera_get_eyex},
+    {"camera_mod_eyex", LuaCameraModEyex},
+    {"camera_set_eyex", LuaCameraSetEyex},
+    {"camera_get_eyex", LuaCameraGetEyex},
 
-    {"camera_mod_eyey", lua_camera_mod_eyey},
-    {"camera_set_eyey", lua_camera_set_eyey},
-    {"camera_get_eyey", lua_camera_get_eyey},
+    {"camera_mod_eyey", LuaCameraModEyey},
+    {"camera_set_eyey", LuaCameraSetEyey},
+    {"camera_get_eyey", LuaCameraGetEyey},
 
-    {"camera_mod_eyez", lua_camera_mod_eyez},
-    {"camera_set_eyez", lua_camera_set_eyez},
-    {"camera_get_eyez", lua_camera_get_eyez},
+    {"camera_mod_eyez", LuaCameraModEyez},
+    {"camera_set_eyez", LuaCameraSetEyez},
+    {"camera_get_eyez", LuaCameraGetEyez},
 
-    {"camera_mod_az", lua_camera_mod_az},
-    {"camera_set_az", lua_camera_set_az},
-    {"camera_get_az", lua_camera_get_az},
-    {"camera_mod_elev", lua_camera_mod_elev},
-    {"camera_zoom_to_fit", lua_camera_zoom_to_fit},
-    {"camera_set_elev", lua_camera_set_elev},
-    {"camera_get_elev", lua_camera_get_elev},
+    {"camera_mod_az", LuaCameraModAz},
+    {"camera_set_az", LuaCameraSetAz},
+    {"camera_get_az", LuaCameraGetAz},
+    {"camera_mod_elev", LuaCameraModElev},
+    {"camera_zoom_to_fit", LuaCameraZoomToFit},
+    {"camera_set_elev", LuaCameraSetElev},
+    {"camera_get_elev", LuaCameraGetElev},
 
-    {"camera_set_viewdir", lua_camera_set_viewdir},
-    {"camera_get_viewdir", lua_camera_get_viewdir},
+    {"camera_set_viewdir", LuaCameraSetViewdir},
+    {"camera_get_viewdir", LuaCameraGetViewdir},
 
-    {"camera_get_zoom", lua_camera_get_zoom},
-    {"camera_set_zoom", lua_camera_set_zoom},
+    {"camera_get_zoom", LuaCameraGetZoom},
+    {"camera_set_zoom", LuaCameraSetZoom},
 
-    {"camera_get_rotation_type", lua_camera_get_rotation_type},
-    {"camera_get_rotation_index", lua_camera_get_rotation_index},
-    {"camera_set_rotation_type", lua_camera_set_rotation_type},
-    {"camera_get_projection_type", lua_camera_get_projection_type},
-    {"camera_set_projection_type", lua_camera_set_projection_type},
+    {"camera_get_rotation_type", LuaCameraGetRotationType},
+    {"camera_get_rotation_index", LuaCameraGetRotationIndex},
+    {"camera_set_rotation_type", LuaCameraSetRotationType},
+    {"camera_get_projection_type", LuaCameraGetProjectionType},
+    {"camera_set_projection_type", LuaCameraSetProjectionType},
 
-    {"get_clipping_mode", lua_get_clipping_mode},
-    {"set_clipping_mode", lua_set_clipping_mode},
-    {"set_sceneclip_x", lua_set_sceneclip_x},
-    {"set_sceneclip_x_min", lua_set_sceneclip_x_min},
-    {"set_sceneclip_x_max", lua_set_sceneclip_x_max},
-    {"set_sceneclip_y", lua_set_sceneclip_y},
-    {"set_sceneclip_y_min", lua_set_sceneclip_y_min},
-    {"set_sceneclip_y_max", lua_set_sceneclip_y_max},
-    {"set_sceneclip_z", lua_set_sceneclip_z},
-    {"set_sceneclip_z_min", lua_set_sceneclip_z_min},
-    {"set_sceneclip_z_max", lua_set_sceneclip_z_max},
+    {"get_clipping_mode", LuaGetClippingMode},
+    {"set_clipping_mode", LuaSetClippingMode},
+    {"set_sceneclip_x", LuaSetSceneclipX},
+    {"set_sceneclip_x_min", LuaSetSceneclipXMin},
+    {"set_sceneclip_x_max", LuaSetSceneclipXMax},
+    {"set_sceneclip_y", LuaSetSceneclipY},
+    {"set_sceneclip_y_min", LuaSetSceneclipYMin},
+    {"set_sceneclip_y_max", LuaSetSceneclipYMax},
+    {"set_sceneclip_z", LuaSetSceneclipZ},
+    {"set_sceneclip_z_min", LuaSetSceneclipZMin},
+    {"set_sceneclip_z_max", LuaSetSceneclipZMax},
 
-    {"set_ambientlight", lua_set_ambientlight},
-    {"get_backgroundcolor", lua_get_backgroundcolor},
-    {"set_backgroundcolor", lua_set_backgroundcolor},
-    {"set_blockcolor", lua_set_blockcolor},
-    {"set_blockshininess", lua_set_blockshininess},
-    {"set_blockspecular", lua_set_blockspecular},
-    {"set_boundcolor", lua_set_boundcolor},
-    {"set_diffuselight", lua_set_diffuselight},
-    {"set_directioncolor", lua_set_directioncolor},
-    {"get_flip", lua_get_flip},
-    {"set_flip", lua_set_flip},
-    {"get_foregroundcolor", lua_get_foregroundcolor},
-    {"set_foregroundcolor", lua_set_foregroundcolor},
-    {"set_heatoffcolor", lua_set_heatoffcolor},
-    {"set_heatoncolor", lua_set_heatoncolor},
-    {"set_isocolors", lua_set_isocolors},
-    {"set_colortable", lua_set_colortable},
-    {"set_lightpos0", lua_set_lightpos0},
-    {"set_lightpos1", lua_set_lightpos1},
-    {"set_sensorcolor", lua_set_sensorcolor},
-    {"set_sensornormcolor", lua_set_sensornormcolor},
-    {"set_bw", lua_set_bw},
-    {"set_sprinkleroffcolor", lua_set_sprinkleroffcolor},
-    {"set_sprinkleroncolor", lua_set_sprinkleroncolor},
-    {"set_staticpartcolor", lua_set_staticpartcolor},
-    {"set_timebarcolor", lua_set_timebarcolor},
-    {"set_ventcolor", lua_set_ventcolor},
-    {"set_gridlinewidth", lua_set_gridlinewidth},
-    {"set_isolinewidth", lua_set_isolinewidth},
-    {"set_isopointsize", lua_set_isopointsize},
-    {"set_linewidth", lua_set_linewidth},
-    {"set_partpointsize", lua_set_partpointsize},
-    {"set_plot3dlinewidth", lua_set_plot3dlinewidth},
-    {"set_plot3dpointsize", lua_set_plot3dpointsize},
-    {"set_sensorabssize", lua_set_sensorabssize},
-    {"set_sensorrelsize", lua_set_sensorrelsize},
-    {"set_sliceoffset", lua_set_sliceoffset},
-    {"set_smoothlines", lua_set_smoothlines},
-    {"set_spheresegs", lua_set_spheresegs},
-    {"set_sprinklerabssize", lua_set_sprinklerabssize},
-    {"set_streaklinewidth", lua_set_streaklinewidth},
-    {"set_ticklinewidth", lua_set_ticklinewidth},
-    {"set_usenewdrawface", lua_set_usenewdrawface},
-    {"set_veclength", lua_set_veclength},
-    {"set_vectorlinewidth", lua_set_vectorlinewidth},
-    {"set_vectorpointsize", lua_set_vectorpointsize},
-    {"set_ventlinewidth", lua_set_ventlinewidth},
-    {"set_ventoffset", lua_set_ventoffset},
-    {"set_windowoffset", lua_set_windowoffset},
-    {"set_windowwidth", lua_set_windowwidth},
-    {"set_windowheight", lua_set_windowheight},
+    {"set_ambientlight", LuaSetAmbientlight},
+    {"get_backgroundcolor", LuaGetBackgroundcolor},
+    {"set_backgroundcolor", LuaSetBackgroundcolor},
+    {"set_blockcolor", LuaSetBlockcolor},
+    {"set_blockshininess", LuaSetBlockshininess},
+    {"set_blockspecular", LuaSetBlockspecular},
+    {"set_boundcolor", LuaSetBoundcolor},
+    {"set_diffuselight", LuaSetDiffuselight},
+    {"set_directioncolor", LuaSetDirectioncolor},
+    {"get_flip", LuaGetFlip},
+    {"set_flip", LuaSetFlip},
+    {"get_foregroundcolor", LuaGetForegroundcolor},
+    {"set_foregroundcolor", LuaSetForegroundcolor},
+    {"set_heatoffcolor", LuaSetHeatoffcolor},
+    {"set_heatoncolor", LuaSetHeatoncolor},
+    {"set_isocolors", LuaSetIsocolors},
+    {"set_colortable", LuaSetColortable},
+    {"set_lightpos0", LuaSetLightpos0},
+    {"set_lightpos1", LuaSetLightpos1},
+    {"set_sensorcolor", LuaSetSensorcolor},
+    {"set_sensornormcolor", LuaSetSensornormcolor},
+    {"set_bw", LuaSetBw},
+    {"set_sprinkleroffcolor", LuaSetSprinkleroffcolor},
+    {"set_sprinkleroncolor", LuaSetSprinkleroncolor},
+    {"set_staticpartcolor", LuaSetStaticpartcolor},
+    {"set_timebarcolor", LuaSetTimebarcolor},
+    {"set_ventcolor", LuaSetVentcolor},
+    {"set_gridlinewidth", LuaSetGridlinewidth},
+    {"set_isolinewidth", LuaSetIsolinewidth},
+    {"set_isopointsize", LuaSetIsopointsize},
+    {"set_linewidth", LuaSetLinewidth},
+    {"set_partpointsize", LuaSetPartpointsize},
+    {"set_plot3dlinewidth", LuaSetPlot3dlinewidth},
+    {"set_plot3dpointsize", LuaSetPlot3dpointsize},
+    {"set_sensorabssize", LuaSetSensorabssize},
+    {"set_sensorrelsize", LuaSetSensorrelsize},
+    {"set_sliceoffset", LuaSetSliceoffset},
+    {"set_smoothlines", LuaSetSmoothlines},
+    {"set_spheresegs", LuaSetSpheresegs},
+    {"set_sprinklerabssize", LuaSetSprinklerabssize},
+    {"set_streaklinewidth", LuaSetStreaklinewidth},
+    {"set_ticklinewidth", LuaSetTicklinewidth},
+    {"set_usenewdrawface", LuaSetUsenewdrawface},
+    {"set_veclength", LuaSetVeclength},
+    {"set_vectorlinewidth", LuaSetVectorlinewidth},
+    {"set_vectorpointsize", LuaSetVectorpointsize},
+    {"set_ventlinewidth", LuaSetVentlinewidth},
+    {"set_ventoffset", LuaSetVentoffset},
+    {"set_windowoffset", LuaSetWindowoffset},
+    {"set_windowwidth", LuaSetWindowwidth},
+    {"set_windowheight", LuaSetWindowheight},
 
-    {"set_boundzipstep", lua_set_boundzipstep},
-    {"set_fed", lua_set_fed},
-    {"set_fedcolorbar", lua_set_fedcolorbar},
-    {"set_isozipstep", lua_set_isozipstep},
-    {"set_nopart", lua_set_nopart},
-    {"set_showfedarea", lua_set_showfedarea},
-    {"set_sliceaverage", lua_set_sliceaverage},
-    {"set_slicedataout", lua_set_slicedataout},
-    {"set_slicezipstep", lua_set_slicezipstep},
-    {"set_smoke3dzipstep", lua_set_smoke3dzipstep},
-    {"set_userrotate", lua_set_userrotate},
+    {"set_boundzipstep", LuaSetBoundzipstep},
+    {"set_fed", LuaSetFed},
+    {"set_fedcolorbar", LuaSetFedcolorbar},
+    {"set_isozipstep", LuaSetIsozipstep},
+    {"set_nopart", LuaSetNopart},
+    {"set_showfedarea", LuaSetShowfedarea},
+    {"set_sliceaverage", LuaSetSliceaverage},
+    {"set_slicedataout", LuaSetSlicedataout},
+    {"set_slicezipstep", LuaSetSlicezipstep},
+    {"set_smoke3dzipstep", LuaSetSmoke3dzipstep},
+    {"set_userrotate", LuaSetUserrotate},
 
-    {"set_aperture", lua_set_aperture},
+    {"set_aperture", LuaSetAperture},
     // { "set_axissmooth", lua_set_axissmooth },
-    {"set_blocklocation", lua_set_blocklocation},
-    {"set_boundarytwoside", lua_set_boundarytwoside},
-    {"set_clip", lua_set_clip},
-    {"set_contourtype", lua_set_contourtype},
-    {"set_cullfaces", lua_set_cullfaces},
-    {"set_texturelighting", lua_set_texturelighting},
-    {"set_eyeview", lua_set_eyeview},
-    {"set_eyex", lua_set_eyex},
-    {"set_eyey", lua_set_eyey},
-    {"set_eyez", lua_set_eyez},
-    {"get_fontsize", lua_get_fontsize},
-    {"set_fontsize", lua_set_fontsize},
-    {"set_frameratevalue", lua_set_frameratevalue},
-    {"set_showfaces_solid", lua_set_showfaces_solid},
-    {"set_showfaces_outline", lua_set_showfaces_outline},
-    {"set_smoothgeomnormal", lua_set_smoothgeomnormal},
-    {"set_geomvertexag", lua_set_geomvertexag},
-    {"set_gversion", lua_set_gversion},
-    {"set_isotran2", lua_set_isotran2},
-    {"set_meshvis", lua_set_meshvis},
-    {"set_meshoffset", lua_set_meshoffset},
+    {"set_blocklocation", LuaSetBlocklocation},
+    {"set_boundarytwoside", LuaSetBoundarytwoside},
+    {"set_clip", LuaSetClip},
+    {"set_contourtype", LuaSetContourtype},
+    {"set_cullfaces", LuaSetCullfaces},
+    {"set_texturelighting", LuaSetTexturelighting},
+    {"set_eyeview", LuaSetEyeview},
+    {"set_eyex", LuaSetEyex},
+    {"set_eyey", LuaSetEyey},
+    {"set_eyez", LuaSetEyez},
+    {"get_fontsize", LuaGetFontsize},
+    {"set_fontsize", LuaSetFontsize},
+    {"set_frameratevalue", LuaSetFrameratevalue},
+    {"set_showfaces_solid", LuaSetShowfacesSolid},
+    {"set_showfaces_outline", LuaSetShowfacesOutline},
+    {"set_smoothgeomnormal", LuaSetSmoothgeomnormal},
+    {"set_geomvertexag", LuaSetGeomvertexag},
+    {"set_gversion", LuaSetGversion},
+    {"set_isotran2", LuaSetIsotran2},
+    {"set_meshvis", LuaSetMeshvis},
+    {"set_meshoffset", LuaSetMeshoffset},
 
-    {"set_northangle", lua_set_northangle},
-    {"set_offsetslice", lua_set_offsetslice},
-    {"set_outlinemode", lua_set_outlinemode},
-    {"set_p3dsurfacetype", lua_set_p3dsurfacetype},
-    {"set_p3dsurfacesmooth", lua_set_p3dsurfacesmooth},
-    {"set_scaledfont", lua_set_scaledfont},
-    {"set_scaledfont_height2d", lua_set_scaledfont_height2d},
-    {"set_showalltextures", lua_set_showalltextures},
-    {"set_showaxislabels", lua_set_showaxislabels},
-    {"set_showblocklabel", lua_set_showblocklabel},
-    {"set_showblocks", lua_set_showblocks},
-    {"set_showcadandgrid", lua_set_showcadandgrid},
-    {"set_showcadopaque", lua_set_showcadopaque},
-    {"set_showceiling", lua_set_showceiling},
-    {"set_showcolorbars", lua_set_showcolorbars},
-    {"set_showcvents", lua_set_showcvents},
-    {"set_showdummyvents", lua_set_showdummyvents},
-    {"set_showfloor", lua_set_showfloor},
-    {"set_showframe", lua_set_showframe},
-    {"set_showframelabel", lua_set_showframelabel},
-    {"set_showframerate", lua_set_showframerate},
-    {"set_showgrid", lua_set_showgrid},
-    {"set_showgridloc", lua_set_showgridloc},
-    {"set_showhmstimelabel", lua_set_showhmstimelabel},
-    {"set_showhrrcutoff", lua_set_showhrrcutoff},
-    {"set_showiso", lua_set_showiso},
-    {"set_showisonormals", lua_set_showisonormals},
-    {"set_showlabels", lua_set_showlabels},
+    {"set_northangle", LuaSetNorthangle},
+    {"set_offsetslice", LuaSetOffsetslice},
+    {"set_outlinemode", LuaSetOutlinemode},
+    {"set_p3dsurfacetype", LuaSetP3dsurfacetype},
+    {"set_p3dsurfacesmooth", LuaSetP3dsurfacesmooth},
+    {"set_scaledfont", LuaSetScaledfont},
+    {"set_scaledfont_height2d", LuaSetScaledfontHeight2d},
+    {"set_showalltextures", LuaSetShowalltextures},
+    {"set_showaxislabels", LuaSetShowaxislabels},
+    {"set_showblocklabel", LuaSetShowblocklabel},
+    {"set_showblocks", LuaSetShowblocks},
+    {"set_showcadandgrid", LuaSetShowcadandgrid},
+    {"set_showcadopaque", LuaSetShowcadopaque},
+    {"set_showceiling", LuaSetShowceiling},
+    {"set_showcolorbars", LuaSetShowcolorbars},
+    {"set_showcvents", LuaSetShowcvents},
+    {"set_showdummyvents", LuaSetShowdummyvents},
+    {"set_showfloor", LuaSetShowfloor},
+    {"set_showframe", LuaSetShowframe},
+    {"set_showframelabel", LuaSetShowframelabel},
+    {"set_showframerate", LuaSetShowframerate},
+    {"set_showgrid", LuaSetShowgrid},
+    {"set_showgridloc", LuaSetShowgridloc},
+    {"set_showhmstimelabel", LuaSetShowhmstimelabel},
+    {"set_showhrrcutoff", LuaSetShowhrrcutoff},
+    {"set_showiso", LuaSetShowiso},
+    {"set_showisonormals", LuaSetShowisonormals},
+    {"set_showlabels", LuaSetShowlabels},
 #ifdef pp_memstatus
-    {"set_showmemload", lua_set_showmemload},
+    {"set_showmemload", LuaSetShowmemload},
 #endif
-    {"set_showopenvents", lua_set_showopenvents},
-    {"set_showothervents", lua_set_showothervents},
-    {"set_showsensors", lua_set_showsensors},
-    {"set_showsliceinobst", lua_set_showsliceinobst},
-    {"set_showsmokepart", lua_set_showsmokepart},
-    {"set_showsprinkpart", lua_set_showsprinkpart},
-    {"set_showstreak", lua_set_showstreak},
-    {"set_showterrain", lua_set_showterrain},
-    {"set_showthreshold", lua_set_showthreshold},
-    {"set_showticks", lua_set_showticks},
-    {"set_showtimebar", lua_set_showtimebar},
-    {"set_showtimelabel", lua_set_showtimelabel},
-    {"set_showtitle", lua_set_showtitle},
-    {"set_showtracersalways", lua_set_showtracersalways},
-    {"set_showtriangles", lua_set_showtriangles},
-    {"set_showtransparent", lua_set_showtransparent},
-    {"set_showtransparentvents", lua_set_showtranparentvents},
-    {"set_showtrianglecount", lua_set_showtrianglecount},
-    {"set_showventflow", lua_set_showventflow},
-    {"set_showvents", lua_set_showvents},
-    {"set_showwalls", lua_set_showwalls},
-    {"set_skipembedslice", lua_set_skipembedslice},
+    {"set_showopenvents", LuaSetShowopenvents},
+    {"set_showothervents", LuaSetShowothervents},
+    {"set_showsensors", LuaSetShowsensors},
+    {"set_showsliceinobst", LuaSetShowsliceinobst},
+    {"set_showsmokepart", LuaSetShowsmokepart},
+    {"set_showsprinkpart", LuaSetShowsprinkpart},
+    {"set_showstreak", LuaSetShowstreak},
+    {"set_showterrain", LuaSetShowterrain},
+    {"set_showthreshold", LuaSetShowthreshold},
+    {"set_showticks", LuaSetShowticks},
+    {"set_showtimebar", LuaSetShowtimebar},
+    {"set_showtimelabel", LuaSetShowtimelabel},
+    {"set_showtitle", LuaSetShowtitle},
+    {"set_showtracersalways", LuaSetShowtracersalways},
+    {"set_showtriangles", LuaSetShowtriangles},
+    {"set_showtransparent", LuaSetShowtransparent},
+    {"set_showtransparentvents", LuaSetShowtranparentvents},
+    {"set_showtrianglecount", LuaSetShowtrianglecount},
+    {"set_showventflow", LuaSetShowventflow},
+    {"set_showvents", LuaSetShowvents},
+    {"set_showwalls", LuaSetShowwalls},
+    {"set_skipembedslice", LuaSetSkipembedslice},
 #ifdef pp_SLICEUP
     {"set_slicedup", lua_set_slicedup},
 #endif
-    {"set_smokesensors", lua_set_smokesensors},
+    {"set_smokesensors", LuaSetSmokesensors},
 #ifdef pp_LANG
     {"set_startuplang", lua_set_startuplang},
 #endif
-    {"set_stereo", lua_set_stereo},
-    {"set_surfinc", lua_set_surfinc},
-    {"set_terrainparams", lua_set_terrainparams},
-    {"set_titlesafe", lua_set_titlesafe},
-    {"set_trainermode", lua_set_trainermode},
-    {"set_trainerview", lua_set_trainerview},
-    {"set_transparent", lua_set_transparent},
-    {"set_treeparms", lua_set_treeparms},
-    {"set_twosidedvents", lua_set_twosidedvents},
-    {"set_vectorskip", lua_set_vectorskip},
-    {"set_volsmoke", lua_set_volsmoke},
-    {"set_zoom", lua_set_zoom},
-    {"set_cellcentertext", lua_set_cellcentertext},
-    {"set_inputfile", lua_set_inputfile},
-    {"set_labelstartupview", lua_set_labelstartupview},
+    {"set_stereo", LuaSetStereo},
+    {"set_surfinc", LuaSetSurfinc},
+    {"set_terrainparams", LuaSetTerrainparams},
+    {"set_titlesafe", LuaSetTitlesafe},
+    {"set_trainermode", LuaSetTrainermode},
+    {"set_trainerview", LuaSetTrainerview},
+    {"set_transparent", LuaSetTransparent},
+    {"set_treeparms", LuaSetTreeparms},
+    {"set_twosidedvents", LuaSetTwosidedvents},
+    {"set_vectorskip", LuaSetVectorskip},
+    {"set_volsmoke", LuaSetVolsmoke},
+    {"set_zoom", LuaSetZoom},
+    {"set_cellcentertext", LuaSetCellcentertext},
+    {"set_inputfile", LuaSetInputfile},
+    {"set_labelstartupview", LuaSetLabelstartupview},
     // { "set_pixelskip", lua_set_pixelskip },
-    {"set_renderclip", lua_set_renderclip},
+    {"set_renderclip", LuaSetRenderclip},
     // { "set_renderfilelabel", lua_set_renderfilelabel },
-    {"set_renderfiletype", lua_set_renderfiletype},
+    {"set_renderfiletype", LuaSetRenderfiletype},
 
     // { "set_skybox", lua_set_skybox },
     // { "set_renderoption", lua_set_renderoption },
-    {"get_units", lua_get_units},
-    {"get_unitclass", lua_get_unitclass},
+    {"get_units", LuaGetUnits},
+    {"get_unitclass", LuaGetUnitclass},
 
-    {"set_pl3d_bound_min", lua_set_pl3d_bound_min},
-    {"set_pl3d_bound_max", lua_set_pl3d_bound_max},
+    {"set_pl3d_bound_min", LuaSetPl3dBoundMin},
+    {"set_pl3d_bound_max", LuaSetPl3dBoundMax},
 
-    {"set_units", lua_set_units},
-    {"set_unitclasses", lua_set_unitclasses},
-    {"set_zaxisangles", lua_set_zaxisangles},
-    {"set_colorbartype", lua_set_colorbartype},
-    {"set_extremecolors", lua_set_extremecolors},
-    {"set_firecolor", lua_set_firecolor},
-    {"set_firecolormap", lua_set_firecolormap},
-    {"set_firedepth", lua_set_firedepth},
+    {"set_units", LuaSetUnits},
+    {"set_unitclasses", LuaSetUnitclasses},
+    {"set_zaxisangles", LuaSetZaxisangles},
+    {"set_colorbartype", LuaSetColorbartype},
+    {"set_extremecolors", LuaSetExtremecolors},
+    {"set_firecolor", LuaSetFirecolor},
+    {"set_firecolormap", LuaSetFirecolormap},
+    {"set_firedepth", LuaSetFiredepth},
     // { "set_golorbar", lua_set_gcolorbar },
-    {"set_showextremedata", lua_set_showextremedata},
-    {"set_smokecolor", lua_set_smokecolor},
-    {"set_smokecull", lua_set_smokecull},
-    {"set_smokeskip", lua_set_smokeskip},
-    {"set_smokealbedo", lua_set_smokealbedo},
+    {"set_showextremedata", LuaSetShowextremedata},
+    {"set_smokecolor", LuaSetSmokecolor},
+    {"set_smokecull", LuaSetSmokecull},
+    {"set_smokeskip", LuaSetSmokeskip},
+    {"set_smokealbedo", LuaSetSmokealbedo},
 #ifdef pp_GPU // TODO: register anyway, but tell user it is not available
-    {"set_smokerthick", lua_set_smokerthick},
+    {"set_smokerthick", LuaSetSmokerthick},
 #endif
 // { "set_smokethick", lua_set_smokethick },
 #ifdef pp_GPU
-    {"set_usegpu", lua_set_usegpu},
+    {"set_usegpu", LuaSetUsegpu},
 #endif
-    {"set_showhazardcolors", lua_set_showhazardcolors},
-    {"set_showhzone", lua_set_showhzone},
-    {"set_showszone", lua_set_showszone},
-    {"set_showvzone", lua_set_showvzone},
-    {"set_showzonefire", lua_set_showzonefire},
-    {"set_showpathnodes", lua_set_showpathnodes},
-    {"set_showtourroute", lua_set_showtourroute},
-    {"set_tourcolors_selectedpathline", lua_set_tourcolors_selectedpathline},
+    {"set_showhazardcolors", LuaSetShowhazardcolors},
+    {"set_showhzone", LuaSetShowhzone},
+    {"set_showszone", LuaSetShowszone},
+    {"set_showvzone", LuaSetShowvzone},
+    {"set_showzonefire", LuaSetShowzonefire},
+    {"set_showpathnodes", LuaSetShowpathnodes},
+    {"set_showtourroute", LuaSetShowtourroute},
+    {"set_tourcolors_selectedpathline", LuaSetTourcolorsSelectedpathline},
     {"set_tourcolors_selectedpathlineknots",
-     lua_set_tourcolors_selectedpathlineknots},
-    {"set_tourcolors_selectedknot", lua_set_tourcolors_selectedknot},
-    {"set_tourcolors_pathline", lua_set_tourcolors_pathline},
-    {"set_tourcolors_pathknots", lua_set_tourcolors_pathknots},
-    {"set_tourcolors_text", lua_set_tourcolors_text},
-    {"set_tourcolors_avatar", lua_set_tourcolors_avatar},
-    {"set_viewalltours", lua_set_viewalltours},
-    {"set_viewtimes", lua_set_viewtimes},
-    {"set_viewtourfrompath", lua_set_viewtourfrompath},
-    {"set_devicevectordimensions", lua_set_devicevectordimensions},
-    {"set_devicebounds", lua_set_devicebounds},
-    {"set_deviceorientation", lua_set_deviceorientation},
-    {"set_gridparms", lua_set_gridparms},
-    {"set_gsliceparms", lua_set_gsliceparms},
-    {"set_loadfilesatstartup", lua_set_loadfilesatstartup},
-    {"set_mscale", lua_set_mscale},
-    {"set_sliceauto", lua_set_sliceauto},
-    {"set_msliceauto", lua_set_msliceauto},
-    {"set_compressauto", lua_set_compressauto},
+     LuaSetTourcolorsSelectedpathlineknots},
+    {"set_tourcolors_selectedknot", LuaSetTourcolorsSelectedknot},
+    {"set_tourcolors_pathline", LuaSetTourcolorsPathline},
+    {"set_tourcolors_pathknots", LuaSetTourcolorsPathknots},
+    {"set_tourcolors_text", LuaSetTourcolorsText},
+    {"set_tourcolors_avatar", LuaSetTourcolorsAvatar},
+    {"set_viewalltours", LuaSetViewalltours},
+    {"set_viewtimes", LuaSetViewtimes},
+    {"set_viewtourfrompath", LuaSetViewtourfrompath},
+    {"set_devicevectordimensions", LuaSetDevicevectordimensions},
+    {"set_devicebounds", LuaSetDevicebounds},
+    {"set_deviceorientation", LuaSetDeviceorientation},
+    {"set_gridparms", LuaSetGridparms},
+    {"set_gsliceparms", LuaSetGsliceparms},
+    {"set_loadfilesatstartup", LuaSetLoadfilesatstartup},
+    {"set_mscale", LuaSetMscale},
+    {"set_sliceauto", LuaSetSliceauto},
+    {"set_msliceauto", LuaSetMsliceauto},
+    {"set_compressauto", LuaSetCompressauto},
     // { "set_part5propdisp", lua_set_part5propdisp },
     // { "set_part5color", lua_set_part5color },
-    {"set_propindex", lua_set_propindex},
+    {"set_propindex", LuaSetPropindex},
     // { "set_shooter", lua_set_shooter },
-    {"set_showdevices", lua_set_showdevices},
-    {"set_showdevicevals", lua_set_showdevicevals},
-    {"set_showmissingobjects", lua_set_showmissingobjects},
-    {"set_tourindex", lua_set_tourindex},
+    {"set_showdevices", LuaSetShowdevices},
+    {"set_showdevicevals", LuaSetShowdevicevals},
+    {"set_showmissingobjects", LuaSetShowmissingobjects},
+    {"set_tourindex", LuaSetTourindex},
     // { "set_userticks", lua_set_userticks },
-    {"set_c_particles", lua_set_c_particles},
-    {"set_c_slice", lua_set_c_slice},
-    {"set_cache_boundarydata", lua_set_cache_boundarydata},
-    {"set_cache_qdata", lua_set_cache_qdata},
-    {"set_percentilelevel", lua_set_percentilelevel},
-    {"set_timeoffset", lua_set_timeoffset},
-    {"set_tload", lua_set_tload},
-    {"set_v_slice", lua_set_v_slice},
-    {"set_patchdataout", lua_set_patchdataout},
+    {"set_c_particles", LuaSetCParticles},
+    {"set_c_slice", LuaSetCSlice},
+    {"set_cache_boundarydata", LuaSetCacheBoundarydata},
+    {"set_cache_qdata", LuaSetCacheQdata},
+    {"set_percentilelevel", LuaSetPercentilelevel},
+    {"set_timeoffset", LuaSetTimeoffset},
+    {"set_tload", LuaSetTload},
+    {"set_v_slice", LuaSetVSlice},
+    {"set_patchdataout", LuaSetPatchdataout},
 
-    {"show_smoke3d_showall", lua_show_smoke3d_showall},
-    {"show_smoke3d_hideall", lua_show_smoke3d_hideall},
-    {"show_slices_showall", lua_show_slices_showall},
-    {"show_slices_hideall", lua_show_slices_hideall},
-    {"add_title_line", lua_add_title_line},
-    {"clear_title_lines", lua_clear_title_lines},
+    {"show_smoke3d_showall", LuaShowSmoke3dShowall},
+    {"show_smoke3d_hideall", LuaShowSmoke3dHideall},
+    {"show_slices_showall", LuaShowSlicesShowall},
+    {"show_slices_hideall", LuaShowSlicesHideall},
+    {"add_title_line", LuaAddTitleLine},
+    {"clear_title_lines", LuaClearTitleLines},
 
-    {"get_nglobal_times", lua_get_nglobal_times},
-    {"get_global_time", lua_get_global_time},
-    {"get_npartinfo", lua_get_npartinfo},
+    {"get_nglobal_times", LuaGetNglobalTimes},
+    {"get_global_time", LuaGetGlobalTime},
+    {"get_npartinfo", LuaGetNpartinfo},
 
-    {"get_slice", lua_get_slice},
-    {"slice_get_label", lua_slice_get_label},
-    {"slice_get_filename", lua_slice_get_filename},
-    {"slice_get_data", lua_slice_get_data},
-    {"slice_data_map_frames", lua_slice_data_map_frames},
-    {"slice_data_map_frames_count_less", lua_slice_data_map_frames_count_less},
-    {"slice_data_map_frames_count_less_eq",
-     lua_slice_data_map_frames_count_less_eq},
-    {"slice_data_map_frames_count_greater",
-     lua_slice_data_map_frames_count_greater},
+    {"get_slice", LuaGetSlice},
+    {"slice_get_label", LuaSliceGetLabel},
+    {"slice_get_filename", LuaSliceGetFilename},
+    {"slice_get_data", LuaSliceGetData},
+    {"slice_data_map_frames", LuaSliceDataMapFrames},
+    {"slice_data_map_frames_count_less", LuaSliceDataMapFramesCountLess},
+    {"slice_data_map_frames_count_less_eq", LuaSliceDataMapFramesCountLessEq},
+    {"slice_data_map_frames_count_greater", LuaSliceDataMapFramesCountGreater},
     {"slice_data_map_frames_count_greater_eq",
-     lua_slice_data_map_frames_count_greater_eq},
-    {"slice_get_times", lua_slice_get_times},
+     LuaSliceDataMapFramesCountGreaterEq},
+    {"slice_get_times", LuaSliceGetTimes},
 
-    {"get_part", lua_get_part},
-    {"get_part_npoints", lua_get_part_npoints},
+    {"get_part", LuaGetPart},
+    {"get_part_npoints", LuaGetPartNpoints},
 
-    {"get_qdata_sum", lua_get_qdata_sum},
-    {"get_qdata_sum_bounded", lua_get_qdata_sum_bounded},
-    {"get_qdata_max_bounded", lua_get_qdata_max_bounded},
-    {"get_qdata_mean", lua_get_qdata_mean},
+    {"get_qdata_sum", LuaGetQdataSum},
+    {"get_qdata_sum_bounded", LuaGetQdataSumBounded},
+    {"get_qdata_max_bounded", LuaGetQdataMaxBounded},
+    {"get_qdata_mean", LuaGetQdataMean},
     // nglobal_times is the number of frames
     //  this cannot be set as a global at init as it will change
     //  on the loading of smokeview cases
     {NULL, NULL}};
 
-int smvlib_newindex(lua_State *L) {
+int SmvlibNewindex(lua_State *L) {
   const char *field = lua_tostring(L, 2);
   const char *value = lua_tostring(L, 3);
   if (strcmp(field, "renderdir") == 0) {
     lua_pushstring(L, value);
-    lua_setrenderdir(L);
+    LuaSetrenderdir(L);
     return 0;
-  } else {
+  }
+  else {
     return 0;
   }
 }
 
-int smvlib_index(lua_State *L) {
+int SmvlibIndex(lua_State *L) {
   // Take the index from the table.
   // lua_pushstring(L, "index");
   // lua_gettable(L, 1);
   // int index = lua_tonumber(L, -1);
   const char *field = lua_tostring(L, 2);
   if (strcmp(field, "renderdir") == 0) {
-    return lua_getrenderdir(L);
-  } else {
+    return LuaGetrenderdir(L);
+  }
+  else {
     return 0;
   }
 }
 
-lua_State *initLua() {
+lua_State *InitLua() {
   L = luaL_newstate();
 
   luaL_openlibs(L);
 
-  luaL_newlib(L, smvlib);
+  luaL_newlib(L, SMVLIB);
 
-  lua_pushcfunction(L, &lua_create_case);
+  lua_pushcfunction(L, &LuaCreateCase);
   lua_setfield(L, -2, "load_default");
 
   lua_createtable(L, 0, 1);
-  lua_pushcfunction(L, &smvlib_newindex);
+  lua_pushcfunction(L, &SmvlibNewindex);
   lua_setfield(L, -2, "__newindex");
-  lua_pushcfunction(L, &smvlib_index);
+  lua_pushcfunction(L, &SmvlibIndex);
   lua_setfield(L, -2, "__index");
   // then set the metatable
   lua_setmetatable(L, -2);
@@ -5601,13 +5620,13 @@ lua_State *initLua() {
   return L;
 }
 
-int runScriptString(const char *string) { return luaL_dostring(L, string); }
+int RunScriptString(const char *string) { return luaL_dostring(L, string); }
 
-int loadLuaScript(const char *filename) {
+int LoadLuaScript(const char *filename) {
   // The display callback needs to be run once initially.
   // PROBLEM: the display CB does not work without a loaded case.
   runluascript = 0;
-  lua_displayCB(L);
+  LuaDisplayCb(L);
   runluascript = 1;
   char cwd[1000];
 #if defined(_WIN32)
@@ -5654,7 +5673,7 @@ int loadLuaScript(const char *filename) {
   return return_code;
 }
 
-int loadSSFScript(const char *filename) {
+int LoadSsfScript(const char *filename) {
   // char filename[1024];
   //   if (strlen(script_filename) == 0) {
   //       strncpy(filename, fdsprefix, 1020);
@@ -5665,19 +5684,19 @@ int loadSSFScript(const char *filename) {
   // The display callback needs to be run once initially.
   // PROBLEM: the display CB does not work without a loaded case.
   runscript = 0;
-  lua_displayCB(L);
+  LuaDisplayCb(L);
   runscript = 1;
   const char *err_msg;
   lua_Debug info;
   int level = 0;
-  char lString[1024];
-  snprintf(lString, 1024, "require(\"ssfparser\")\nrunSSF(\"%s.ssf\")",
+  char l_string[1024];
+  snprintf(l_string, 1024, "require(\"ssfparser\")\nrunSSF(\"%s.ssf\")",
            fdsprefix);
   int ssfparser_loaded_err = luaL_dostring(L, "require \"ssfparser\"");
   if (ssfparser_loaded_err) {
     fprintf(stderr, "Failed to load ssfparser\n");
   }
-  int return_code = luaL_loadstring(L, lString);
+  int return_code = luaL_loadstring(L, l_string);
   switch (return_code) {
   case LUA_OK:
     break;
@@ -5713,22 +5732,24 @@ int loadSSFScript(const char *filename) {
   return 0;
 }
 
-int yieldOrOkSSF = LUA_YIELD;
-int runSSFScript() {
-  if (yieldOrOkSSF == LUA_YIELD) {
+int yield_or_ok_ssf = LUA_YIELD;
+int RunSsfScript() {
+  if (yield_or_ok_ssf == LUA_YIELD) {
     int nresults = 0;
 #if LUA_VERSION_NUM < 502
-    yieldOrOkSSF = lua_resume(L, 0);
+    yield_or_ok_ssf = lua_resume(L, 0);
 #elif LUA_VERSION_NUM < 504
-    yieldOrOkSSF = lua_resume(L, NULL, 0);
+    yield_or_ok_ssf = lua_resume(L, NULL, 0);
 #else
-    yieldOrOkSSF = lua_resume(L, NULL, 0, &nresults);
+    yield_or_ok_ssf = lua_resume(L, NULL, 0, &nresults);
 #endif
-    if (yieldOrOkSSF == LUA_YIELD) {
+    if (yield_or_ok_ssf == LUA_YIELD) {
       printf("  LUA_YIELD\n");
-    } else if (yieldOrOkSSF == LUA_OK) {
+    }
+    else if (yield_or_ok_ssf == LUA_OK) {
       printf("  LUA_OK\n");
-    } else if (yieldOrOkSSF == LUA_ERRRUN) {
+    }
+    else if (yield_or_ok_ssf == LUA_ERRRUN) {
       printf("  LUA_ERRRUN\n");
       const char *err_msg;
       err_msg = lua_tostring(L, -1);
@@ -5742,34 +5763,39 @@ int runSSFScript() {
                 info.what);
         ++level;
       };
-    } else if (yieldOrOkSSF == LUA_ERRMEM) {
-      printf("  LUA_ERRMEM\n");
-    } else {
-      printf("  resume code: %i\n", yieldOrOkSSF);
     }
-  } else {
+    else if (yield_or_ok_ssf == LUA_ERRMEM) {
+      printf("  LUA_ERRMEM\n");
+    }
+    else {
+      printf("  resume code: %i\n", yield_or_ok_ssf);
+    }
+  }
+  else {
     lua_close(L);
     glutIdleFunc(NULL);
   }
-  return yieldOrOkSSF;
+  return yield_or_ok_ssf;
 }
 
-int yieldOrOk = LUA_YIELD;
-int runLuaScript() {
-  if (yieldOrOk == LUA_YIELD) {
+int yield_or_ok = LUA_YIELD;
+int RunLuaScript() {
+  if (yield_or_ok == LUA_YIELD) {
     int nresults = 0;
 #if LUA_VERSION_NUM < 502
-    yieldOrOk = lua_resume(L, 0);
+    yield_or_ok_ssf = lua_resume(L, 0);
 #elif LUA_VERSION_NUM < 504
-    yieldOrOk = lua_resume(L, NULL, 0);
+    yield_or_ok_ssf = lua_resume(L, NULL, 0);
 #else
-    yieldOrOk = lua_resume(L, NULL, 0, &nresults);
+    yield_or_ok = lua_resume(L, NULL, 0, &nresults);
 #endif
-    if (yieldOrOk == LUA_YIELD) {
+    if (yield_or_ok == LUA_YIELD) {
       printf("  LUA_YIELD\n");
-    } else if (yieldOrOk == LUA_OK) {
+    }
+    else if (yield_or_ok == LUA_OK) {
       printf("  LUA_OK\n");
-    } else if (yieldOrOk == LUA_ERRRUN) {
+    }
+    else if (yield_or_ok == LUA_ERRRUN) {
       printf("  LUA_ERRRUN\n");
       const char *err_msg;
       err_msg = lua_tostring(L, -1);
@@ -5783,17 +5809,20 @@ int runLuaScript() {
                 info.what);
         ++level;
       };
-    } else if (yieldOrOk == LUA_ERRMEM) {
-      printf("  LUA_ERRMEM\n");
-    } else {
-      printf("  resume code: %i\n", yieldOrOk);
     }
-  } else {
+    else if (yield_or_ok == LUA_ERRMEM) {
+      printf("  LUA_ERRMEM\n");
+    }
+    else {
+      printf("  resume code: %i\n", yield_or_ok);
+    }
+  }
+  else {
     lua_close(L);
     glutIdleFunc(NULL);
   }
   GLUTPOSTREDISPLAY;
-  return yieldOrOk;
+  return yield_or_ok;
 }
 #if LUA_VERSION_NUM < 502
 LUA_API lua_Number lua_version(lua_State *L) {

--- a/Source/smokeview/lua_api.h
+++ b/Source/smokeview/lua_api.h
@@ -1,23 +1,23 @@
 #include "lua.h"
 
-int lua_render(lua_State *L);
-lua_State *initLua();
+int LuaRender(lua_State *L);
+lua_State *InitLua();
 int RunLuaBranch(lua_State *L, int argc, char **argv);
 
-int lua_initsmvproginfo(lua_State *L);
-int lua_initsmvdata(lua_State *L);
-void addLuaPaths(lua_State *L);
+int LuaInitsmvproginfo(lua_State *L);
+int LuaInitsmvdata(lua_State *L);
+void AddLuaPaths(lua_State *L);
 
-int load_script(const char *filename);
-int loadLuaScript(const char *filename);
-int runLuaScript();
-int loadSSFScript(const char *filename);
-int runSSFScript();
+int LoadScript(const char *filename);
+int LoadLuaScript(const char *filename);
+int RunLuaScript();
+int LoadSsfScript(const char *filename);
+int RunSsfScript();
 
-int runScriptString(const char *string);
-int lua_get_sliceinfo(lua_State *L);
-int lua_get_csvinfo(lua_State *L);
-int lua_initsmvdata(lua_State *L);
+int RunScriptString(const char *string);
+int LuaGetSliceinfo(lua_State *L);
+int LuaGetCsvinfo(lua_State *L);
+int LuaInitsmvdata(lua_State *L);
 #if LUA_VERSION_NUM < 502
 /* macro to avoid warnings about unused variables */
 #if !defined(UNUSED)

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -748,7 +748,7 @@ int main(int argc, char **argv){
 #ifdef pp_LUA
   // If we are using lua, let lua take control here.
   // Initialise the lua interpreter, it does not take control at this point
-  lua_State *L = initLua();
+  lua_State *L = InitLua();
   // This code branch gives more control to the interpreter during startup.
   return_code = RunLuaBranch(L, argc, argv);
   // All of the below code is run by the lua interpreter, therefore if we want


### PR DESCRIPTION
This makes fairly extensive formatting changes to match the style set out in .clang-tidy and .clang-format