### PR TITLE
Add parse_smv_benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ if (SMOKEVIEW_OBJECT_DEFS_PATH)
 endif()
 
 if (LUA)
-    add_definitions(-Dpp_LUA)
+    target_compile_definitions(smokeview PRIVATE pp_LUA)
     find_package(Lua)
     if (LUA_FOUND)
         target_link_libraries(smokeview PRIVATE ${LUA_LIBRARIES})
@@ -711,4 +711,165 @@ file(DOWNLOAD "https://raw.githubusercontent.com/firemodels/bot/a0a9d710f7a55b4e
 list(GET smokeview_ini_status 0 smokeview_ini_status_code)
 if (smokeview_ini_status_code)
     message(FATAL_ERROR "Could not download smokeview.ini ${smokeview_ini_status_code}")
+endif()
+
+# parse_smv_benchmark
+add_executable(parse_smv_benchmark Tests/parse_smv_benchmark.c
+    Source/shared/getdata.c
+    Source/shared/dmalloc.c
+    Source/smokeview/menus.c
+    Source/smokeview/IOscript.c
+    Source/smokeview/IOshooter.c
+    Source/shared/csphere.c
+    Source/smokeview/colortimebar.c
+    Source/smokeview/camera.c
+    Source/smokeview/IOgeometry.c
+    Source/smokeview/IOwui.c
+    Source/smokeview/IOobjects.c
+    Source/smokeview/IOtour.c
+    Source/smokeview/getdatacolors.c
+    Source/smokeview/smokeview.c
+    Source/smokeview/output.c
+    Source/smokeview/renderimage.c
+    Source/smokeview/renderhtml.c
+    Source/shared/isobox.c
+    Source/smokeview/getdatabounds.c
+    Source/smokeview/readsmv.c
+    Source/smokeview/scontour2d.c
+    Source/shared/dmalloc.c
+    Source/shared/compress.c
+    Source/smokeview/IOvolsmoke.c
+    Source/smokeview/IOsmoke.c
+    Source/smokeview/IOplot3d.c
+    Source/smokeview/IOplot2d.c
+    Source/smokeview/IOslice.c
+    Source/smokeview/IOhvac.c
+    Source/smokeview/IOboundary.c
+    Source/smokeview/IOpart.c
+    Source/smokeview/IOzone.c
+    Source/smokeview/IOiso.c
+    Source/smokeview/callbacks.c
+    Source/smokeview/drawGeometry.c
+    Source/smokeview/skybox.c
+    Source/shared/file_util.c
+    Source/shared/string_util.c
+    Source/smokeview/startup.c
+    Source/smokeview/shaders.c
+    Source/smokeview/unit.c
+    Source/smokeview/threader.c
+    Source/shared/histogram.c
+    Source/shared/translate.c
+    Source/smokeview/update.c
+    Source/smokeview/viewports.c
+    Source/smokeview/smv_geometry.c
+    Source/smokeview/showscene.c
+    Source/smokeview/infoheader.c
+    Source/shared/md5.c
+    Source/shared/sha1.c
+    Source/shared/sha256.c
+    Source/shared/stdio_m.c
+    Source/shared/stdio_buffer.c
+    Source/shared/getdata.c
+    Source/shared/color2rgb.c
+    Source/smokeview/colortable.c
+    Source/smokeview/command_args.c
+
+    Source/smokeview/glui_smoke.cpp
+    Source/smokeview/glui_clip.cpp
+    Source/smokeview/glui_stereo.cpp
+    Source/smokeview/glui_geometry.cpp
+    Source/smokeview/glui_motion.cpp
+    Source/smokeview/glui_bounds.cpp
+    Source/smokeview/glui_colorbar.cpp
+    Source/smokeview/glui_display.cpp
+    Source/smokeview/glui_tour.cpp
+    Source/smokeview/glui_trainer.cpp
+    Source/smokeview/glui_objects.cpp
+    Source/smokeview/glui_shooter.cpp
+)
+
+target_include_directories(parse_smv_benchmark PRIVATE
+    Source/shared
+    Source/glew
+    Source/smokeview
+    Source/glui_v2_1_beta
+    Source/glui_gl
+)
+
+
+# These include directories are an existing workaround that would be good to
+# remove.Because of this custom code and the potential conflict with native libs
+# this needs to be early in the include order.
+if (WIN32)
+    target_include_directories(parse_smv_benchmark PRIVATE Source/glut_gl)
+else()
+    target_include_directories(parse_smv_benchmark PRIVATE Source/glui_gl)
+endif ()
+# GLUI can be provided natively, but there are modifications in the code
+# vendored with Smokeview that we rely on. Because of this custom code and the
+# potential conflict with native libs this needs to be early in the include order.
+target_link_libraries(parse_smv_benchmark PRIVATE glui_static)
+target_include_directories(parse_smv_benchmark PRIVATE Source/glui_v2_1_beta)
+if(WIN32)
+    if (PThreads4W_FOUND)
+        target_link_libraries(parse_smv_benchmark PRIVATE PThreads4W::PThreads4W)
+    else()
+        target_include_directories(parse_smv_benchmark PRIVATE Source/pthreads)
+        target_link_libraries(parse_smv_benchmark PRIVATE pthread_static)
+    endif()
+endif()
+# Selecting which GLUT version to use is the most platform-dependent part of the
+# build.
+if (MACOSX)
+    add_definitions(-Dpp_NOQUARTZ)
+    target_link_libraries(parse_smv_benchmark PRIVATE "-framework OpenGL" "-framework GLUT")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+elseif (GLUT_FOUND)
+    target_link_libraries(parse_smv_benchmark PRIVATE GLUT::GLUT)
+else()
+    target_link_libraries(parse_smv_benchmark PRIVATE glut32_static)
+endif ()
+if (GLEW_FOUND)
+    target_link_libraries(parse_smv_benchmark PRIVATE GLEW::GLEW)
+    # This line is a hack to work around the fact the code includes "glew.h"
+    # rather than <GL/glew.h>
+    target_include_directories(parse_smv_benchmark PRIVATE ${GLEW_INCLUDE_DIRS}/GL)
+else()
+    target_sources(parse_smv_benchmark PRIVATE
+        Source/glew/glew.c
+    )
+    target_include_directories(parse_smv_benchmark PRIVATE Source/glew)
+endif()
+if (JPEG_FOUND)
+    target_link_libraries(parse_smv_benchmark PRIVATE JPEG::JPEG)
+else()
+    target_link_libraries(parse_smv_benchmark PRIVATE jpeg_static)
+endif()
+if (PNG_FOUND)
+    target_link_libraries(parse_smv_benchmark PRIVATE PNG::PNG)
+else()
+    target_link_libraries(parse_smv_benchmark PRIVATE png_static)
+endif()
+if (ZLIB_FOUND)
+    target_link_libraries(parse_smv_benchmark PRIVATE ZLIB::ZLIB)
+else()
+    target_link_libraries(parse_smv_benchmark PRIVATE zlib_static)
+endif()
+if (LIBGD_FOUND)
+    target_link_libraries(parse_smv_benchmark PRIVATE PkgConfig::LIBGD)
+else()
+    target_link_libraries(parse_smv_benchmark PRIVATE gd_static)
+endif()
+target_link_libraries(parse_smv_benchmark PRIVATE OpenGL::GL OpenGL::GLU)
+
+
+if (WIN32)
+    target_include_directories(parse_smv_benchmark PRIVATE Source/pthreads)
+endif()
+if ((NOT MACOSX) AND UNIX)
+    target_link_libraries(parse_smv_benchmark PRIVATE m)
+endif()
+if (LINUX)
+    add_definitions(-Dpp_LINUX)
+    target_link_libraries(parse_smv_benchmark PRIVATE pthread X11 Xmu GLU GL m stdc++)
 endif()

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -847,6 +847,7 @@ int main(int argc, char **argv){
   InitScriptErrorFiles();
   smokezippath= GetSmokeZipPath(smokeview_bindir);
   DisplayVersionInfo("Smokeview ");
+  InitStartupDirs();
   SetupGlut(argc,argv);
   START_TIMER(startup_time);
 

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -463,8 +463,6 @@ void SetupGlut(int argc, char **argv){
   char workingdir[1000];
 #endif
 
-  InitStartupDirs();
-
 #ifdef pp_OSX
   getcwd(workingdir, 1000);
 #endif

--- a/Tests/.gitignore
+++ b/Tests/.gitignore
@@ -1,1 +1,3 @@
 fig/
+test_model_small/
+test_model_large/

--- a/Tests/options.h
+++ b/Tests/options.h
@@ -1,18 +1,113 @@
 #ifndef OPTIONS_H_DEFINED
 #define OPTIONS_H_DEFINED
 
+
 #include "options_common.h"
 
-//*** uncomment the following two lines to force all versions to be beta
-//#undef pp_BETA
-//#define pp_BETA
-
-//*** define smokediff title
+//*** define smokeview title
 
 #ifdef pp_BETA
-  #define PROGVERSION "Test"
-#else
-  #define PROGVERSION "1.0.11"
+#define pp_DEBUG_SUBMENU       // debug output and testing for building menus
 #endif
+
+//*** parallel file loading
+#define pp_SLICE_MULTI    // load slice files in parallel
+#define pp_PART_MULTI     // load particle files in parallel
+#define pp_CSV_MULTI      // read in csv files in parallel
+
+#define pp_PATCH_HIST     // simplify boundary file histogram computation
+//#define pp_HIST           // compute histograms
+
+#define pp_SMOKE_SKIP     // add option to skip smoke frames
+//#define pp_SMOKE16      // load 16 bit smoke files
+//#define pp_VOLSMOKE     // add option to compress volume rendered data
+//#define pp_GAMMA        // show gamma correction checkbox
+#define pp_BLACKBODY      // use blackbody theory for generating fire colors
+// pp_BLACKBODY_OUT       // output generated blackbody color data
+//#define pp_BOUND_HIST_ON // turn on boundary file histograms
+//#define pp_DECIMATE     // decimate terrain geometry
+
+#define pp_FAST           // set fast startup by default
+#define pp_FED_COMPRESS   // skip fed slices when co, o2 or co2 slices are compressed (for now)
+
+#define pp_COLOR_PLOT     /  add checkbox for showing CIELab colorbar delta distance plot
+
+//#define pp_BNDF         // merge geometry and structured boundary files in load menus
+
+//#define pp_DPRINT       // turn on debug print (file, line number)
+
+// streaming directives
+
+//#define pp_SMOKE3DSTREAM      // stream smoke3d data
+//#define pp_PARTSTREAM         // stream particle data
+
+// turn on pp_STREAM if streaming is on for any file type
+
+#ifdef pp_SMOKE3DSTREAM
+#define pp_STREAM
+#endif
+#ifdef pp_PARTSTREAM
+#undef pp_STREAM
+#define pp_STREAM
+#endif
+
+#define pp_READBUFFER_THREAD // use pthreads in ReadBuffer routine (don't use pthreads when used in smokezip and smokediff)
+//#define pp_CRASH_TEST       // test detection of division by zero or use of undefined pointer
+#define pp_GPU                // support the GPU
+// #define pp_THREAD             // turn on multi-threading
+//#define pp_LOAD_NEWDATA     // add button for loading new data
+
+#ifdef pp_GPU
+#define pp_GPUTHROTTLE  // pp_GPU directive must also be set
+#endif
+
+//*** options: windows
+
+#ifdef WIN32
+#define pp_memstatus
+#define pp_COMPRESS         // support for smokezip
+#define pp_DIALOG_SHORTCUTS // dialog shortcuts
+#ifdef pp_GPU
+#define pp_WINGPU           // only draw 3d slices with the GPU on windows
+#endif
+#endif
+
+
+//*** options: Linux
+
+#ifdef pp_LINUX
+#define pp_REFRESH          // refresh glui dialogs when they change size
+#define pp_DIALOG_SHORTCUTS // dialog shortcuts
+#endif
+
+//*** options: Mac
+
+#ifdef pp_OSX
+#ifndef pp_NOQUARTZ     // if used, passed in from the command line so we don'thave to change source
+#define pp_QUARTZ       // use Quartz
+#endif
+#endif
+
+#ifdef pp_QUARTZ
+#define pp_CLOSEOFF     // turn off and disable close buttons in dialog box
+#endif
+
+#undef pp_OSX_HIGHRES
+#ifdef pp_OSX
+#ifndef pp_QUARTZ
+#define pp_REFRESH      // refresh glui dialogs when they change size
+#ifndef pp_OSX_LOWRES
+#define pp_OSX_HIGHRES
+#endif
+#endif
+#endif
+
+//*** options: for debugging
+
+#ifdef _DEBUG
+#define pp_MOVIE_BATCH_DEBUG // allow movei batch dialogs to be defined for testing
+#define pp_SNIFF_ERROR
+#endif
+#define pp_RENDER360_DEBUG
 
 #endif

--- a/Tests/parse_smv_benchmark.c
+++ b/Tests/parse_smv_benchmark.c
@@ -1,0 +1,232 @@
+#define INMAIN
+#include "options.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include GLUT_H
+
+#include "MALLOCC.h"
+#include "command_args.h"
+#include "smokeviewvars.h"
+#include "string_util.h"
+
+#ifndef _WIN32
+#include <libgen.h>
+#endif
+
+/// @brief Given a file path, get the filename excluding the final extension.
+/// This allocates a new copy which can be deallocated with free().
+/// @param input_file a file path
+/// @return an allocated string containing the basename or NULL on failure.
+char *GetBaseName(const char *input_file) {
+  if (input_file == NULL) return NULL;
+#ifdef _WIN32
+  char *result = malloc(_MAX_FNAME + 1);
+  errno_t err =
+      _splitpath_s(input_file, NULL, 0, NULL, 0, result, _MAX_FNAME, NULL, 0);
+  if (err) return NULL;
+#else
+  // POSIX basename can modify it's contents, so we'll make some copies.
+  char *input_file_temp = strdup(input_file);
+  // Get the filename (final component of the path, including any extensions).
+  char *bname = basename(input_file_temp);
+  // If a '.' exists, set it to '\0' to trim the extension.
+  char *dot = strrchr(bname, '.');
+  if (dot) *dot = '\0';
+  char *result = strdup(bname);
+  free(input_file_temp);
+#endif
+  return result;
+}
+
+int SetGlobalFilenames(const char *fdsprefix) {
+  int len_casename = strlen(fdsprefix);
+  strcpy(movie_name, fdsprefix);
+  strcpy(render_file_base, fdsprefix);
+  strcpy(html_file_base, fdsprefix);
+
+  FREEMEMORY(log_filename);
+  NewMemory((void **)&log_filename, len_casename + strlen(".smvlog") + 1);
+  STRCPY(log_filename, fdsprefix);
+  STRCAT(log_filename, ".smvlog");
+
+  FREEMEMORY(caseini_filename);
+  NewMemory((void **)&caseini_filename, len_casename + strlen(".ini") + 1);
+  STRCPY(caseini_filename, fdsprefix);
+  STRCAT(caseini_filename, ".ini");
+
+  FREEMEMORY(expcsv_filename);
+  NewMemory((void **)&expcsv_filename, len_casename + strlen("_exp.csv") + 1);
+  STRCPY(expcsv_filename, fdsprefix);
+  STRCAT(expcsv_filename, "_exp.csv");
+
+  FREEMEMORY(dEcsv_filename);
+  NewMemory((void **)&dEcsv_filename, len_casename + strlen("_dE.csv") + 1);
+  STRCPY(dEcsv_filename, fdsprefix);
+  STRCAT(dEcsv_filename, "_dE.csv");
+
+  FREEMEMORY(html_filename);
+  NewMemory((void **)&html_filename, len_casename + strlen(".html") + 1);
+  STRCPY(html_filename, fdsprefix);
+  STRCAT(html_filename, ".html");
+
+  FREEMEMORY(smv_orig_filename);
+  NewMemory((void **)&smv_orig_filename, len_casename + strlen(".smo") + 1);
+  STRCPY(smv_orig_filename, fdsprefix);
+  STRCAT(smv_orig_filename, ".smo");
+
+  FREEMEMORY(hrr_filename);
+  NewMemory((void **)&hrr_filename, len_casename + strlen("_hrr.csv") + 1);
+  STRCPY(hrr_filename, fdsprefix);
+  STRCAT(hrr_filename, "_hrr.csv");
+
+  FREEMEMORY(htmlvr_filename);
+  NewMemory((void **)&htmlvr_filename, len_casename + strlen("_vr.html") + 1);
+  STRCPY(htmlvr_filename, fdsprefix);
+  STRCAT(htmlvr_filename, "_vr.html");
+
+  FREEMEMORY(htmlobst_filename);
+  NewMemory((void **)&htmlobst_filename,
+            len_casename + strlen("_obst.json") + 1);
+  STRCPY(htmlobst_filename, fdsprefix);
+  STRCAT(htmlobst_filename, "_obst.json");
+
+  FREEMEMORY(htmlslicenode_filename);
+  NewMemory((void **)&htmlslicenode_filename,
+            len_casename + strlen("_slicenode.json") + 1);
+  STRCPY(htmlslicenode_filename, fdsprefix);
+  STRCAT(htmlslicenode_filename, "_slicenode.json");
+
+  FREEMEMORY(htmlslicecell_filename);
+  NewMemory((void **)&htmlslicecell_filename,
+            len_casename + strlen("_slicecell.json") + 1);
+  STRCPY(htmlslicecell_filename, fdsprefix);
+  STRCAT(htmlslicecell_filename, "_slicecell.json");
+
+  FREEMEMORY(event_filename);
+  NewMemory((void **)&event_filename, len_casename + strlen("_events.csv") + 1);
+  STRCPY(event_filename, fdsprefix);
+  STRCAT(event_filename, "_events.csv");
+
+  if (ffmpeg_command_filename == NULL) {
+    NewMemory((void **)&ffmpeg_command_filename,
+              (unsigned int)(len_casename + 12));
+    STRCPY(ffmpeg_command_filename, fdsprefix);
+    STRCAT(ffmpeg_command_filename, "_ffmpeg");
+#ifdef WIN32
+    STRCAT(ffmpeg_command_filename, ".bat");
+#else
+    STRCAT(ffmpeg_command_filename, ".sh");
+#endif
+  }
+  if (fed_filename == NULL) {
+    STRCPY(fed_filename_base, fdsprefix);
+    STRCAT(fed_filename_base, ".fed_smv");
+    fed_filename =
+        GetFileName(smokeview_scratchdir, fed_filename_base, NOT_FORCE_IN_DIR);
+  }
+  if (stop_filename == NULL) {
+    NewMemory((void **)&stop_filename,
+              (unsigned int)(len_casename + strlen(".stop") + 1));
+    STRCPY(stop_filename, fdsprefix);
+    STRCAT(stop_filename, ".stop");
+  }
+  if (smvzip_filename == NULL) {
+    NewMemory((void **)&smvzip_filename,
+              (unsigned int)(len_casename + strlen(".smvzip") + 1));
+    STRCPY(smvzip_filename, fdsprefix);
+    STRCAT(smvzip_filename, ".smvzip");
+  }
+  if (sliceinfo_filename == NULL) {
+    NewMemory((void **)&sliceinfo_filename,
+              strlen(fdsprefix) + strlen(".sinfo") + 1);
+    STRCPY(sliceinfo_filename, fdsprefix);
+    STRCAT(sliceinfo_filename, ".sinfo");
+  }
+  if (deviceinfo_filename == NULL) {
+    NewMemory((void **)&deviceinfo_filename,
+              strlen(fdsprefix) + strlen("_device.info") + 1);
+    STRCPY(deviceinfo_filename, fdsprefix);
+    STRCAT(deviceinfo_filename, "_device.info");
+  }
+
+  // if smokezip created part2iso files then concatenate .smv entries found in
+  // the .isosmv file to the end of the .smv file creating a new .smv file. Then
+  // read in that .smv file.
+
+  {
+    FILE *stream_iso = NULL;
+
+    NewMemory((void **)&iso_filename, len_casename + strlen(".isosmv") + 1);
+    STRCPY(iso_filename, fdsprefix);
+    STRCAT(iso_filename, ".isosmv");
+    stream_iso = fopen(iso_filename, "r");
+    if (stream_iso != NULL) {
+      fclose(stream_iso);
+    }
+    else {
+      FREEMEMORY(iso_filename);
+    }
+  }
+
+  if (trainer_filename == NULL) {
+    NewMemory((void **)&trainer_filename, (unsigned int)(len_casename + 6));
+    STRCPY(trainer_filename, fdsprefix);
+    STRCAT(trainer_filename, ".svd");
+  }
+  if (test_filename == NULL) {
+    NewMemory((void **)&test_filename, (unsigned int)(len_casename + 6));
+    STRCPY(test_filename, fdsprefix);
+    STRCAT(test_filename, ".svd");
+  }
+  return 0;
+}
+
+int RunBenchmark(int argc, char **argv, char *input_file) {
+  initMALLOC();
+  InitVars();
+  SetupGlut(argc, argv);
+
+  SetGlobalFilenames(fdsprefix);
+
+  INIT_PRINT_TIMER(parse_time);
+  printf("reading:\t%s\n", input_file);
+  {
+    bufferstreamdata *smv_streaminfo = GetSMVBuffer(NULL, input_file);
+    if (smv_streaminfo == NULL) {
+      printf("could not open %s\n", input_file);
+      return 1;
+    }
+    INIT_PRINT_TIMER(ReadSMV_time);
+    int return_code = ReadSMV(smv_streaminfo);
+    STOP_TIMER(ReadSMV_time);
+    printf("ReadSMV:\t%8.3f ms\n", ReadSMV_time * 1000);
+    if (smv_streaminfo != NULL) {
+      FCLOSE(smv_streaminfo);
+    }
+    if (return_code) return return_code;
+  }
+  show_timings = 1;
+  ReadSMVOrig();
+  INIT_PRINT_TIMER(ReadSMVDynamic_time);
+  ReadSMVDynamic(input_file);
+  STOP_TIMER(ReadSMVDynamic_time);
+  printf("ReadSMVDynamic:\t%8.3f ms\n", ReadSMVDynamic_time * 1000);
+  STOP_TIMER(parse_time);
+  printf("Total Time:\t%8.3f ms\n", parse_time * 1000);
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  char *input_file = argv[1];
+  if (input_file == NULL) {
+    fprintf(stderr, "No input file specified.\n");
+    return 1;
+  }
+  fdsprefix = GetBaseName(input_file);
+  int result = RunBenchmark(argc, argv, input_file);
+  if (fdsprefix != NULL) free(fdsprefix);
+  return result;
+}

--- a/Tests/test_model_large/test_model_large.fds
+++ b/Tests/test_model_large/test_model_large.fds
@@ -1,0 +1,70 @@
+&HEAD CHID='test_model_large'  /
+
+&MESH IJK=10,10,10, XB=0,1,0,1,0,1, MULT_ID='mesh' /
+&MULT ID='mesh', DX=1, DY=1, DZ=1, I_UPPER=10, J_UPPER=10, K_UPPER=10/
+
+&TIME T_END=0. /
+
+&DUMP NFRAMES=2  /
+
+&REAC FUEL='POLYURETHANE', FORMULA='C6.3H7.1N1.0O2.1', SOOT_YIELD=0.01, HEAT_OF_COMBUSTION=22700. /
+
+&MATL ID                    = 'FABRIC'
+      FYI                   = 'Properties completely fabricated'
+      SPECIFIC_HEAT         = 1.0
+      CONDUCTIVITY          = 0.5
+      DENSITY               = 50.
+      NU_SPEC               = 1.
+      SPEC_ID               = 'POLYURETHANE'
+      REFERENCE_TEMPERATURE = 250.
+      HEAT_OF_REACTION      = 500.
+      HEAT_OF_COMBUSTION    = 16000. /
+
+&MATL ID                    = 'FOAM'
+      FYI                   = 'Properties completely fabricated'
+      SPECIFIC_HEAT         = 1.0
+      CONDUCTIVITY          = 0.1
+      DENSITY               = 40.0
+      NU_SPEC               = 1.
+      SPEC_ID               = 'POLYURETHANE'
+      REFERENCE_TEMPERATURE = 280.
+      HEAT_OF_REACTION      = 800.
+      HEAT_OF_COMBUSTION    = 22700. /
+
+&MATL ID            = 'GYPSUM PLASTER'
+      CONDUCTIVITY  = 0.5
+      SPECIFIC_HEAT = 1.0
+      DENSITY       = 500. /
+
+&SURF ID             = 'UPHOLSTERY'
+      FYI            = 'Properties completely fabricated'
+      COLOR          = 'PURPLE'
+      BURN_AWAY      = .TRUE.
+      MATL_ID(1:2,1) = 'FABRIC','FOAM'
+      THICKNESS(1:2) = 0.0005,0.1  /
+
+&SURF ID             = 'WALL'
+      DEFAULT        = .TRUE.
+      RGB            = 200,200,200
+      MATL_ID        = 'GYPSUM PLASTER'
+      THICKNESS      = 0.012 /
+
+&MULT ID='m1', DX=0.2, DY=0.2, DZ=0.2, I_UPPER=100, J_UPPER=100, K_UPPER=100 /
+&OBST XB=0,0.1,0,0.1,0,0.1,SURF_ID='UPHOLSTERY', MULT_ID='m1' /
+
+&PART ID='ignitor particle', SURF_ID='ignitor', STATIC=.TRUE. /
+&SURF ID='ignitor', TMP_FRONT=1000., EMISSIVITY=1., GEOMETRY='CYLINDRICAL', LENGTH=0.15, RADIUS=0.01 /
+&INIT XB=2.4,2.7,4.1,4.4,0.60,0.70, PART_ID='ignitor particle', N_PARTICLES_PER_CELL=1, CELL_CENTERED=T /
+
+&VENT XB=1,4,0,0,0,2, SURF_ID='OPEN' /
+
+&BNDF QUANTITY='RADIATIVE HEAT FLUX' /
+&BNDF QUANTITY='CONVECTIVE HEAT FLUX' /
+&BNDF QUANTITY='NET HEAT FLUX' /
+&BNDF QUANTITY='WALL TEMPERATURE' /
+&BNDF QUANTITY='BURNING RATE' /
+
+&SLCF PBX=2.50, QUANTITY='TEMPERATURE',VECTOR=.TRUE., CELL_CENTERED=.TRUE. /
+&SLCF PBX=2.50, QUANTITY='HRRPUV', CELL_CENTERED=.TRUE. /
+
+&TAIL /

--- a/Tests/test_model_small/test_model_small.fds
+++ b/Tests/test_model_small/test_model_small.fds
@@ -1,0 +1,70 @@
+&HEAD CHID='test_model_small'  /
+
+&MESH IJK=10,10,10, XB=0,1,0,1,0,1, MULT_ID='mesh' /
+&MULT ID='mesh', DX=1, DY=1, DZ=1, I_UPPER=1, J_UPPER=1, K_UPPER=1/
+
+&TIME T_END=0. /
+
+&DUMP NFRAMES=2  /
+
+&REAC FUEL='POLYURETHANE', FORMULA='C6.3H7.1N1.0O2.1', SOOT_YIELD=0.01, HEAT_OF_COMBUSTION=22700. /
+
+&MATL ID                    = 'FABRIC'
+      FYI                   = 'Properties completely fabricated'
+      SPECIFIC_HEAT         = 1.0
+      CONDUCTIVITY          = 0.5
+      DENSITY               = 50.
+      NU_SPEC               = 1.
+      SPEC_ID               = 'POLYURETHANE'
+      REFERENCE_TEMPERATURE = 250.
+      HEAT_OF_REACTION      = 500.
+      HEAT_OF_COMBUSTION    = 16000. /
+
+&MATL ID                    = 'FOAM'
+      FYI                   = 'Properties completely fabricated'
+      SPECIFIC_HEAT         = 1.0
+      CONDUCTIVITY          = 0.1
+      DENSITY               = 40.0
+      NU_SPEC               = 1.
+      SPEC_ID               = 'POLYURETHANE'
+      REFERENCE_TEMPERATURE = 280.
+      HEAT_OF_REACTION      = 800.
+      HEAT_OF_COMBUSTION    = 22700. /
+
+&MATL ID            = 'GYPSUM PLASTER'
+      CONDUCTIVITY  = 0.5
+      SPECIFIC_HEAT = 1.0
+      DENSITY       = 500. /
+
+&SURF ID             = 'UPHOLSTERY'
+      FYI            = 'Properties completely fabricated'
+      COLOR          = 'PURPLE'
+      BURN_AWAY      = .TRUE.
+      MATL_ID(1:2,1) = 'FABRIC','FOAM'
+      THICKNESS(1:2) = 0.0005,0.1  /
+
+&SURF ID             = 'WALL'
+      DEFAULT        = .TRUE.
+      RGB            = 200,200,200
+      MATL_ID        = 'GYPSUM PLASTER'
+      THICKNESS      = 0.012 /
+
+&MULT ID='m1', DX=0.2, DY=0.2, DZ=0.2, I_UPPER=100, J_UPPER=100, K_UPPER=100 /
+&OBST XB=0,0.1,0,0.1,0,0.1,SURF_ID='UPHOLSTERY', MULT_ID='m1' /
+
+&PART ID='ignitor particle', SURF_ID='ignitor', STATIC=.TRUE. /
+&SURF ID='ignitor', TMP_FRONT=1000., EMISSIVITY=1., GEOMETRY='CYLINDRICAL', LENGTH=0.15, RADIUS=0.01 /
+&INIT XB=2.4,2.7,4.1,4.4,0.60,0.70, PART_ID='ignitor particle', N_PARTICLES_PER_CELL=1, CELL_CENTERED=T /
+
+&VENT XB=1,4,0,0,0,2, SURF_ID='OPEN' /
+
+&BNDF QUANTITY='RADIATIVE HEAT FLUX' /
+&BNDF QUANTITY='CONVECTIVE HEAT FLUX' /
+&BNDF QUANTITY='NET HEAT FLUX' /
+&BNDF QUANTITY='WALL TEMPERATURE' /
+&BNDF QUANTITY='BURNING RATE' /
+
+&SLCF PBX=2.50, QUANTITY='TEMPERATURE',VECTOR=.TRUE., CELL_CENTERED=.TRUE. /
+&SLCF PBX=2.50, QUANTITY='HRRPUV', CELL_CENTERED=.TRUE. /
+
+&TAIL /


### PR DESCRIPTION
Currently, ReadSMV depends on GLUT and GLUI to be able to parse *.smv file (along with fair number of global variables). This PR introduces a new test for *.smv file parsing. This is mainly to demonstrate and test future changes.

There are two other changes:

1. The dependency of lua_api.c on main.c has been removed.
2. `InitStartupDirs()` has been moved up out of `SetupGlut` and placed near the other `Init*` functions. This is so GLUT can be setup without parsing the startup dirs (which is not necessary in the tests for example).