### PR TITLE
smokeview source: append a directory separator to the -bindir directo…

### DIFF
--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -1174,7 +1174,7 @@ void SetSmvRootOverride(const char *path) {
   size_t len = strlen(path);
   NEWMEMORY(smv_root_override, (len + 2) * sizeof(char));
   STRCPY(smv_root_override, path);
-  if(path[len - 1] != dirseparator){
+  if(path[len - 1] != dirseparator[0]){
     STRCAT(smv_root_override, dirseparator);
   }
 }

--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -1172,8 +1172,11 @@ void SetSmvRootOverride(const char *path) {
   FREEMEMORY(smv_root_override);
   if (path == NULL) return;
   size_t len = strlen(path);
-  NEWMEMORY(smv_root_override, (len + 1) * sizeof(char));
+  NEWMEMORY(smv_root_override, (len + 2) * sizeof(char));
   STRCPY(smv_root_override, path);
+  if(path[len - 1] != dirseparator){
+    STRCAT(smv_root_override, dirseparator);
+  }
 }
 
 char *GetSmvRootDir() {

--- a/Source/smokebot_trigger.txt
+++ b/Source/smokebot_trigger.txt
@@ -1,4 +1,4 @@
     master: dummy text to trigger smokebot 
- devel:  dummy text to trigger smokebot
+devel:  dummy text to trigger smokebot
   devel2:  dummy text to trigger smokebot
   test: dummy text to trigger smokebot


### PR DESCRIPTION
…ry parameter if it is not there (to ensure when concatenating files names that the full path name is valid)