### PR TITLE
Expose more information via smvq

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -152,6 +152,30 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Write vcpkg config
+        uses: "DamianReeves/write-file-action@v1.3"
+        with:
+          path: vcpkg.json
+          write-mode: overwrite
+          contents: |
+            {
+              "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+              "name":"smv",
+              "version-string":"0.1.0",
+              "dependencies":[
+                  "zlib",
+                  "freeglut",
+                  "glew",
+                  "getopt",
+                  "libjpeg-turbo",
+                  "libpng",
+                  "pkgconf",
+                  "libgd",
+                  "lua",
+                  "pthreads",
+                  "json-c"
+              ]
+            }
       - name: build smokeview
         shell: cmd
         run: |

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -22,6 +22,8 @@
 #include "glutbitmap.h"
 #endif
 
+#include GLUT_H
+
 //*** threader variables
 
 //***isosurface

--- a/Source/smvq/CMakeLists.txt
+++ b/Source/smvq/CMakeLists.txt
@@ -185,3 +185,5 @@ if (LINUX)
     add_definitions(-Dpp_LINUX)
     target_link_libraries(smvq PRIVATE pthread X11 Xmu GLU GL m stdc++)
 endif()
+
+install(TARGETS smvq)

--- a/Source/smvq/CMakeLists.txt
+++ b/Source/smvq/CMakeLists.txt
@@ -177,6 +177,8 @@ target_link_libraries(smvq PRIVATE OpenGL::GL OpenGL::GLU)
 
 if (WIN32)
     target_include_directories(smvq PRIVATE ../pthreads)
+    find_package(unofficial-getopt-win32 REQUIRED)
+    target_link_libraries(smvq PRIVATE unofficial::getopt-win32::getopt)
 endif()
 if ((NOT MACOSX) AND UNIX)
     target_link_libraries(smvq PRIVATE m)

--- a/Source/smvq/smvq.c
+++ b/Source/smvq/smvq.c
@@ -1,10 +1,13 @@
 #define INMAIN
 #include "options.h"
+#include <ctype.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <getopt.h>
 
 #include "MALLOCC.h"
 #include "smokeviewvars.h"
@@ -382,7 +385,45 @@ int RunBenchmark(char *input_file) {
 }
 
 int main(int argc, char **argv) {
-  char *input_file = argv[1];
+
+  bool print_help = false;
+  bool print_version = false;
+
+  int c;
+
+  opterr = 0;
+
+  while ((c = getopt(argc, argv, "hV")) != -1)
+    switch (c) {
+    case 'h':
+      print_help = true;
+      break;
+    case 'V':
+      print_version = true;
+      break;
+    case '?':
+      if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
+      return 1;
+    default:
+      abort();
+    }
+  if (print_help) {
+    printf("smvq-%s\n", PROGVERSION);
+    printf("\nUsage:  smvq [OPTIONS] <FILE>\n");
+    printf("\nOptions:\n");
+    printf("  -h Print help\n");
+    printf("  -V Print version\n");
+    return 0;
+  }
+  if (print_version) {
+    printf("smvq - smv query processor (v%s)\n", PROGVERSION);
+    return 0;
+  }
+  char *input_file = argv[optind];
+
   if (input_file == NULL) {
     fprintf(stderr, "No input file specified.\n");
     return 1;


### PR DESCRIPTION
This exposes more information, including surfaces and device activations via the `smvq` binary. This also adds commandline options via getopt.

The only modification is to add `#include GLUT_H` to `smokeviewvars.h` as it is a missing dependency.