### PR TITLE
Move SMV_EXIT and StartTimer from main.c

### DIFF
--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -879,18 +879,3 @@ int main(int argc, char **argv){
   glutMainLoop();
   return 0;
 }
-
-/* ------------------ SMV_EXIT ------------------------ */
-
-void SMV_EXIT(int code){
-  exit(code);
-}
-
-/* ------------------ StartTimer ------------------------ */
-
-void StartTimer(float *timerptr){
-  float timer;
-
-  START_TIMER(timer);
-  *timerptr = timer;
-}

--- a/Source/smokeview/smokeview.c
+++ b/Source/smokeview/smokeview.c
@@ -236,3 +236,17 @@ void DisplayVersionInfo(char *progname){
   }
 }
 
+/* ------------------ SMV_EXIT ------------------------ */
+
+void SMV_EXIT(int code){
+  exit(code);
+}
+
+/* ------------------ StartTimer ------------------------ */
+
+void StartTimer(float *timerptr){
+  float timer;
+
+  START_TIMER(timer);
+  *timerptr = timer;
+}


### PR DESCRIPTION
Many files depend on `smokeview/`main.c as that is where `SMV_EXIT` is defined. Any file which depends on main.c cannot be used anywhere else. With this commit, no other files depend on `smokeview/main.c`.

This is done with the intention of being able to share `ReadSMV` et al. with other programs.