### PR TITLE
split label functions into shared

### DIFF
--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -48,7 +48,7 @@ bin = .
 
 csrc = callbacks.c camera.c color2rgb.c readimage.c readgeom.c readobject.c colortimebar.c compress.c csphere.c dmalloc.c \
       drawGeometry.c file_util.c getdata.c getdatabounds.c getdatacolors.c glew.c  \
-      histogram.c infoheader.c \
+      histogram.c infoheader.c readlabel.c \
       IOboundary.c IOgeometry.c IOhvac.c IOiso.c IOobjects.c IOpart.c IOplot2d.c IOplot3d.c \
       IOscript.c IOshooter.c IOslice.c IOsmoke.c IOtour.c IOvolsmoke.c IOwui.c IOzone.c IOframe.o isobox.c \
       main.c md5.c menus.c output.c readsmv.c renderhtml.c renderimage.c scontour2d.c sha1.c \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ add_executable(smokeview
     Source/shared/readimage.c
     Source/shared/readgeom.c
     Source/shared/readobject.c
+    Source/shared/readlabel.c
     Source/smokeview/colortable.c
     Source/smokeview/command_args.c
 )

--- a/Source/shared/readlabel.c
+++ b/Source/shared/readlabel.c
@@ -1,0 +1,208 @@
+#include "options.h"
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "MALLOCC.h"
+#include "contourdefs.h"
+#include "histogram.h"
+#include "isodefs.h"
+#include "smokeviewdefs.h"
+#include "string_util.h"
+#include "structures.h"
+
+#include "readobject.h"
+
+#include "readlabel.h"
+
+/* ------------------ LabelGet ------------------------ */
+
+labeldata *LabelGet(labels_collection *labelscoll, char *name) {
+  labeldata *thislabel;
+
+  if(name == NULL) return NULL;
+  for(thislabel = labelscoll->label_first_ptr->next; thislabel->next != NULL;
+      thislabel = thislabel->next) {
+    if(strcmp(thislabel->name, name) == 0) return thislabel;
+  }
+  return NULL;
+}
+
+void LabelInsertBefore(labeldata *listlabel, labeldata *label) {
+  labeldata *prev, *next;
+
+  prev = listlabel->prev;
+  next = listlabel;
+  prev->next = label;
+  next->prev = label;
+  label->prev = prev;
+  label->next = next;
+}
+
+void LabelInsertAfter(labeldata *listlabel, labeldata *label) {
+  labeldata *prev, *next;
+
+  prev = listlabel;
+  next = listlabel->next;
+  prev->next = label;
+  next->prev = label;
+  label->prev = prev;
+  label->next = next;
+}
+
+labeldata *LabelInsert(labels_collection *labelscoll, labeldata *labeltemp) {
+  labeldata *newlabel, *thislabel;
+  labeldata *firstuserptr, *lastuserptr;
+
+  NewMemory((void **)&newlabel, sizeof(labeldata));
+  memcpy(newlabel, labeltemp, sizeof(labeldata));
+
+  thislabel = LabelGet(labelscoll, newlabel->name);
+  if(thislabel != NULL) {
+    LabelInsertAfter(thislabel->prev, newlabel);
+    return newlabel;
+  }
+
+  firstuserptr = labelscoll->label_first_ptr->next;
+  if(firstuserptr == labelscoll->label_last_ptr) firstuserptr = NULL;
+
+  lastuserptr = labelscoll->label_last_ptr->prev;
+  if(lastuserptr == labelscoll->label_first_ptr) lastuserptr = NULL;
+
+  if(firstuserptr != NULL && strcmp(newlabel->name, firstuserptr->name) < 0) {
+    LabelInsertBefore(firstuserptr, newlabel);
+    return newlabel;
+  }
+  if(lastuserptr != NULL && strcmp(newlabel->name, lastuserptr->name) > 0) {
+    LabelInsertAfter(lastuserptr, newlabel);
+    return newlabel;
+  }
+  if(firstuserptr == NULL && lastuserptr == NULL) {
+    LabelInsertAfter(labelscoll->label_first_ptr, newlabel);
+    return newlabel;
+  }
+  for(thislabel = labelscoll->label_first_ptr->next; thislabel->next != NULL;
+      thislabel = thislabel->next) {
+    labeldata *nextlabel;
+
+    nextlabel = thislabel->next;
+    if(strcmp(thislabel->name, newlabel->name) < 0 &&
+       strcmp(newlabel->name, nextlabel->name) < 0) {
+      LabelInsertAfter(thislabel, newlabel);
+      return newlabel;
+    }
+  }
+  return NULL;
+}
+
+/* ------------------ LabelDelete ------------------------ */
+
+void LabelDelete(labeldata *label) {
+  labeldata *prev, *next;
+
+  prev = label->prev;
+  next = label->next;
+  CheckMemory;
+  FREEMEMORY(label);
+  prev->next = next;
+  next->prev = prev;
+}
+
+/* ------------------ LabelCopy ------------------------ */
+
+void LabelCopy(labeldata *label_to, labeldata *label_from) {
+  labeldata *prev, *next;
+
+  prev = label_to->prev;
+  next = label_to->next;
+  memcpy(label_to, label_from, sizeof(labeldata));
+  label_to->prev = prev;
+  label_to->next = next;
+}
+
+/* ------------------ LabelResort ------------------------ */
+
+void LabelResort(labels_collection *labelscoll, labeldata *label) {
+  labeldata labelcopy;
+
+  CheckMemory;
+  memcpy(&labelcopy, label, sizeof(labeldata));
+  CheckMemory;
+  LabelDelete(label);
+  LabelInsert(labelscoll, &labelcopy);
+}
+
+/* ------------------ LabelPrint ------------------------ */
+
+void LabelPrint(labeldata *label_first_ptr) {
+  labeldata *thislabel;
+  float *xyz;
+
+  for(thislabel = label_first_ptr->next; thislabel->next != NULL;
+      thislabel = thislabel->next) {
+    xyz = thislabel->xyz;
+    PRINTF("label: %s position: %f %f %f\n", thislabel->name, xyz[0], xyz[1],
+           xyz[2]);
+  }
+}
+
+/* ------------------ LabelNext ------------------------ */
+
+labeldata *LabelNext(labels_collection *labelscoll, labeldata *label) {
+  labeldata *thislabel;
+
+  if(label == NULL) return NULL;
+  if(labelscoll->label_first_ptr->next->next == NULL) return NULL;
+  for(thislabel = label->next; thislabel != label;
+      thislabel = thislabel->next) {
+    if(thislabel->next == NULL) thislabel = labelscoll->label_first_ptr->next;
+    if(thislabel->labeltype == TYPE_SMV) continue;
+    return thislabel;
+  }
+  return NULL;
+}
+
+/* ------------------ LabelPrevious ------------------------ */
+
+labeldata *LabelPrevious(labels_collection *labelscoll, labeldata *label) {
+  labeldata *thislabel;
+
+  if(label == NULL) return NULL;
+  if(labelscoll->label_last_ptr->prev->prev == NULL) return NULL;
+  for(thislabel = label->prev; thislabel != label;
+      thislabel = thislabel->prev) {
+    if(thislabel->prev == NULL) thislabel = labelscoll->label_last_ptr->prev;
+    if(thislabel->labeltype == TYPE_SMV) continue;
+    return thislabel;
+  }
+  return NULL;
+}
+
+/* ------------------ LabelInit ------------------------ */
+
+int LabelInit(labels_collection *labelscoll, labeldata *gl) {
+  labeldata *thislabel;
+
+  for(thislabel = labelscoll->label_first_ptr->next; thislabel->next != NULL;
+      thislabel = thislabel->next) {
+    if(thislabel->labeltype == TYPE_SMV) continue;
+    LabelCopy(gl, thislabel);
+    return 1;
+  }
+  return 0;
+}
+
+/* ------------------ LabelGetNUserLabels ------------------------ */
+
+int LabelGetNUserLabels(labels_collection *labelscoll) {
+  int count = 0;
+  labeldata *thislabel;
+
+  for(thislabel = labelscoll->label_first_ptr->next; thislabel->next != NULL;
+      thislabel = thislabel->next) {
+    if(thislabel->labeltype == TYPE_INI) count++;
+  }
+  return count;
+}

--- a/Source/shared/readlabel.h
+++ b/Source/shared/readlabel.h
@@ -1,0 +1,26 @@
+#ifndef READLABEL_H_DEFINED
+#define READLABEL_H_DEFINED
+
+/**
+ * @brief A collection of labels. At it's core this collection
+ * contains a linked list, but also an array of pointers into that linked list.
+ *
+ */
+typedef struct {
+  labeldata label_first;
+  labeldata label_last;
+  labeldata *label_first_ptr;
+  labeldata *label_last_ptr;
+} labels_collection;
+
+EXTERNCPP labeldata *LabelGet(labels_collection *labelscoll, char *name);
+EXTERNCPP labeldata *LabelInsert(labels_collection *labelscoll,
+                                 labeldata *labeltemp);
+
+EXTERNCPP int LabelGetNUserLabels(labels_collection *labelscoll);
+EXTERNCPP labeldata *LabelPrevious(labels_collection *labelscoll,
+                                   labeldata *label);
+EXTERNCPP labeldata *LabelNext(labels_collection *labelscoll, labeldata *label);
+EXTERNCPP void LabelCopy(labeldata *label_to, labeldata *label_from);
+EXTERNCPP void LabelDelete(labeldata *label);
+#endif

--- a/Source/smokeview/glui_display.cpp
+++ b/Source/smokeview/glui_display.cpp
@@ -7,6 +7,7 @@
 #include <math.h>
 
 #include "smokeviewvars.h"
+#include "readlabel.h"
 
 GLUI *glui_labels=NULL;
 
@@ -311,7 +312,7 @@ void DisplayRolloutCB(int var){
 /* ------------------ UpdateGluiLabelText ------------------------ */
 
 void UpdateGluiLabelText(void){
-  if(LabelGetNUserLabels()>0){
+  if(LabelGetNUserLabels(&labelscoll)>0){
     labeldata *gl;
 
     gl=&LABEL_local;
@@ -394,7 +395,7 @@ void TextLabelsCB(int var){
     updatemenu = 1;
     break;
   case LB_UPDATE:
-    for(thislabel = label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->glui_id < 0)continue;
       LIST_LB_labels->delete_item(thislabel->glui_id);
     }
@@ -402,7 +403,7 @@ void TextLabelsCB(int var){
     //LabelResort(LABEL_global_ptr);
 
     count = 0;
-    for(thislabel = label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->labeltype == TYPE_SMV)continue;
       thislabel->glui_id = count;
       LIST_LB_labels->add_item(count++, thislabel->name);
@@ -418,8 +419,8 @@ void TextLabelsCB(int var){
     memcpy(&LABEL_global_ptr->useforegroundcolor, &gl->useforegroundcolor, sizeof(int));
     break;
   case LB_PREVIOUS:
-    new_label = LabelGet(LIST_LB_labels->curr_text);
-    new_label = LabelPrevious(new_label);
+    new_label = LabelGet(&labelscoll,LIST_LB_labels->curr_text);
+    new_label = LabelPrevious(&labelscoll,new_label);
     if(new_label == NULL)break;
     LABEL_global_ptr = new_label;
     if(new_label != NULL){
@@ -428,8 +429,8 @@ void TextLabelsCB(int var){
     }
     break;
   case LB_NEXT:
-    new_label = LabelGet(LIST_LB_labels->curr_text);
-    new_label = LabelNext(new_label);
+    new_label = LabelGet(&labelscoll,LIST_LB_labels->curr_text);
+    new_label = LabelNext(&labelscoll,new_label);
     if(new_label == NULL)break;
     LABEL_global_ptr = new_label;
     if(new_label != NULL){
@@ -438,7 +439,7 @@ void TextLabelsCB(int var){
     }
     break;
   case LB_LIST:
-    new_label = LabelGet(LIST_LB_labels->curr_text);
+    new_label = LabelGet(&labelscoll,LIST_LB_labels->curr_text);
     LABEL_global_ptr = new_label;
     if(new_label != NULL){
       LabelCopy(gl, new_label);
@@ -447,7 +448,7 @@ void TextLabelsCB(int var){
     break;
   case LB_ADD:
     updatemenu = 1;
-    if(LabelGetNUserLabels() > 0){
+    if(LabelGetNUserLabels(&labelscoll) > 0){
       strcpy(name, "copy of ");
       strcat(name, gl->name);
       strcpy(gl->name, name);
@@ -456,13 +457,13 @@ void TextLabelsCB(int var){
       gl = &LABEL_default;
     }
     gl->labeltype = TYPE_INI;
-    for(thislabel = label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->glui_id < 0)continue;
       LIST_LB_labels->delete_item(thislabel->glui_id);
     }
-    LabelInsert(gl);
+    LabelInsert(&labelscoll, gl);
     count = 0;
-    for(thislabel = label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->labeltype == TYPE_SMV)continue;
       thislabel->glui_id = count;
       LIST_LB_labels->add_item(count++, thislabel->name);
@@ -471,16 +472,16 @@ void TextLabelsCB(int var){
     break;
   case LB_DELETE:
     strcpy(name, LIST_LB_labels->curr_text);
-    for(thislabel = label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->glui_id < 0)continue;
       LIST_LB_labels->delete_item(thislabel->glui_id);
     }
-    thislabel = LabelGet(name);
+    thislabel = LabelGet(&labelscoll,name);
     if(thislabel != NULL){
       LabelDelete(thislabel);
     }
     count = 0;
-    for(thislabel = label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->labeltype == TYPE_SMV)continue;
       thislabel->glui_id = count;
       LIST_LB_labels->add_item(count++, thislabel->name);
@@ -1069,7 +1070,7 @@ extern "C" void GLUIDisplaySetup(int main_window){
     labeldata *thislabel;
     int count=0;
 
-    for(thislabel=label_first_ptr->next;thislabel->next!=NULL;thislabel=thislabel->next){
+    for(thislabel=labelscoll.label_first_ptr->next;thislabel->next!=NULL;thislabel=thislabel->next){
       if(thislabel->labeltype==TYPE_SMV){
         thislabel->glui_id=-1;
         continue;

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -3418,7 +3418,7 @@ char *FileSize2Label(char *label, FILE_SIZE bytes){
 
 void Plot3DSummary(char *label, int count, FILE_SIZE file_size, float timer){
   char size_label[256], time_label[256], time_label2[256];
-  
+
   sprintf(label, "PLOT3D: loaded %i files, %s", count, FileSize2Label(size_label, file_size));
   Float2String(time_label2, timer, ncolorlabel_digits, force_fixedpoint);
   sprintf(time_label, " in %ss", time_label2);
@@ -3552,7 +3552,7 @@ void LoadUnloadMenu(int value){
     STOP_TIMER(plot3d_timer);
     if(file_count>0){
       char label[256];
-      
+
       Plot3DSummary(label, file_count, total_plot3d_filesize, plot3d_timer);
       printf("%s\n",label);
     }
@@ -5721,7 +5721,7 @@ void Plot3DListMenu(int value){
   STOP_TIMER(plot3d_timer);
   if(file_count>0){
     char label[256];
-      
+
     Plot3DSummary(label, file_count, total_plot3d_filesize, plot3d_timer);
     printf("%s\n",label);
   }
@@ -5779,7 +5779,7 @@ int LoadAllPlot3D(float time){
   STOP_TIMER(plot3d_timer);
   if(file_count>0){
     char label[256];
-      
+
     Plot3DSummary(label, file_count, total_plot3d_filesize, plot3d_timer);
     printf("%s\n",label);
   }
@@ -5837,7 +5837,7 @@ void LoadPlot3dMenu(int value){
       STOP_TIMER(plot3d_timer);
       if(file_count>0){
         char label[256];
-      
+
         Plot3DSummary(label, file_count, total_plot3d_filesize, plot3d_timer);
         printf("%s\n",label);
       }
@@ -5888,7 +5888,7 @@ void LoadPlot3dMenu(int value){
     STOP_TIMER(plot3d_timer);
     if(file_count>0){
       char label[256];
-      
+
       Plot3DSummary(label, file_count, total_plot3d_filesize, plot3d_timer);
       printf("%s\n",label);
     }
@@ -10305,7 +10305,7 @@ static int menu_count=0;
   if(visMeshlabel == 0)glutAddMenuEntry(_("Mesh"), MENU_LABEL_meshlabel);
   if(vis_slice_average == 1)glutAddMenuEntry(_("*Slice average"), MENU_LABEL_sliceaverage);
   if(vis_slice_average == 0)glutAddMenuEntry(_("Slice average"), MENU_LABEL_sliceaverage);
-  if(LabelGetNUserLabels() > 0){
+  if(LabelGetNUserLabels(&labelscoll) > 0){
     if(visLabels == 1)glutAddMenuEntry(_("*Text labels"), MENU_LABEL_textlabels);
     if(visLabels == 0)glutAddMenuEntry(_("Text labels"), MENU_LABEL_textlabels);
   }

--- a/Source/smokeview/output.c
+++ b/Source/smokeview/output.c
@@ -387,7 +387,7 @@ void OutputBarText(float x, float y, const GLfloat *color, char *string){
 
 /* ------------------ WriteLabels ------------------------ */
 
-void WriteLabels(void){
+void WriteLabels(labels_collection *labelscoll){
   labeldata *first_label, *thislabel;
   FILE *stream = NULL;
   char quote[2];
@@ -396,7 +396,7 @@ void WriteLabels(void){
   stream = fopen(event_filename, "w");
   if(stream==NULL)return;
 
-  first_label = label_first_ptr;
+  first_label = labelscoll->label_first_ptr;
   strcpy(quote,"\"");
 
   for(thislabel = first_label->next; thislabel->next!=NULL; thislabel = thislabel->next){
@@ -418,10 +418,10 @@ void WriteLabels(void){
 
 /* ------------------ DrawLabels ------------------------ */
 
-void DrawLabels(void){
+void DrawLabels(labels_collection *labelscoll){
   labeldata *first_label, *thislabel;
 
-  first_label = label_first_ptr;
+  first_label = labelscoll->label_first_ptr;
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
@@ -468,194 +468,6 @@ void DrawLabels(void){
     }
   }
   glPopMatrix();
-}
-
-/* ------------------ LabelNext ------------------------ */
-
-labeldata *LabelNext(labeldata *label){
-  labeldata *thislabel;
-
-  if(label==NULL)return NULL;
-  if(label_first_ptr->next->next==NULL)return NULL;
-  for(thislabel=label->next;thislabel!=label;thislabel=thislabel->next){
-    if(thislabel->next==NULL)thislabel=label_first_ptr->next;
-    if(thislabel->labeltype==TYPE_SMV)continue;
-    return thislabel;
-  }
-  return NULL;
-}
-
-/* ------------------ LabelPrevious ------------------------ */
-
-labeldata *LabelPrevious(labeldata *label){
-  labeldata *thislabel;
-
-  if(label==NULL)return NULL;
-  if(label_last_ptr->prev->prev==NULL)return NULL;
-  for(thislabel=label->prev;thislabel!=label;thislabel=thislabel->prev){
-    if(thislabel->prev==NULL)thislabel=label_last_ptr->prev;
-    if(thislabel->labeltype==TYPE_SMV)continue;
-    return thislabel;
-  }
-  return NULL;
-}
-
-/* ------------------ LabelInit ------------------------ */
-
-int LabelInit(labeldata *gl){
-  labeldata *thislabel;
-
-  for(thislabel=label_first_ptr->next;thislabel->next!=NULL;thislabel=thislabel->next){
-    if(thislabel->labeltype==TYPE_SMV)continue;
-    LabelCopy(gl,thislabel);
-    return 1;
-  }
-  return 0;
-}
-
-/* ------------------ LabelGetNUserLabels ------------------------ */
-
-int LabelGetNUserLabels(void){
-  int count=0;
-  labeldata *thislabel;
-
-  for(thislabel=label_first_ptr->next;thislabel->next!=NULL;thislabel=thislabel->next){
-    if(thislabel->labeltype==TYPE_INI)count++;
-  }
-  return count;
-}
-
-/* ------------------ LabelGet ------------------------ */
-
-labeldata *LabelGet(char *name){
-  labeldata *thislabel;
-
-  if(name==NULL)return NULL;
-  for(thislabel=label_first_ptr->next;thislabel->next!=NULL;thislabel=thislabel->next){
-    if(strcmp(thislabel->name,name)==0)return thislabel;
-  }
-  return NULL;
-}
-
-/* ------------------ LabelInsertBefore ------------------------ */
-
-void LabelInsertBefore(labeldata *listlabel, labeldata *label){
-  labeldata *prev, *next;
-
-  prev        = listlabel->prev;
-  next        = listlabel;
-  prev->next  = label;
-  next->prev  = label;
-  label->prev = prev;
-  label->next = next;
-}
-
-/* ------------------ LabelDelete ------------------------ */
-
-void LabelDelete(labeldata *label){
-  labeldata *prev, *next;
-
-  prev = label->prev;
-  next =label->next;
-  CheckMemory;
-  FREEMEMORY(label);
-  prev->next=next;
-  next->prev=prev;
-}
-
-/* ------------------ LabelCopy ------------------------ */
-
-void LabelCopy(labeldata *label_to, labeldata *label_from){
-  labeldata *prev, *next;
-
-  prev=label_to->prev;
-  next=label_to->next;
-  memcpy(label_to,label_from,sizeof(labeldata));
-  label_to->prev=prev;
-  label_to->next=next;
-
-}
-
-/* ------------------ LabelResort ------------------------ */
-
-void LabelResort(labeldata *label){
-  labeldata labelcopy;
-
-  CheckMemory;
-  memcpy(&labelcopy,label,sizeof(labeldata));
-  CheckMemory;
-  LabelDelete(label);
-  LabelInsert(&labelcopy);
-}
-
-/* ------------------ LabelInsertAfter ------------------------ */
-
-void LabelInsertAfter(labeldata *listlabel, labeldata *label){
-  labeldata *prev, *next;
-
-  prev        = listlabel;
-  next        = listlabel->next;
-  prev->next  = label;
-  next->prev  = label;
-  label->prev = prev;
-  label->next = next;
-}
-
-/* ------------------ LabelPrint ------------------------ */
-
-void LabelPrint(void){
-  labeldata *thislabel;
-  float *xyz;
-
-  for(thislabel=label_first_ptr->next;thislabel->next!=NULL;thislabel=thislabel->next){
-    xyz = thislabel->xyz;
-    PRINTF("label: %s position: %f %f %f\n",thislabel->name,xyz[0],xyz[1],xyz[2]);
-  }
-}
-
-/* ------------------ LabelInsert ------------------------ */
-
-labeldata *LabelInsert(labeldata *labeltemp){
-  labeldata *newlabel, *thislabel;
-  labeldata *firstuserptr, *lastuserptr;
-
-  NewMemory((void **)&newlabel,sizeof(labeldata));
-  memcpy(newlabel,labeltemp,sizeof(labeldata));
-
-  thislabel = LabelGet(newlabel->name);
-  if(thislabel!=NULL){
-    LabelInsertAfter(thislabel->prev,newlabel);
-    return newlabel;
-  }
-
-  firstuserptr=label_first_ptr->next;
-  if(firstuserptr==label_last_ptr)firstuserptr=NULL;
-
-  lastuserptr=label_last_ptr->prev;
-  if(lastuserptr==label_first_ptr)lastuserptr=NULL;
-
-  if(firstuserptr!=NULL&&strcmp(newlabel->name,firstuserptr->name)<0){
-    LabelInsertBefore(firstuserptr,newlabel);
-    return newlabel;
-  }
-  if(lastuserptr!=NULL&&strcmp(newlabel->name,lastuserptr->name)>0){
-    LabelInsertAfter(lastuserptr,newlabel);
-    return newlabel;
-  }
-  if(firstuserptr==NULL&&lastuserptr==NULL){
-    LabelInsertAfter(label_first_ptr,newlabel);
-    return newlabel;
-  }
-  for(thislabel=label_first_ptr->next;thislabel->next!=NULL;thislabel=thislabel->next){
-    labeldata *nextlabel;
-
-    nextlabel=thislabel->next;
-    if(strcmp(thislabel->name,newlabel->name)<0&&strcmp(newlabel->name,nextlabel->name)<0){
-      LabelInsertAfter(thislabel,newlabel);
-      return newlabel;
-    }
-  }
-  return NULL;
 }
 
 /* ----------------------- ScaleFont2D ----------------------------- */

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -6460,7 +6460,7 @@ void UpdateEvents(void){
 
       label.useforegroundcolor = 0;
       label.show_always = 0;
-      LabelInsert(&label);
+      LabelInsert(&labelscoll, &label);
       event_file_exists = 1;
     }
   }
@@ -9132,7 +9132,7 @@ int ReadSMV_Parse(bufferstreamdata *stream){
         rgbtemp[0]=frgbtemp[0]*255;
         rgbtemp[1]=frgbtemp[1]*255;
         rgbtemp[2]=frgbtemp[2]*255;
-        LabelInsert(labeli);
+        LabelInsert(&labelscoll, labeli);
       }
       continue;
     }
@@ -15734,7 +15734,7 @@ int ReadIni2(char *inifile, int localfile){
         TrimBack(buffer);
         bufferptr = TrimFront(buffer);
         strcpy(labeli->name, bufferptr);
-        LabelInsert(labeli);
+        LabelInsert(&labelscoll, labeli);
         continue;
       }
       if(MatchINI(buffer, "VIEWTIMES") == 1){
@@ -16450,7 +16450,7 @@ void WriteIniLocal(FILE *fileout){
   fprintf(fileout, " %i %i %i %i\n", vis_gslice_data, show_gslice_triangles, show_gslice_triangulation, show_gslice_normal);
   fprintf(fileout, " %f %f %f\n", gslice_xyz[0], gslice_xyz[1], gslice_xyz[2]);
   fprintf(fileout, " %f %f\n", gslice_normal_azelev[0], gslice_normal_azelev[1]);
-  for(thislabel = label_first_ptr->next; thislabel->next != NULL; thislabel = thislabel->next){
+  for(thislabel = labelscoll.label_first_ptr->next; thislabel->next != NULL; thislabel = thislabel->next){
     labeldata *labeli;
     float *xyz, *rgbtemp, *tstart_stop;
     int *useforegroundcolor, *show_always;
@@ -16924,7 +16924,7 @@ void WriteIniLocal(FILE *fileout){
   }
 
   // write out labels to casename.evt if this file exsits
-  //WriteLabels();
+  //WriteLabels(&labelscoll);
 }
 
   /* ------------------ WriteIni ------------------------ */

--- a/Source/smokeview/showscene.c
+++ b/Source/smokeview/showscene.c
@@ -424,7 +424,7 @@ void ShowScene2(int mode){
 
   if(visLabels == 1){
     CLIP_GEOMETRY;
-    DrawLabels();
+    DrawLabels(&labelscoll);
   }
 
   /* ++++++++++++++++++++++++ draw animated isosurfaces +++++++++++++++++++++++++ */

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -652,16 +652,6 @@ EXTERNCPP void GetViewportInfo(void);
 
 EXTERNCPP void ScaleFont2D(void);
 EXTERNCPP void ScaleFont3D(void);
-EXTERNCPP int  LabelGetNUserLabels(void);
-EXTERNCPP labeldata *LabelNext(labeldata *gl);
-EXTERNCPP labeldata *LabelPrevious(labeldata *gl);
-EXTERNCPP int  LabelInit(labeldata *gl);
-EXTERNCPP void LabelResort(labeldata *label);
-EXTERNCPP void LabelCopy(labeldata *label_to, labeldata *label_from);
-EXTERNCPP labeldata *LabelGet(char *name);
-EXTERNCPP void LabelDelete(labeldata *label);
-EXTERNCPP void LabelPrint(void);
-EXTERNCPP labeldata *LabelInsert(labeldata *labeltemp);
 
 EXTERNCPP void SetScreenSize(int *width, int *height);
 EXTERNCPP void KeyboardCB(unsigned char key, int x, int y);
@@ -856,8 +846,8 @@ EXTERNCPP float Zoom2Aperture(float zoom0);
 EXTERNCPP float Aperture2Zoom(float ap);
 EXTERNCPP int  GetZoneColor(float t, float tmin, float tmax, int nlevel);
 EXTERNCPP void DrawBlockages(int mode, int flag);
-EXTERNCPP void WriteLabels(void);
-EXTERNCPP void DrawLabels(void);
+EXTERNCPP void WriteLabels(labels_collection *labelscoll);
+EXTERNCPP void DrawLabels(labels_collection *labelscoll);
 EXTERNCPP void GetNewPos(float *oldpos, float dx, float dy, float dz, float speed_factor);
 EXTERNCPP void FreeSkybox(void);
 EXTERNCPP void DrawSkybox(void);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -14,6 +14,7 @@
 #include "histogram.h"
 #include "structures.h"
 #include "readobject.h"
+#include "readlabel.h"
 #ifndef CPP
 #include <zlib.h>
 #endif
@@ -2252,7 +2253,7 @@ SVEXTERN int SVDECL(visMAINmenus,0);
 SVEXTERN int SVDECL(ijkbarmax,5);
 SVEXTERN int SVDECL(blockage_as_input,0), SVDECL(blockage_snapped,1);
 SVEXTERN int SVDECL(show_cad_and_grid,0);
-SVEXTERN labeldata label_first, label_last, *label_first_ptr, *label_last_ptr;
+SVEXTERN labels_collection SVDECL(labelscoll, {0});
 SVEXTERN int SVDECL(*isotypes,NULL), SVDECL(*boundarytypes,NULL);
 SVEXTERN plot3ddata SVDECL(*plot3dinfo,NULL);
 SVEXTERN int SVDECL(iplot3dtimelist, -1), SVDECL(nplot3dtimelist, 0);

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -1425,16 +1425,16 @@ void InitVars(void){
   strcpy((char *)degC,"C");
   strcpy((char *)degF,"F");
 
-  label_first_ptr = &label_first;
-  label_last_ptr = &label_last;
+  labelscoll.label_first_ptr = &labelscoll.label_first;
+  labelscoll.label_last_ptr = &labelscoll.label_last;
 
-  label_first_ptr->prev = NULL;
-  label_first_ptr->next = label_last_ptr;
-  strcpy(label_first_ptr->name,"first");
+  labelscoll.label_first_ptr->prev = NULL;
+  labelscoll.label_first_ptr->next = labelscoll.label_last_ptr;
+  strcpy(labelscoll.label_first_ptr->name,"first");
 
-  label_last_ptr->prev = label_first_ptr;
-  label_last_ptr->next = NULL;
-  strcpy(label_last_ptr->name,"last");
+  labelscoll.label_last_ptr->prev = labelscoll.label_first_ptr;
+  labelscoll.label_last_ptr->next = NULL;
+  strcpy(labelscoll.label_last_ptr->name,"last");
 
   {
     labeldata *gl;

--- a/Source/smvq/CMakeLists.txt
+++ b/Source/smvq/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(smvq smvq.c
     ../shared/readimage.c
     ../shared/readgeom.c
     ../shared/readobject.c
+    ../shared/readlabel.c
     ../smokeview/colortable.c
     ../smokeview/command_args.c
 


### PR DESCRIPTION
Move the label functions into shared. Labels are parsed in a *.smv file, therefore the parsing/management code needs to be in shared in order to be able to parse *.smv files without GLUT & GLUI.