### PR TITLE
ci: fetch thouse5 from fig and run render tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           echo "CC=gcc-11" >> $GITHUB_ENV
           echo "CXX=g++-11" >> $GITHUB_ENV
+          brew install glew lua gd zlib
       # If we are building on linux configure the environment to use gcc as the
       # compiler
       - name: set linux gcc
@@ -66,6 +67,14 @@ jobs:
         run: |
           echo "CC=gcc" >> $GITHUB_ENV
           echo "CXX=g++" >> $GITHUB_ENV
+      # Download a snaphot of the fig repo and use that as test data.
+      - name: Download test data
+        working-directory: ${{github.workspace}}/Tests
+        run: ./get_test_data.sh
+      # Remove Visualization data on macos as we can't render currently.
+      - name: Download test data
+        if: runner.os == 'macOS'
+        run: rm -rf Verification/Visualization/*.smv
       # Run cmake to build smokeview
       - name: Build
         shell: bash
@@ -73,16 +82,18 @@ jobs:
           cmake -B ${{github.workspace}}/cbuild -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DLUA=${{ matrix.lua }}
           cmake --build ${{github.workspace}}/cbuild -j4
           cp ${{github.workspace}}/cbuild/smokeview smokeview
-      # Download a snaphot of the fig repo and use that as test data.
-      - name: Download test data
-        working-directory: ${{github.workspace}}/Tests
-        run: ./get_test_data.sh
-      # Run the CMake-based tests
+      # Run the CMake-based tests on MacOS
       - name: Test
+        if: runner.os == 'macOS'
         shell: bash
-        working-directory: ${{github.workspace}}/cbuild
         run: |
-          ctest -j10 --output-on-failure -V
+          ctest --test-dir cbuild -j10 --output-on-failure -V
+      # Run the CMake-based tests on Linux
+      - name: Test
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          xvfb-run ctest --test-dir cbuild -j10 --output-on-failure -V
       # Set a suffix based on whether lua is included
       - name: Set exec suffix
         if: ${{ matrix.lua }}

--- a/Tests/get_test_data.ps1
+++ b/Tests/get_test_data.ps1
@@ -1,9 +1,9 @@
-$commit = "97c852beff8c6142ec09dc0092381a605d08d943"
+$commit = "67300634bc63eb9a6959abf6623b4922ff7b1e34"
 
 $zip_path = "$env:temp\test-data.zip"
 $unzip_path = "$env:temp\test-data-out"
-Invoke-WebRequest -Uri https://github.com/firemodels/fig/archive/$commit.zip -OutFile $zip_path
+Invoke-WebRequest -Uri https://github.com/JakeOShannessy/fig/archive/$commit.zip -OutFile $zip_path
 Expand-Archive $zip_path -DestinationPath $unzip_path -Force
 mkdir fig -Force
 Move-Item $unzip_path/fig-$commit/* fig -Force
-
+Copy-Item -Force -Recurse fig/smv/Tests/Visualization ../Verification

--- a/Tests/get_test_data.ps1
+++ b/Tests/get_test_data.ps1
@@ -1,8 +1,8 @@
-$commit = "67300634bc63eb9a6959abf6623b4922ff7b1e34"
+$commit = "bf2446b600b4062196923a74cd2cf67c3b7be76d"
 
 $zip_path = "$env:temp\test-data.zip"
 $unzip_path = "$env:temp\test-data-out"
-Invoke-WebRequest -Uri https://github.com/JakeOShannessy/fig/archive/$commit.zip -OutFile $zip_path
+Invoke-WebRequest -Uri https://github.com/firemodels/fig/archive/$commit.zip -OutFile $zip_path
 Expand-Archive $zip_path -DestinationPath $unzip_path -Force
 mkdir fig -Force
 Move-Item $unzip_path/fig-$commit/* fig -Force

--- a/Tests/get_test_data.sh
+++ b/Tests/get_test_data.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-COMMIT=67300634bc63eb9a6959abf6623b4922ff7b1e34
+COMMIT=bf2446b600b4062196923a74cd2cf67c3b7be76d
 
 TEMP_DIR=$(mktemp -d)
 ZIP_PATH=$TEMP_DIR/test-data.zip
-wget --tries=5 https://github.com/JakeOShannessy/fig/archive/$COMMIT.zip -O "$ZIP_PATH"
+wget --tries=5 https://github.com/firemodels/fig/archive/$COMMIT.zip -O "$ZIP_PATH"
 unzip "$ZIP_PATH"
 rm -rf fig
 mkdir -p fig

--- a/Tests/get_test_data.sh
+++ b/Tests/get_test_data.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
-COMMIT=97c852beff8c6142ec09dc0092381a605d08d943
+COMMIT=67300634bc63eb9a6959abf6623b4922ff7b1e34
 
 TEMP_DIR=$(mktemp -d)
 ZIP_PATH=$TEMP_DIR/test-data.zip
-wget --tries=5 https://github.com/firemodels/fig/archive/$COMMIT.zip -O "$ZIP_PATH"
+wget --tries=5 https://github.com/JakeOShannessy/fig/archive/$COMMIT.zip -O "$ZIP_PATH"
 unzip "$ZIP_PATH"
+rm -rf fig
 mkdir -p fig
-mv fig-$COMMIT/* fig
+mv -f fig-$COMMIT/* fig
+cp -rf fig/smv/Tests/Visualization ../Verification

--- a/Verification/Visualization/thouse5.fds
+++ b/Verification/Visualization/thouse5.fds
@@ -5,8 +5,8 @@ MULT ID='mesh', DX=3.2, DY=4.0, DZ=2.4, I_UPPER=1, J_UPPER=1, K_UPPER=1 /
 &MESH IJK=24,20,24, XB=0.0,6.4,0.0,4.0,0.0,4.8 /
 &MESH IJK=24,20,24, XB=0.0,6.4,4.0,8.0,0.0,4.8 /
 
-&TIME T_END=61. /
-&DUMP NFRAMES=610 DT_PL3D=12.2, DT_SL3D=0.1/
+&TIME T_END=60. /
+&DUMP NFRAMES=2 DT_PL3D=12.2 /
 
 &SURF ID='BURNER', HRRPUA=3000., PART_ID='smoke' /
 &REAC CO_YIELD=0.5,SOOT_YIELD=0.01,FUEL='PROPANE'/
@@ -97,7 +97,7 @@ Reaction 3: "ACTIVE" solid is converted FUEL gases
       NU_SPEC(1,1:2)        = 0.65,    1.0
       SPEC_ID(1,1:2)        = 'PROPANE',  'PROPANE'
       NU_MATL               = 0.35
-      MATL_ID               = 'CHAR' /  
+      MATL_ID               = 'CHAR' /
 
 Water evaporation from original wood
 

--- a/Verification/Visualization/thouse5.fds
+++ b/Verification/Visualization/thouse5.fds
@@ -5,8 +5,8 @@ MULT ID='mesh', DX=3.2, DY=4.0, DZ=2.4, I_UPPER=1, J_UPPER=1, K_UPPER=1 /
 &MESH IJK=24,20,24, XB=0.0,6.4,0.0,4.0,0.0,4.8 /
 &MESH IJK=24,20,24, XB=0.0,6.4,4.0,8.0,0.0,4.8 /
 
-&TIME T_END=60. /
-&DUMP NFRAMES=2 DT_PL3D=12.2 /
+&TIME T_END=61. /
+&DUMP NFRAMES=610 DT_PL3D=12.2, DT_SL3D=0.1/
 
 &SURF ID='BURNER', HRRPUA=3000., PART_ID='smoke' /
 &REAC CO_YIELD=0.5,SOOT_YIELD=0.01,FUEL='PROPANE'/
@@ -97,7 +97,7 @@ Reaction 3: "ACTIVE" solid is converted FUEL gases
       NU_SPEC(1,1:2)        = 0.65,    1.0
       SPEC_ID(1,1:2)        = 'PROPANE',  'PROPANE'
       NU_MATL               = 0.35
-      MATL_ID               = 'CHAR' /
+      MATL_ID               = 'CHAR' /  
 
 Water evaporation from original wood
 


### PR DESCRIPTION
This fetches a completed FDS run from the fig repo (thouse5) and runs the SSF scripts for it on Github Actions.

Currently it fetches data from a fork of fig, but will be pointed toward firemodels/fig if the PR (https://github.com/firemodels/fig/pull/145) in that repo is merged.

This depends on #1732.