### PR TITLE
add macro definition for pp_COMPVER

### DIFF
--- a/Source/shared/string_util.c
+++ b/Source/shared/string_util.c
@@ -1958,9 +1958,6 @@ void PRINTversion(char *progname){
   PRINTF("Revision         : %s\n", githash);
   PRINTF("Revision Date    : %s\n", gitdate);
   PRINTF("Compilation Date : %s %s\n", __DATE__, __TIME__);
-#ifndef pp_COMPVER
-#define pp_COMPVER "unknown"
-#endif
   PRINTF("Compiler         : %s\n", pp_COMPVER);
 #ifdef pp_SANITIZE
   PRINTF("Sanitize checks  : enabled\n");

--- a/Source/shared/string_util.h
+++ b/Source/shared/string_util.h
@@ -66,6 +66,21 @@ typedef struct {
 #define HELP_SUMMARY 1
 #define HELP_ALL 2
 
+#ifndef pp_COMPVER
+#ifdef __VERSION__
+#define pp_COMPVER __VERSION__
+#elif defined(__VERSION)
+#define pp_COMPVER __VERSION
+#elif defined(_MSC_VER)
+// These macros are to convert the MSVC version number to a string
+#define xstr(s) str(s)
+#define str(s) #s
+#define pp_COMPVER "MSVC " xstr(_MSC_VER)
+#else
+#define pp_COMPVER "unknown"
+#endif
+#endif
+
 // vvvvvvvvvvvvvvvvvvvvvvvv headers vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 
 EXTERNCPP char          *GetStringPtr(char *buffer);

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -11698,9 +11698,6 @@ static int menu_count=0;
 
     sprintf(menulabel,"  Smokeview build: %s",smv_githash);
     glutAddMenuEntry(menulabel,1);
-#ifndef pp_COMPVER
-#define pp_COMPVER "unknown"
-#endif
     strcpy(compiler_version_label, _("    Compiler version:"));
     strcat(compiler_version_label, " ");
     strcat(compiler_version_label, pp_COMPVER);


### PR DESCRIPTION
`pp_COMPVER` (i.e., what is printed as the compiler version) is defined in the makefile by various scripts. ifdefs fall back to "unknown" otherwise. This also means its not defined when using cmake.

This commit modifies the ifdefs to use compiler defined macros such as `__VERSION__`. This means makes the scripts unnecessary.

The version scripts could be removed from the makefile with this, but I have not done so.