### PR TITLE
add platform-specific function to get path of the running executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,10 @@ if (BETA)
     add_compile_definitions(pp_BETA)
 endif ()
 
+if (SMV_ROOT_OVERRIDE)
+    target_compile_definitions(smokeview PRIVATE SMV_ROOT_OVERRIDE="${SMV_ROOT_OVERRIDE}")
+endif()
+
 if (SMOKEVIEW_CONFIG_PATH)
     target_compile_definitions(smokeview PRIVATE SMOKEVIEW_CONFIG_PATH="${SMOKEVIEW_CONFIG_PATH}")
 endif()

--- a/Source/background/main.c
+++ b/Source/background/main.c
@@ -129,7 +129,7 @@ int main(int argc, char **argv){
 #endif
 
   if(argc==1){
-    PRINTVERSION("background ", argv[0]);
+    PRINTVERSION("background ");
     return 1;
   }
 
@@ -139,7 +139,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version==1){
-    PRINTVERSION("background", argv[0]);
+    PRINTVERSION("background");
     return 1;
   }
 

--- a/Source/env2mod/main.c
+++ b/Source/env2mod/main.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version == 1){
-    PRINTVERSION("env2mod", argv[0]);
+    PRINTVERSION("env2mod");
     return 1;
   }
 

--- a/Source/fds2fed/main.c
+++ b/Source/fds2fed/main.c
@@ -48,11 +48,11 @@ int main(int argc, char **argv){
     return 0;
   }
   if(show_version==1){
-    PRINTVERSION("fds2fed", argv[0]);
+    PRINTVERSION("fds2fed");
     return 0;
   }
     if(argc==1){
-    PRINTVERSION("fds2fed ",argv[0]);
+    PRINTVERSION("fds2fed ");
     return 0;
   }
   for(i=1;i<argc;i++){

--- a/Source/flush/main.c
+++ b/Source/flush/main.c
@@ -79,7 +79,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version==1){
-    PRINTVERSION("flushcache", argv[0]);
+    PRINTVERSION("flushcache");
     return 1;
   }
 

--- a/Source/hashfile/main.c
+++ b/Source/hashfile/main.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version==1){
-    PRINTVERSION("hashfile",argv[0]);
+    PRINTVERSION("hashfile");
     return 1;
   }
   casename = argv[argc-1];

--- a/Source/makepo/main.c
+++ b/Source/makepo/main.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version==1){
-    PRINTVERSION("makepo",argv[0]);
+    PRINTVERSION("makepo");
     return 1;
   }
   for(ii=1;ii<argc;ii++){

--- a/Source/mergepo/main.c
+++ b/Source/mergepo/main.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version==1){
-    PRINTVERSION("makepo",argv[0]);
+    PRINTVERSION("makepo");
     return 1;
   }
   for(i=1;i<argc;i++){

--- a/Source/set_path/main.c
+++ b/Source/set_path/main.c
@@ -131,7 +131,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version==1){
-    PRINTVERSION("set_file", argv[0]);
+    PRINTVERSION("set_file");
     return 1;
   }
 

--- a/Source/sh2bat/sh2bat.c
+++ b/Source/sh2bat/sh2bat.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version==1){
-    PRINTVERSION("sh2bat", argv[0]);
+    PRINTVERSION("sh2bat");
     return 1;
   }
 

--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -26,14 +26,18 @@
 #include <io.h>
 #include <direct.h>
 #include <dirent_win.h>
+#include <shlwapi.h>
+#pragma comment(lib, "shlwapi.lib")
 #else
 #include <dirent.h>
+#include <libgen.h>
 #endif
 #include "MALLOCC.h"
 #include "string_util.h"
 #include "file_util.h"
 #include "threader.h"
 #include "fopen.h"
+
 
 FILE *alt_stdout=NULL;
 
@@ -509,7 +513,7 @@ void *fread_mt(void *mtfileinfo){
   file_size      = mtf->file_size;
   file_offset    = mtf->file_offset;
   nchars         = mtf->nchars;
-  
+
   buffer_size = nchars/nthreads;
   buffer_beg  = i*buffer_size;
   file_beg    = file_offset + buffer_beg;
@@ -570,7 +574,7 @@ int MakeFile(char *file, int size){
   if(file == NULL || strlen(file) == 0)return 0;
   stream = fopen(file, "w");
   if(stream == NULL)return 0;
-  
+
   NewMemory(( void ** )&buffer, BUFFERSIZE);
   for(i = 0; i < BUFFERSIZE; i++){
     buffer[i] = i % 255;
@@ -616,7 +620,7 @@ FILE_SIZE fread_p(char *file, unsigned char *buffer, FILE_SIZE offset, FILE_SIZE
 #else
   else{
     int i;
-    
+
     chars_read = 0;
     for(i = 0;i < nthreads;i++){
       mtfiledata *mti;
@@ -1065,48 +1069,149 @@ char *GetFloatFileSizeLabel(float size, char *sizelabel){
   return sizelabel;
 }
 
-/* ------------------ GetProgDir ------------------------ */
-
-char *GetProgDir(char *progname, char **svpath){
-
-// returns the directory containing the file progname
-
-  char *progpath, *lastsep, *smokeviewpath2;
-
-  lastsep=strrchr(progname,dirseparator[0]);
-  if(lastsep==NULL){
-    char *dir;
-
-    dir = Which(progname, NULL);
-    if(dir==NULL){
-      NewMemory((void **)&progpath,(unsigned int)3);
-      strcpy(progpath,".");
-      strcat(progpath,dirseparator);
+#ifdef _WIN32
+char *GetBinPath() {
+  size_t MAX_BUFFER_SIZE = MAX_PATH * 20;
+  char *buffer;
+  size_t buffer_size = MAX_PATH * sizeof(char);
+  NEWMEMORY(buffer, buffer_size);
+  for (;;) {
+    GetModuleFileNameA(NULL, buffer, buffer_size);
+    DWORD dw = GetLastError();
+    if (dw == ERROR_SUCCESS) {
+      return buffer;
     }
-    else{
-      int lendir;
-
-      lendir=strlen(dir);
-      NewMemory((void **)&progpath,(unsigned int)(lendir+2));
-      strcpy(progpath,dir);
-      if(progpath[lendir-1]!=dirseparator[0])strcat(progpath,dirseparator);
+    else if (dw == ERROR_INSUFFICIENT_BUFFER && buffer_size < MAX_BUFFER_SIZE) {
+      // increase buffer size by a factor of 2
+      buffer_size *= 2;
+      RESIZEMEMORY(buffer, buffer_size);
     }
-    NewMemory((void **)&smokeviewpath2,(unsigned int)(strlen(progpath)+strlen(progname)+1));
-    strcpy(smokeviewpath2,progpath);
+    else {
+      FREEMEMORY(buffer);
+      return NULL;
+    }
   }
-  else{
-    int lendir;
+}
 
-    lendir=lastsep-progname+1;
-    NewMemory((void **)&progpath,(unsigned int)(lendir+1));
-    strncpy(progpath,progname,lendir);
-    progpath[lendir]=0;
-    NewMemory((void **)&smokeviewpath2,(unsigned int)(strlen(progname)+1));
-    strcpy(smokeviewpath2,"");
+char *GetBinDir() {
+  char *buffer = GetBinPath();
+  // NB: This uses on older function in order to support "char *".
+  // PathCchRemoveFileSpec would be better but requires switching to "wchar *".
+  PathRemoveFileSpecA(buffer);
+  return buffer;
+}
+#elif __linux__
+char *GetBinPath() {
+  size_t MAX_BUFFER_SIZE = 2048 * 20;
+  char *buffer;
+  size_t buffer_size = 256 * sizeof(char);
+  NEWMEMORY(buffer, buffer_size);
+  for (;;) {
+    int ret = readlink("/proc/self/exe", buffer, buffer_size);
+    if (ret < buffer_size) {
+      buffer[ret] = '\0';
+      return buffer;
+    }
+    else if (ret == buffer_size && buffer_size < MAX_BUFFER_SIZE) {
+      // increase buffer size by a factor of 2
+      buffer_size *= 2;
+      RESIZEMEMORY(buffer, buffer_size);
+    }
+    else {
+      FREEMEMORY(buffer);
+      return NULL;
+    }
   }
-  strcat(smokeviewpath2,progname);
-  *svpath=smokeviewpath2;
-  return progpath;
+}
+
+char *GetBinDir() {
+  char *buffer = GetBinPath();
+  dirname(buffer);
+  return buffer;
+}
+#else
+char *GetBinPath() {
+  uint32_t  MAX_BUFFER_SIZE = 2048 * 20;
+  char *buffer;
+  uint32_t buffer_size = 256 * sizeof(char);
+  NEWMEMORY(buffer, buffer_size);
+  for (;;) {
+    int ret = _NSGetExecutablePath(buffer, &buffer_size);
+    if (ret == 0) {
+      return buffer;
+    }
+    else if (ret == -1 && buffer_size < MAX_BUFFER_SIZE) {
+      // buffer_size has been set to the required buffer size by
+      // _NSGetExecutablePath
+      RESIZEMEMORY(buffer, buffer_size);
+    }
+    else {
+      FREEMEMORY(buffer);
+      return NULL;
+    }
+  }
+}
+
+char *GetBinDir() {
+  char *buffer = GetBinPath();
+  // The BSD and OSX version of dirname uses an internal buffer, therefore we
+  // need to copy the string out.
+  char *dir_buffer = dirname(buffer);
+  RESIZEMEMORY(buffer, (strlen(dir_buffer) + 1) * sizeof(char));
+  STRCPY(buffer, dir_buffer);
+  return buffer;
+}
+#endif
+
+/// @brief Stored the value of the -bindir commandline option. NULL if that
+/// options is not used. Only referenced by @ref SetSmvRootOverride and @ref
+/// GetSmvRootDir.
+char *smv_root_override = NULL;
+
+void SetSmvRootOverride(const char *path) {
+  FREEMEMORY(smv_root_override);
+  if (path == NULL) return;
+  size_t len = strlen(path);
+  NEWMEMORY(smv_root_override, (len + 1) * sizeof(char));
+  STRCPY(smv_root_override, path);
+}
+
+char *GetSmvRootDir() {
+  char *envar_path = getenv("SMV_ROOT_OVERRIDE");
+  if (smv_root_override != NULL) {
+    // Take the SMV_ROOT as defined on the command line
+    char *buffer;
+    int len = strlen(smv_root_override);
+    NEWMEMORY(buffer, (len + 1) * sizeof(char));
+    STRCPY(buffer, smv_root_override);
+    buffer[len] = '\0';
+    return buffer;
+  }
+  else if (envar_path != NULL) {
+    // Take the SMV_ROOT as defined by the SMV_ROOT_OVERRIDE environment
+    // variable
+    char *buffer;
+    int len = strlen(envar_path);
+    NEWMEMORY(buffer, (len + 1) * sizeof(char));
+    STRCPY(buffer, envar_path);
+    buffer[len] = '\0';
+    return buffer;
+  }
+  else {
+#ifdef SMV_ROOT_OVERRIDE
+    // Take the SMV_ROOT as defined by the SMV_ROOT_OVERRIDE macro
+    char *buffer;
+    int len = strlen(SMV_ROOT_OVERRIDE);
+    NEWMEMORY(buffer, (len + 1) * sizeof(char));
+    STRCPY(buffer, SMV_ROOT_OVERRIDE);
+    buffer[len] = '\0';
+    return buffer;
+#else
+    // Otherwise simply return the directory of the running executable (using
+    // the platform-dependent code).
+    return GetBinDir();
+#endif
+  }
 }
 
 /* ------------------ IsSootFile ------------------------ */
@@ -1118,24 +1223,6 @@ int IsSootFile(char *shortlabel, char *longlabel){
   if(strlen(longlabel)>=12&&strncmp(longlabel, "SOOT DENSITY",12)==0)return 1;
   return 0;
 }
-
-/* ------------------ getprogdirabs ------------------------ */
-
-#ifdef pp_LUA
-char *getprogdirabs(char *progname, char **svpath){
-
-// returns the absolute path of the directory containing the file progname
-  char *progpath;
-#ifdef WIN32
-  NewMemory((void **)&progpath,_MAX_PATH);
-  _fullpath(progpath,GetProgDir(progname,svpath),_MAX_PATH);
-#else
-  NewMemory((void **)&progpath,PATH_MAX);
-  realpath(GetProgDir(progname,svpath),progpath);
-#endif
-  return progpath;
-}
-#endif
 
 /* ------------------ LastName ------------------------ */
 
@@ -1208,38 +1295,6 @@ time_t FileModtime(char *filename){
   if(statfile!=0)return return_val;
   return_val = statbuffer.st_mtime;
   return return_val;
-}
-
-/* ------------------ GetProgFullPath ------------------------ */
-
-void GetProgFullPath(char *progexe, int maxlen_progexe){
-  char *end, savedir[1024], tempdir[1024], *tempexe;
-
-  strcpy(tempdir, progexe);
-  end = strrchr(tempdir, dirseparator[0]);
-  if(end == NULL){
-    char *progpath;
-
-    progpath = Which(progexe, NULL);
-    if(progpath != NULL){
-      char copy[1024];
-
-      strcpy(copy, progexe);
-      strcpy(progexe, progpath);
-      if(progexe[strlen(progexe) - 1] != dirseparator[0])strcat(progexe, dirseparator);
-      strcat(progexe, copy);
-    }
-  }
-  else{
-    end[0] = 0;
-    tempexe = end + 1;
-    GETCWD(savedir, 1024);
-    CHDIR(tempdir);
-    GETCWD(progexe, maxlen_progexe);
-    if(progexe[strlen(progexe) - 1] != dirseparator[0])strcat(progexe, dirseparator);
-    strcat(progexe, tempexe);
-    CHDIR(savedir);
-  }
 }
 
 /* ------------------ Which ------------------------ */

--- a/Source/shared/options_common.h
+++ b/Source/shared/options_common.h
@@ -85,9 +85,9 @@
 //*** hash output
 
 #ifdef pp_HASH
-#define PRINTVERSION(a,b) PRINTversion(a,b,hash_option)
+#define PRINTVERSION(a) PRINTversion(a,hash_option)
 #else
-#define PRINTVERSION(a,b) PRINTversion(a)
+#define PRINTVERSION(a) PRINTversion(a)
 #endif
 
 // debugging macros

--- a/Source/shared/readobject.c
+++ b/Source/shared/readobject.c
@@ -1486,15 +1486,13 @@ void LoadDefaultObjectDefs(object_collection *objectscoll) {
 /* ----------------------- InitObjectDefs ----------------------------- */
 
 void ReadDefaultObjectCollection(object_collection *objectscoll,
-                                 const char *smokeview_bindir,
                                  const char *fdsprefix, int setbw,
                                  int isZoneFireModel) {
   char objectfile[1024];
 
   // There are 5 places to retrieve object definitions from:
   //
-  //   1. A file within the same directory as the smokeview executable named
-  //      "objects.svo".
+  //   1. A file within SMV root directory named "objects.svo".
   //   2. A file in the current directory named "objects.svo".
   //   3. A file in the current directory named "${fdsprefix}.svo".
   //   4. A file pointed to by SMOKEVIEW_OBJECT_DEFS_PATH.
@@ -1503,11 +1501,13 @@ void ReadDefaultObjectCollection(object_collection *objectscoll,
   // Last definition wins.
 
   // Read "objects.svo" from bin dir
-  if (smokeview_bindir != NULL) {
-    strcpy(objectfile, smokeview_bindir);
+  char *smv_bindir = GetSmvRootDir();
+  if (smv_bindir) {
+    strcpy(objectfile, smv_bindir);
     strcat(objectfile, "objects.svo");
     ReadObjectDefs(objectscoll, objectfile, setbw);
   }
+  FREEMEMORY(smv_bindir);
 
   // Read "objects.svo" from the current directory.
   strcpy(objectfile, "objects.svo");

--- a/Source/shared/readobject.h
+++ b/Source/shared/readobject.h
@@ -391,16 +391,12 @@ object_collection *CreateObjectCollection(void);
  * @param[inout] objectscoll Pointer to the location of the @ref
  * object_collection to read object definitions into. This @ref
  * object_collection
- * @param[in] smokeview_bindir The path which contains the smokeview binary.
- * Object definition files from this directory are read. If NULL, this step is
- * skipped.
  * @param[in] setbw Set the colors to black and white.
  * @param[in] fdsprefix The fdsprefix. This is used to find case-specific object
  * files (e.g., "${fdsprefix}.svo"). If NULL, such files are never read.
  * @param[in] isZoneFireModel Is this model a zone fire model.
  */
 void ReadDefaultObjectCollection(object_collection *objectscoll,
-                                 const char *smokeview_bindir,
                                  const char *fdsprefix, int setbw,
                                  int isZoneFireModel);
 /**

--- a/Source/shared/string_util.c
+++ b/Source/shared/string_util.c
@@ -1937,10 +1937,11 @@ int ParseCommonOptions(int argc, char **argv){
 /* ------------------ version ------------------------ */
 
 #ifdef pp_HASH
-void PRINTversion(char *progname, char *progfullpath, int option){
+void PRINTversion(char *progname, int option){
 #else
 void PRINTversion(char *progname){
 #endif
+  char *progfullpath = GetBinPath();
   char version[256];
   char githash[256];
   char gitdate[256];
@@ -2003,4 +2004,5 @@ void PRINTversion(char *progname){
 #ifdef pp_LINUX
   PRINTF("Platform         : LINUX64\n");
 #endif
+  FREEMEMORY(progfullpath);
 }

--- a/Source/shared/string_util.h
+++ b/Source/shared/string_util.h
@@ -157,7 +157,7 @@ EXTERNCPP char          *RandStr(char* str, int length);
 EXTERNCPP void           GetBaseTitle(char *progname, char *title_base);
 EXTERNCPP void           GetTitle(char *progname, char *fulltitle);
 #ifdef pp_HASH
-EXTERNCPP void           PRINTversion(char *progname, char *progfullpath, int hash_option);
+EXTERNCPP void           PRINTversion(char *progname, int hash_option);
 #else
 EXTERNCPP void           PRINTversion(char *progname);
 #endif

--- a/Source/smokediff/main.c
+++ b/Source/smokediff/main.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv){
     return 0;
   }
   if(show_version==1){
-    PRINTVERSION("smokediff", argv[0]);
+    PRINTVERSION("smokediff");
     return 0;
   }
 
@@ -99,7 +99,7 @@ int main(int argc, char **argv){
   strcpy(type_label,"");
 
   if(argc==1){
-    PRINTVERSION("Smokediff ",argv[0]);
+    PRINTVERSION("Smokediff ");
     return 0;
   }
 

--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -276,7 +276,9 @@ int Loadsmv(char *input_filename, char *input_filename_ext) {
 
   if (use_graphics == 0) return 0;
   glui_defined = 1;
-  InitTranslate(smokeview_bindir, tr_name);
+  char *smv_bindir = GetSmvRootDir();
+  InitTranslate(smv_bindir, tr_name);
+  FREEMEMORY(smv_bindir);
 
   if (ntourinfo == 0) SetupTour();
   InitRolloutList();

--- a/Source/smokeview/command_args.c
+++ b/Source/smokeview/command_args.c
@@ -216,17 +216,17 @@ CommandlineArgs ParseCommandlineNew(int argc, char **argv, char *message,
       i++;
       sscanf(argv[i],"%f",&args.max_mem_GB);
       if(args.max_mem_GB<0.0)args.max_mem_GB = 0.0;
-    } 
+    }
     else if(strcmp(argv[i], "-x0") == 0) {
       args.have_x0 = true;
       i++;
       sscanf(argv[i],"%i",&args.x0);
-    } 
+    }
     else if(strcmp(argv[i], "-y0") == 0) {
       args.have_y0 = true;
       i++;
       sscanf(argv[i],"%i",&args.y0);
-    } 
+    }
     else if(strcmp(argv[i], "-X0") == 0) {
       args.have_X0 = true;
       i++;

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -2803,8 +2803,7 @@ void SmokeviewIniMenu(int value){
     WriteIni(LOCAL_INI,NULL);
     break;
   case MENU_READSVO:
-    ReadDefaultObjectCollection(objectscoll, smokeview_bindir, fdsprefix, setbw,
-                         isZoneFireModel);
+    ReadDefaultObjectCollection(objectscoll, fdsprefix, setbw, isZoneFireModel);
     break;
   case MENU_DUMMY:
     break;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -6702,7 +6702,7 @@ int GenerateSmvOrigFile(void){
 
 void *GenerateSmvOrigFileWrapper(void *arg){
   if(GenerateSmvOrigFile()==1){
-    printf("%s generated\n", smv_orig_filename);  
+    printf("%s generated\n", smv_orig_filename);
   }
   ReadSMVOrig();
   THREAD_EXIT(readsmvorig_threads);
@@ -7208,8 +7208,7 @@ int ReadSMV_Init() {
   // read in device (.svo) definitions
 
   START_TIMER(timer_setup);
-  ReadDefaultObjectCollection(objectscoll, smokeview_bindir, fdsprefix, setbw,
-                       isZoneFireModel);
+  ReadDefaultObjectCollection(objectscoll, fdsprefix, setbw, isZoneFireModel);
   PRINT_TIMER(timer_setup, "InitSurface");
 
   if(noutlineinfo>0){
@@ -16248,7 +16247,9 @@ int ReadBinIni(void){
   char *smvprogini_ptr = NULL;
 
   strcpy(smvprogini, "");
-  if(smokeview_bindir!=NULL)strcat(smvprogini, smokeview_bindir);
+  char *smv_bindir = GetSmvRootDir();
+  strcat(smvprogini, smv_bindir);
+  FREEMEMORY(smv_bindir);
   strcat(smvprogini, "smokeview.ini");
   smvprogini_ptr = smokeviewini;
   if(smokeviewini!=NULL){
@@ -16293,7 +16294,9 @@ int ReadIni(char *inifile){
 
   ntickinfo=ntickinfo_smv;
   strcpy(smvprogini,"");
-  if(smokeview_bindir!=NULL)strcat(smvprogini,smokeview_bindir);
+  char *smv_bindir = GetSmvRootDir();
+  strcat(smvprogini,smv_bindir);
+  FREEMEMORY(smv_bindir);
   strcat(smvprogini,"smokeview.ini");
   smvprogini_ptr=smokeviewini;
   if(smokeviewini!=NULL){

--- a/Source/smokeview/smokeview.c
+++ b/Source/smokeview/smokeview.c
@@ -203,11 +203,12 @@ void InitVolrenderScript(char *prefix, char *tour_label, int startframe, int ski
 /* ------------------ DisplayVersionInfo ------------------------ */
 
 void DisplayVersionInfo(char *progname){
-  PRINTVERSION(progname,prog_fullpath);
+  PRINTVERSION(progname);
   if(fds_version!=NULL){
     PRINTF("FDS Build        : %s\n",fds_githash);
   }
-  PRINTF("Smokeview path   : %s\n",smokeview_progname);
+  char *smv_progname = GetBinPath();
+  PRINTF("Smokeview path   : %s\n",smv_progname);
 #ifdef pp_COMPRESS
   if(smokezippath!=NULL){
     if(verbose_output==1)PRINTF("Smokezip         : %s\n",smokezippath);
@@ -216,9 +217,12 @@ void DisplayVersionInfo(char *progname){
   if(texturedir!=NULL){
     if(verbose_output==1)PRINTF("Texture directory: %s\n",texturedir);
   }
-  if(smokeview_bindir != NULL){
-    PRINTF("Bin directory    : %s\n", smokeview_bindir);
+  char *smv_bindir = GetSmvRootDir();
+  if(smv_bindir){
+    PRINTF("Root directory   : %s\n", smv_bindir);
   }
+  FREEMEMORY(smv_progname);
+  FREEMEMORY(smv_bindir);
 }
 
 /* ------------------ IsFDSRunning ------------------------ */

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -587,7 +587,6 @@ SVEXTERN int SVDECL(clip_rotate, 0);
 SVEXTERN int curdir_writable;
 SVEXTERN char SVDECL(*file_smokesensors, NULL);
 SVEXTERN int SVDECL(light_faces, 1);
-SVEXTERN char SVDECL(*prog_fullpath, NULL);
 SVEXTERN int SVDECL(nwindrosez_checkboxes, 0);
 SVEXTERN float startup_time;
 #ifdef pp_FRAME
@@ -1929,9 +1928,6 @@ SVEXTERN char SVDECL(*part_globalbound_filename, NULL);
 SVEXTERN char SVDECL(*sliceinfo_filename,NULL);
 SVEXTERN char SVDECL(*deviceinfo_filename, NULL);
 SVEXTERN char SVDECL(*database_filename,NULL),SVDECL(*iso_filename,NULL);
-SVEXTERN char SVDECL(*smokeview_bindir,NULL);
-SVEXTERN char smokeview_progname[1024];
-SVEXTERN int SVDECL(have_bindir_arg, 0);
 SVEXTERN char SVDECL(*smokeview_casedir, NULL);
 SVEXTERN int SVDECL(update_vectorskip, 0);
 SVEXTERN int SVDECL(smoke_offaxis, 0), SVDECL(smoke_adjust, 1);
@@ -1945,7 +1941,6 @@ SVEXTERN int SVDECL(runhtmlscript, 0);
 #ifdef pp_LUA
 SVEXTERN int SVDECL(runluascript,0);
 SVEXTERN int SVDECL(exit_on_script_crash,0);
-SVEXTERN char SVDECL(*smokeview_bindir_abs,NULL);
 #endif
 #ifdef INMAIN
 SVEXTERN float slice_xyz[3]={0.0,0.0,0.0}, slice_dxyz[3] = {0.0, 0.0, 0.0};

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -309,7 +309,9 @@ int SetupCase(char *filename){
     return 0;
   }
   glui_defined = 1;
-  InitTranslate(smokeview_bindir, tr_name);
+  char *smv_bindir = GetSmvRootDir();
+  InitTranslate(smv_bindir, tr_name);
+  FREEMEMORY(smv_bindir);
   PRINT_TIMER(timer_start, "InitTranslate");
 
   if(ntourinfo==0)SetupTour();
@@ -403,24 +405,25 @@ char *GetHomeDir(){
 
 void InitStartupDirs(void){
   char *homedir = NULL;
-
+  char *smv_bindir = GetSmvRootDir();
 // get smokeview bin directory from argv[0] which contains the full path of the smokeview binary
 
   // create full path for smokeview.ini file
 
-  NewMemory((void **)&smokeviewini, (unsigned int)(strlen(smokeview_bindir)+14));
-  STRCPY(smokeviewini, smokeview_bindir);
+  NewMemory((void **)&smokeviewini, (unsigned int)(strlen(smv_bindir)+14));
+  STRCPY(smokeviewini, smv_bindir);
   STRCAT(smokeviewini, "smokeview.ini");
 
   // create full path for html template file
 
-  NewMemory((void **)&smokeview_html, (unsigned int)(strlen(smokeview_bindir)+strlen("smokeview.html")+1));
-  STRCPY(smokeview_html, smokeview_bindir);
+  NewMemory((void **)&smokeview_html, (unsigned int)(strlen(smv_bindir)+strlen("smokeview.html")+1));
+  STRCPY(smokeview_html, smv_bindir);
   STRCAT(smokeview_html, "smokeview.html");
 
-  NewMemory((void **)&smokeviewvr_html, (unsigned int)(strlen(smokeview_bindir)+strlen("smokeview_vr.html")+1));
-  STRCPY(smokeviewvr_html, smokeview_bindir);
+  NewMemory((void **)&smokeviewvr_html, (unsigned int)(strlen(smv_bindir)+strlen("smokeview_vr.html")+1));
+  STRCPY(smokeviewvr_html, smv_bindir);
   STRCAT(smokeviewvr_html, "smokeview_vr.html");
+  FREEMEMORY(smv_bindir);
 
   startup_pass = 2;
 
@@ -1255,15 +1258,16 @@ void InitOpenGL(int option){
 
   char *InitColorbarsSubDir(char *subdir){
     char *return_path = NULL;
-
-    if(smokeview_bindir == NULL || subdir==NULL)return return_path;
+    char *smv_bindir = GetSmvRootDir();
+    if(subdir==NULL)return return_path;
 
     NewMemory((void **)&return_path,
-              strlen(smokeview_bindir) + strlen("colorbars") + strlen(dirseparator) + strlen(subdir) + 2);
-    strcpy(return_path, smokeview_bindir);
+              strlen(smv_bindir) + strlen("colorbars") + strlen(dirseparator) + strlen(subdir) + 2);
+    strcpy(return_path, smv_bindir);
     strcat(return_path, "colorbars");
     strcat(return_path, dirseparator);
     if(strlen(subdir)>0)strcat(return_path, subdir);
+    FREEMEMORY(smv_bindir);
     return return_path;
   }
 
@@ -1290,22 +1294,24 @@ void InitTextureDir(void){
     NewMemory((void **)&texturedir,texture_len+1);
     strcpy(texturedir,texture_buffer);
   }
-  if(texturedir==NULL&&smokeview_bindir!=NULL){
-    texture_len=strlen(smokeview_bindir)+strlen("textures");
+  char *smv_bindir = GetSmvRootDir();
+  if(texturedir==NULL){
+    texture_len=strlen(smv_bindir)+strlen("textures");
     NewMemory((void **)&texturedir,texture_len+2);
-    strcpy(texturedir,smokeview_bindir);
+    strcpy(texturedir,smv_bindir);
     strcat(texturedir,"textures");
   }
+  FREEMEMORY(smv_bindir);
 }
 
 /* ------------------ InitScriptError ------------------------ */
 
 void InitScriptErrorFiles(void){
-  if(smokeview_bindir != NULL){
-    NewMemory((void **)&script_error1_filename, strlen(smokeview_bindir)+strlen("script_error1.png") + 1);
-    strcpy(script_error1_filename, smokeview_bindir);
-    strcat(script_error1_filename, "script_error1.png");
-  }
+  char *smv_bindir = GetSmvRootDir();
+  NewMemory((void **)&script_error1_filename, strlen(smv_bindir)+strlen("script_error1.png") + 1);
+  strcpy(script_error1_filename, smv_bindir);
+  strcat(script_error1_filename, "script_error1.png");
+  FREEMEMORY(smv_bindir);
 }
 
 /* ------------------ InitVars ------------------------ */

--- a/Source/smokezip/main.c
+++ b/Source/smokezip/main.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv){
     return 0;
   }
   if(show_version==1){
-    PRINTVERSION("smokezip", argv[0]);
+    PRINTVERSION("smokezip");
     return 0;
   }
 
@@ -146,7 +146,7 @@ int main(int argc, char **argv){
 
   filebase=NULL;
   if(argc==1){
-    PRINTVERSION("Smokezip ",argv[0]);
+    PRINTVERSION("Smokezip ");
     return 0;
   }
 

--- a/Source/timep/main.c
+++ b/Source/timep/main.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version==1){
-    PRINTVERSION("timep", argv[0]);
+    PRINTVERSION("timep");
     return 1;
   }
   if(nargs<argc){

--- a/Source/wind2fds/main.c
+++ b/Source/wind2fds/main.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv){
     return 1;
   }
   if(show_version==1){
-    PRINTVERSION("wind2fds", argv[0]);
+    PRINTVERSION("wind2fds");
     return 1;
   }
 
@@ -114,7 +114,7 @@ int main(int argc, char **argv){
   strcpy(prefix,"");
 
   if(argc==1){
-    PRINTVERSION("wind2fds ", argv[0]);
+    PRINTVERSION("wind2fds ");
    return 1;
   }
 
@@ -524,4 +524,3 @@ int main(int argc, char **argv){
   if(stream_out!=NULL)fclose(stream_out);
   return 0;
 }
-

--- a/Tests/test_objects.c
+++ b/Tests/test_objects.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
     object_collection *objectscoll = CreateObjectCollection();
     // There should be no objects to begin with
     assert(objectscoll->nobject_defs == 0);
-    ReadDefaultObjectCollection(objectscoll, NULL, NULL, 0, 0);
+    ReadDefaultObjectCollection(objectscoll, NULL, 0, 0);
     // for (int i = 0; i < objectscoll->nobject_defs; i++) {
     //   sv_object *objecti = objectscoll->object_defs[i];
     //   printf("label[%d]: %s\n", i, objecti->label);
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
   {
     // Create an object collection, read in object definitions, then free it.
     object_collection *objectscoll = CreateObjectCollection();
-    ReadDefaultObjectCollection(objectscoll, NULL, NULL, 0, 0);
+    ReadDefaultObjectCollection(objectscoll, NULL, 0, 0);
     // for (int i = 0; i < objectscoll->nobject_defs; i++) {
     //   sv_object *objecti = objectscoll->object_defs[i];
     //   printf("label[%d]: %s\n", i, objecti->label);


### PR DESCRIPTION
This commit changes how the path of the running executable is determined. Previously it would be taken from argv[0] which means either passing argv around everywhere or storing it in a global variable (which makes the code less flexible).

Technically, argv[0] could have issues as it's not guaranteed to be correct. On Windows the path is relative which means doing more logic on the path.

This commit replaces that logic with the dedicated API for each platform:

  - Windows: `GetModuleFileName`
  - Linux: symlink at `/proc/self/exe`
  - MacOS: `_NSGetExecutablePath`

The API is changed to `char *GetBinDir()` and `char *GetSmvRootDir()` and is never stored in a global.

There were some hardcoded paths to match the Windows installer which this removes but they should be redundant.