### PR TITLE
ci: vcpkg: disable default features of libgd

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -152,30 +152,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Write vcpkg config
-        uses: "DamianReeves/write-file-action@v1.3"
-        with:
-          path: vcpkg.json
-          write-mode: overwrite
-          contents: |
-            {
-              "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-              "name":"smv",
-              "version-string":"0.1.0",
-              "dependencies":[
-                  "zlib",
-                  "freeglut",
-                  "glew",
-                  "getopt",
-                  "libjpeg-turbo",
-                  "libpng",
-                  "pkgconf",
-                  "libgd",
-                  "lua",
-                  "pthreads",
-                  "json-c"
-              ]
-            }
+      - name: Pin vcpkg version
+        run: |
+          cd C:\vcpkg
+          git fetch
+          git checkout 2024.03.25
       - name: build smokeview
         shell: cmd
         run: |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "smv",
+  "version-string": "0.1.0",
+  "dependencies": [
+    "zlib",
+    "freeglut",
+    "glew",
+    "getopt",
+    "libjpeg-turbo",
+    "libpng",
+    "pkgconf",
+    { "name": "libgd", "default-features": false },
+    "lua",
+    "pthreads",
+    "json-c"
+  ]
+}


### PR DESCRIPTION
This commit does three things, firstly moves the vcpkg information (i.e., system libraries for Windows) from CI into the repo to ensure consistent usage.

Secondly it disables features of libgd that are not used. One of these features was withdrawn for security reasons by GitHub/Microsoft which caused a build failure.

Thirdly it pins the vcpkg snapshot version so that any if any such withdrawal happens again we'll get a warning from GitHub rather than waiting for the build to fail.