### PR TITLE
smokeview source: ignore orientation and position when forming slice …

### DIFF
--- a/Source/smokeview/IOslice.c
+++ b/Source/smokeview/IOslice.c
@@ -1520,12 +1520,12 @@ int SliceCompare( const void *arg1, const void *arg2 ){
   if(strcmp(slicei->label.longlabel,slicej->label.longlabel)>0)return 1;
   if(slicei->volslice==1&&slicej->volslice==0)return -1;
   if(slicei->volslice==0&&slicej->volslice==1)return 1;
-  if(slicei->volslice==0){
-    if(slicei->idir<slicej->idir)return -1;
-    if(slicei->idir>slicej->idir)return 1;
-    if(slicei->position_orig<slicej->position_orig)return -1;
-    if(slicei->position_orig>slicej->position_orig)return 1;
-  }
+//  if(slicei->volslice==0){
+//    if(slicei->idir<slicej->idir)return -1;
+//    if(slicei->idir>slicej->idir)return 1;
+//    if(slicei->position_orig<slicej->position_orig)return -1;
+//    if(slicei->position_orig>slicej->position_orig)return 1;
+//  }
   if(slicei->slice_filetype<slicej->slice_filetype)return -1;
   if(slicei->slice_filetype>slicej->slice_filetype)return 1;
   if(slicei->slcf_index<slicej->slcf_index)return -1;


### PR DESCRIPTION
…menus, let &SLCF index in input file take priority - addresses smokeview issue 1928