### PR TITLE
Add small memory test

### DIFF
--- a/Source/shared/MALLOCC.h
+++ b/Source/shared/MALLOCC.h
@@ -12,6 +12,7 @@
 #ifndef pp_OSX
 #include <malloc.h>
 #endif
+#include <stddef.h>
 #define memGarbage 0xA3
 
 typedef int mallocflag;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -99,6 +99,16 @@ if ((NOT MACOSX) AND UNIX)
     target_link_libraries(test_objects m)
 endif()
 
+# mem_test
+add_executable(mem_test mem_test.c
+    ../Source/shared/dmalloc.c
+)
+
+target_include_directories(mem_test PRIVATE
+    ../Tests
+    ../Source/shared
+)
+
 # Arguments to this tests are <slice path> <number of frames in slice>
 # Simple slice is a finished slice file with 3 frames
 add_test(NAME "Simple Slice - Complete"
@@ -126,3 +136,6 @@ COMMAND parse_simple_pl3d ${CMAKE_SOURCE_DIR}/Tests/fig/smv/Tests/simple_pl3d.q)
 
 add_test(NAME "Test Object API"
 COMMAND test_objects ${CMAKE_SOURCE_DIR}/Tests/bad_objects.svo)
+
+add_test(NAME "Mem Test"
+    COMMAND mem_test)

--- a/Tests/mem_test.c
+++ b/Tests/mem_test.c
@@ -1,0 +1,16 @@
+#include "MALLOCC.h"
+
+#include <assert.h>
+
+int main(int argc, char **argv) {
+  initMALLOC();
+  int *cb;
+  NEWMEMORY(cb, 256 * sizeof(int));
+  RESIZEMEMORY(cb, 256 * sizeof(int));
+  RESIZEMEMORY(cb, 512 * sizeof(int));
+  cb[400] = 25;
+  assert(cb[400] == 25);
+  CheckMemory;
+  FREEMEMORY(cb);
+  return 0;
+}


### PR DESCRIPTION
There were some issues with #include ordering. This test was added to demonstrate that (and make sure the allocator is working in the most basic sense).

MALLOCC.h uses size_t, which was not previously included. This has not arisen previously because size_t has been included for other reasons.

This makes MALLOCC.h independent and doesn't need to be included in any particular order.