### PR TITLE
lint: disable linting hash libs

### DIFF
--- a/Source/shared/md5.c
+++ b/Source/shared/md5.c
@@ -1,3 +1,4 @@
+// NOLINTBEGIN
 #include "options.h"
 #ifdef pp_HASH
 /*
@@ -405,3 +406,4 @@ int mbedtls_md5_self_test( int verbose )
 
 #endif /* MBEDTLS_MD5_C */
 #endif /* pp_HASH */
+// NOLINTEND

--- a/Source/shared/sha1.c
+++ b/Source/shared/sha1.c
@@ -1,3 +1,4 @@
+// NOLINTBEGIN
 #include "options.h"
 #ifdef pp_HASH
 /*
@@ -449,3 +450,4 @@ exit:
 
 #endif /* MBEDTLS_SHA1_C */
 #endif /* pp_HASH*/
+// NOLINTEND

--- a/Source/shared/sha256.c
+++ b/Source/shared/sha256.c
@@ -1,3 +1,4 @@
+// NOLINTBEGIN
 #include "options.h"
 #ifdef pp_HASH
 /*
@@ -459,3 +460,4 @@ exit:
 
 #endif /* MBEDTLS_SHA256_C */
 #endif /* pp_HASH */
+// NOLINTEND


### PR DESCRIPTION
Very minor change. These files are code for hashing taken from mbedtls, so we probably don't want to be changing them unnecessarily.

This PR just adds comments to that clang-tidy doesn't lint them.