### PR TITLE
smokeview source: fix to boundary file color conversion when valmin =…

### DIFF
--- a/Source/smokeview/IOboundary.c
+++ b/Source/smokeview/IOboundary.c
@@ -15,7 +15,7 @@
 
 #define IJKBF(i,j) ((i)*ncol+(j))
 #define BOUNDCONVERT(index, valmin, valmax) (patchi->compression_type==UNCOMPRESSED ? \
-               ( (patchvals[index]-valmin)/(valmax-valmin) ) : \
+               ( valmin == valmax ? 0.0 : (patchvals[index]-valmin)/(valmax-valmin) ) : \
                (float)cpatchvals[index]/255 \
                )
 


### PR DESCRIPTION
…= valmax (cherry picked from master branch)