### PR TITLE
smokeview source: fix typo when computing boundary file bounds (cherr…

### DIFF
--- a/Source/smokeview/IOboundary.c
+++ b/Source/smokeview/IOboundary.c
@@ -2388,7 +2388,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int flag, int *errorcode){
     int set_valmin_save, set_valmax_save;
     float qmin_save, qmax_save;
     GLUIGetMinMax(BOUND_PATCH, patchi->label.shortlabel, &set_valmin_save, &qmin_save, &set_valmax_save, &qmax_save);
-    if(force_bound_update==1||patch_bounds_defined==0 || BuildGbndFile(BOUND_SLICE) == 1){
+    if(force_bound_update==1||patch_bounds_defined==0 || BuildGbndFile(BOUND_PATCH) == 1){
       GetGlobalPatchBounds(1,DONOT_SET_MINMAX_FLAG);
       SetLoadedPatchBounds(NULL, 0);
       GLUIPatchBoundsCPP_CB(BOUND_DONTUPDATE_COLORS);


### PR DESCRIPTION
…y pick from fed branch)