### PR TITLE
Separate HVAC reading functions

### DIFF
--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -48,7 +48,7 @@ bin = .
 
 csrc = callbacks.c camera.c color2rgb.c readimage.c readgeom.c readobject.c colortimebar.c compress.c csphere.c dmalloc.c \
       drawGeometry.c file_util.c getdata.c getdatabounds.c getdatacolors.c glew.c  \
-      histogram.c infoheader.c readlabel.c \
+      histogram.c infoheader.c \
       IOboundary.c IOgeometry.c IOhvac.c IOiso.c IOobjects.c IOpart.c IOplot2d.c IOplot3d.c \
       readhvac.c \
       IOscript.c IOshooter.c IOslice.c IOsmoke.c IOtour.c IOvolsmoke.c IOwui.c IOzone.c IOframe.o isobox.c \

--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -48,7 +48,7 @@ bin = .
 
 csrc = callbacks.c camera.c color2rgb.c readimage.c readgeom.c readobject.c colortimebar.c compress.c csphere.c dmalloc.c \
       drawGeometry.c file_util.c getdata.c getdatabounds.c getdatacolors.c glew.c  \
-      histogram.c infoheader.c \
+      histogram.c infoheader.c readlabel.c readhvac.c \
       IOboundary.c IOgeometry.c IOhvac.c IOiso.c IOobjects.c IOpart.c IOplot2d.c IOplot3d.c \
       IOscript.c IOshooter.c IOslice.c IOsmoke.c IOtour.c IOvolsmoke.c IOwui.c IOzone.c IOframe.o isobox.c \
       main.c md5.c menus.c output.c readsmv.c renderhtml.c renderimage.c scontour2d.c sha1.c \

--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -48,8 +48,9 @@ bin = .
 
 csrc = callbacks.c camera.c color2rgb.c readimage.c readgeom.c readobject.c colortimebar.c compress.c csphere.c dmalloc.c \
       drawGeometry.c file_util.c getdata.c getdatabounds.c getdatacolors.c glew.c  \
-      histogram.c infoheader.c readlabel.c readhvac.c \
+      histogram.c infoheader.c readlabel.c \
       IOboundary.c IOgeometry.c IOhvac.c IOiso.c IOobjects.c IOpart.c IOplot2d.c IOplot3d.c \
+      readhvac.c \
       IOscript.c IOshooter.c IOslice.c IOsmoke.c IOtour.c IOvolsmoke.c IOwui.c IOzone.c IOframe.o isobox.c \
       main.c md5.c menus.c output.c readsmv.c renderhtml.c renderimage.c scontour2d.c sha1.c \
       sha256.c shaders.c showscene.c skybox.c smokestream.c smokeview.c smv_geometry.c startup.c fopen.c \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,8 @@ add_executable(smokeview
     Source/shared/getdata.c
     Source/shared/color2rgb.c
     Source/shared/readimage.c
+    Source/shared/readhvac.c
+    Source/shared/readcad.c
     Source/shared/readgeom.c
     Source/shared/readobject.c
     Source/smokeview/colortable.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,6 @@ add_executable(smokeview
     Source/shared/color2rgb.c
     Source/shared/readimage.c
     Source/shared/readhvac.c
-    Source/shared/readcad.c
     Source/shared/readgeom.c
     Source/shared/readobject.c
     Source/smokeview/colortable.c

--- a/Source/shared/readhvac.c
+++ b/Source/shared/readhvac.c
@@ -1,0 +1,1027 @@
+#include "options_common.h"
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "MALLOCC.h"
+#include "datadefs.h"
+#include "histogram.h"
+#include "isodefs.h"
+#include "string_util.h"
+
+#include "file_util.h"
+#include "stdio_buffer.h"
+
+#include "readhvac.h"
+
+static inline int hvacval(hvacdatacollection *hvaccoll, int itime, int iduct,
+                          int icell) {
+  return (itime)*hvaccoll->hvac_maxcells * hvaccoll->hvac_n_ducts +
+         (iduct)*hvaccoll->hvac_maxcells + (icell);
+}
+
+/* ------------------ GetHVACDuctID ------------------------ */
+
+hvacductdata *GetHVACDuctID(hvacdatacollection *hvaccoll, char *duct_name) {
+  int i;
+
+  for(i = 0; i < hvaccoll->nhvacductinfo; i++) {
+    hvacductdata *ducti;
+
+    ducti = hvaccoll->hvacductinfo + i;
+    if(strcmp(ducti->duct_name, duct_name) == 0) return ducti;
+  }
+  return NULL;
+}
+
+/* ------------------ GetHVACDuctValIndex ------------------------ */
+
+int GetHVACDuctValIndex(hvacdatacollection *hvaccoll, char *shortlabel) {
+  int i;
+
+  for(i = 0; i < hvaccoll->hvacductvalsinfo->n_duct_vars; i++) {
+    hvacvaldata *hi;
+
+    hi = hvaccoll->hvacductvalsinfo->duct_vars + i;
+    if(strcmp(hi->label.shortlabel, shortlabel) == 0) return i;
+  }
+  return -1;
+}
+
+/* ------------------ GetHVACNodeValIndex ------------------------ */
+
+int GetHVACNodeValIndex(hvacdatacollection *hvaccoll, char *shortlabel) {
+  int i;
+
+  for(i = 0; i < hvaccoll->hvacnodevalsinfo->n_node_vars; i++) {
+    hvacvaldata *hi;
+
+    hi = hvaccoll->hvacnodevalsinfo->node_vars + i;
+    if(strcmp(hi->label.shortlabel, shortlabel) == 0) return i;
+  }
+  return -1;
+}
+
+/* ------------------ GetHVACNodeID ------------------------ */
+
+hvacnodedata *GetHVACNodeID(hvacdatacollection *hvaccoll, char *node_name) {
+  int i;
+
+  for(i = 0; i < hvaccoll->nhvacnodeinfo; i++) {
+    hvacnodedata *nodei;
+
+    nodei = hvaccoll->hvacnodeinfo + i;
+    if(strcmp(nodei->duct_name, node_name) == 0) return nodei;
+  }
+  return NULL;
+}
+
+/* ------------------ InitHvacData ------------------------ */
+
+void InitHvacData(hvacvaldata *hi) {
+  hi->vals = NULL;
+  hi->nvals = 0;
+  hi->vis = 0;
+  hi->valmax = 1.0;
+  hi->valmin = 0.0;
+}
+
+/* ------------------ CompareHvacConnect ------------------------ */
+
+int CompareHvacConnect(const void *arg1, const void *arg2) {
+  hvacconnectdata *hi, *hj;
+  int indexi, indexj;
+
+  hi = (hvacconnectdata *)arg1;
+  hj = (hvacconnectdata *)arg2;
+  indexi = hi->index;
+  indexj = hj->index;
+  if(indexi < indexj) return -1;
+  if(indexi > indexj) return 1;
+  return 0;
+}
+
+/* ------------------ IsHVACVisible ------------------------ */
+
+int IsHVACVisible(hvacdatacollection *hvaccoll) {
+  for(int i = 0; i < hvaccoll->nhvacinfo; i++) {
+    hvacdata *hvaci = hvaccoll->hvacinfo + i;
+    if(hvaci->display == 1) return 1;
+  }
+  return 0;
+}
+
+/* ------------------ HaveHVACConnect ------------------------ */
+
+int HaveHVACConnect(int val, hvacconnectdata *vals, int nvals) {
+  int i;
+
+  if(val == -1) return 1;
+  for(i = 0; i < nvals; i++) {
+    if(val == vals[i].index) return 1;
+  }
+  return 0;
+}
+
+/* ------------------ GetHVACPathXYZ ------------------------ */
+
+void GetHVACPathXYZ(float fraction, float *xyzs, int n, float *xyz) {
+  int i;
+  float length = 0.0, lengthf;
+  float length1, length2;
+
+  if(fraction <= 0.0) {
+    memcpy(xyz, xyzs, 3 * sizeof(float));
+    return;
+  }
+  if(fraction >= 1.0) {
+    memcpy(xyz, xyzs + 3 * (n - 1), 3 * sizeof(float));
+    return;
+  }
+  for(i = 0; i < n - 1; i++) {
+    float *x1, *x2;
+    float dx, dy, dz;
+
+    x1 = xyzs + 3 * i;
+    x2 = x1 + 3;
+    dx = x1[0] - x2[0];
+    dy = x1[1] - x2[1];
+    dz = x1[2] - x2[2];
+    length += sqrt(dx * dx + dy * dy + dz * dz);
+  }
+  lengthf = fraction * length;
+  length1 = 0.0;
+  for(i = 0; i < n - 1; i++) {
+    float *x1, *x2;
+    float dx, dy, dz;
+
+    x1 = xyzs + 3 * i;
+    x2 = x1 + 3;
+    dx = x1[0] - x2[0];
+    dy = x1[1] - x2[1];
+    dz = x1[2] - x2[2];
+    length2 = length1 + sqrt(dx * dx + dy * dy + dz * dz);
+    if(lengthf >= length1 && lengthf <= length2) {
+      float f1;
+
+      f1 = 0.5;
+      if(length2 > length1) f1 = (length2 - lengthf) / (length2 - length1);
+      xyz[0] = f1 * x1[0] + (1.0 - f1) * x2[0];
+      xyz[1] = f1 * x1[1] + (1.0 - f1) * x2[1];
+      xyz[2] = f1 * x1[2] + (1.0 - f1) * x2[2];
+      return;
+    }
+    length1 = length2;
+  }
+  memcpy(xyz, xyzs + 3 * (n - 1), 3 * sizeof(float));
+}
+
+/* ------------------ GetCellXYZs ------------------------ */
+
+void GetCellXYZs(float *xyz, int nxyz, int ncells, float **xyz_cellptr,
+                 int *nxyz_cell, int **cell_indptr) {
+  float length, *xyzi;
+  float *fractions, *fractions_cell, *fractions_both;
+  float *xyz_cell;
+  int *cell_ind;
+  int i;
+
+  length = 0.0;
+  xyzi = xyz;
+  NewMemory((void **)&fractions, nxyz * sizeof(float));
+  NewMemory((void **)&fractions_cell, (ncells + 1) * sizeof(float));
+  NewMemory((void **)&fractions_both, (nxyz + ncells + 1) * sizeof(float));
+  fractions[0] = 0.0;
+  for(i = 0; i < nxyz - 1; i++) {
+    float dx, dy, dz, *xyzip1;
+
+    xyzip1 = xyzi + 3;
+    dx = xyzip1[0] - xyzi[0];
+    dy = xyzip1[1] - xyzi[1];
+    dz = xyzip1[2] - xyzi[2];
+    length += sqrt(dx * dx + dy * dy + dz * dz);
+    fractions[i + 1] = length;
+    xyzi += 3;
+  }
+  for(i = 1; i < nxyz - 1; i++) {
+    fractions[i] /= length;
+  }
+  fractions[nxyz - 1] = 1.0;
+
+  fractions_cell[0] = 0.0;
+  for(i = 1; i < ncells; i++) {
+    fractions_cell[i] = (float)i / (float)ncells;
+  }
+  fractions_cell[ncells] = 1.0;
+
+  int i1, i2, nmerge;
+  for(i1 = 0, i2 = 0, nmerge = 0; i1 < nxyz || i2 < ncells;) {
+    if(i1 >= nxyz) {
+      fractions_both[nmerge++] = fractions_cell[i2++];
+      continue;
+    }
+    if(i2 >= ncells) {
+      fractions_both[nmerge++] = fractions[i1++];
+      continue;
+    }
+    if(fractions[i1] < fractions_cell[i2]) {
+      fractions_both[nmerge++] = fractions[i1++];
+      continue;
+    }
+    if(fractions_cell[i2] < fractions[i1]) {
+      fractions_both[nmerge++] = fractions_cell[i2++];
+      continue;
+    }
+    fractions_both[nmerge++] = fractions[i1++];
+    i2++;
+  }
+  *nxyz_cell = nmerge;
+  NewMemory((void **)&xyz_cell, 3 * nmerge * sizeof(float));
+  NewMemory((void **)&cell_ind, nmerge * sizeof(int));
+  *xyz_cellptr = xyz_cell;
+  *cell_indptr = cell_ind;
+  for(i = 0; i < nmerge; i++) {
+    GetHVACPathXYZ(fractions_both[i], xyz, nxyz, xyz_cell + 3 * i);
+  }
+  assert(ncells >= 1);
+  for(i = 0; i < nmerge - 1; i++) {
+    if(ncells > 1) {
+      float frac_avg;
+
+      frac_avg = (fractions_both[i] + fractions_both[i + 1]) / 2.0;
+      cell_ind[i] = CLAMP((int)(frac_avg * (float)ncells), 0, ncells - 1);
+    }
+    else {
+      cell_ind[i] = 0;
+    }
+  }
+  FREEMEMORY(fractions);
+  FREEMEMORY(fractions_cell);
+  FREEMEMORY(fractions_both);
+}
+
+/* ------------------ SetDuctLabelSymbolXYZ ------------------------ */
+
+void SetDuctLabelSymbolXYZ(hvacductdata *ducti) {
+  int j;
+  float *xyz1, *xyz2;
+
+  if(ducti->nxyz_reg == 2) {
+    xyz1 = ducti->node_from->xyz;
+    xyz2 = ducti->node_to->xyz;
+    for(j = 0; j < 3; j++) {
+      ducti->xyz_symbol[j] = 0.50 * xyz1[j] + 0.50 * xyz2[j];
+      ducti->xyz_label[j] = 0.25 * xyz1[j] + 0.75 * xyz2[j];
+    }
+  }
+  else {
+    GetHVACPathXYZ(0.50, ducti->xyz_reg, ducti->nxyz_reg, ducti->xyz_symbol);
+    GetHVACPathXYZ(0.75, ducti->xyz_reg, ducti->nxyz_reg, ducti->xyz_label);
+  }
+}
+
+/* ------------------ SetHVACInfo ------------------------ */
+
+void SetHVACInfo(hvacdatacollection *hvaccoll) {
+  int i;
+
+  if(hvaccoll->hvacconnectinfo == NULL) {
+    NewMemory((void **)&hvaccoll->hvacconnectinfo,
+              (hvaccoll->nhvacnodeinfo + hvaccoll->nhvacductinfo + 1) *
+                  sizeof(hvacconnectdata));
+    hvaccoll->nhvacconnectinfo = 0;
+    for(i = 0; i < hvaccoll->nhvacductinfo; i++) {
+      hvacductdata *ducti;
+
+      ducti = hvaccoll->hvacductinfo + i;
+      if(HaveHVACConnect(ducti->connect_id, hvaccoll->hvacconnectinfo,
+                         hvaccoll->nhvacconnectinfo) == 1)
+        continue;
+      hvaccoll->hvacconnectinfo[hvaccoll->nhvacconnectinfo].index =
+          ducti->connect_id;
+      hvaccoll->hvacconnectinfo[hvaccoll->nhvacconnectinfo].display = 0;
+      hvaccoll->nhvacconnectinfo++;
+    }
+    for(i = 0; i < hvaccoll->nhvacnodeinfo; i++) {
+      hvacnodedata *nodei;
+
+      nodei = hvaccoll->hvacnodeinfo + i;
+      if(HaveHVACConnect(nodei->connect_id, hvaccoll->hvacconnectinfo,
+                         hvaccoll->nhvacconnectinfo) == 1)
+        continue;
+      hvaccoll->hvacconnectinfo[hvaccoll->nhvacconnectinfo].index =
+          nodei->connect_id;
+      hvaccoll->hvacconnectinfo[hvaccoll->nhvacconnectinfo].display = 1;
+      hvaccoll->nhvacconnectinfo++;
+    }
+    if(hvaccoll->nhvacconnectinfo > 0) {
+      ResizeMemory((void **)&hvaccoll->hvacconnectinfo,
+                   hvaccoll->nhvacconnectinfo * sizeof(hvacconnectdata));
+      qsort((int *)hvaccoll->hvacconnectinfo, hvaccoll->nhvacconnectinfo,
+            sizeof(hvacconnectdata), CompareHvacConnect);
+      for(i = 0; i < hvaccoll->nhvacductinfo; i++) {
+        hvacductdata *ducti;
+        int j;
+
+        ducti = hvaccoll->hvacductinfo + i;
+        ducti->connect = NULL;
+        for(j = 0; j < hvaccoll->nhvacconnectinfo; j++) {
+          hvacconnectdata *hj;
+
+          hj = hvaccoll->hvacconnectinfo + j;
+          if(ducti->connect_id == hj->index) {
+            ducti->connect = hj;
+            break;
+          }
+        }
+      }
+      for(i = 0; i < hvaccoll->nhvacnodeinfo; i++) {
+        hvacnodedata *nodei;
+        int j;
+
+        nodei = hvaccoll->hvacnodeinfo + i;
+        nodei->connect = NULL;
+        for(j = 0; j < hvaccoll->nhvacconnectinfo; j++) {
+          hvacconnectdata *hj;
+
+          hj = hvaccoll->hvacconnectinfo + j;
+          if(nodei->connect_id == hj->index) {
+            nodei->connect = hj;
+            break;
+          }
+        }
+      }
+    }
+    else {
+      FREEMEMORY(hvaccoll->hvacconnectinfo);
+    }
+  }
+  for(i = 0; i < hvaccoll->nhvacnodeinfo; i++) {
+    hvacnodedata *nodei;
+
+    nodei = hvaccoll->hvacnodeinfo + i;
+    memcpy(nodei->xyz, nodei->xyz_orig, 3 * sizeof(float));
+  }
+
+  for(i = 0; i < hvaccoll->nhvacductinfo; i++) {
+    int j;
+    hvacductdata *ducti;
+    hvacnodedata *from_i, *to_i;
+    float *xyz_from;
+    float *xyz_to;
+
+    ducti = hvaccoll->hvacductinfo + i;
+    from_i = ducti->node_from;
+    to_i = ducti->node_to;
+    if(from_i == NULL || to_i == NULL) continue;
+    xyz_from = from_i->xyz;
+    xyz_to = to_i->xyz;
+    for(j = 0; j < hvaccoll->nhvacductinfo; j++) {
+      hvacductdata *ductj;
+      hvacnodedata *from_j, *to_j;
+      float diff[3];
+
+      if(i == j) continue;
+      ductj = hvaccoll->hvacductinfo + j;
+      from_j = ductj->node_from;
+      to_j = ductj->node_to;
+      if(from_j == NULL || to_j == NULL) continue;
+      if(from_i != from_j && from_i != to_j && to_i != from_j && to_i != to_j)
+        continue;
+      diff[0] = ABS(xyz_from[0] - xyz_to[0]);
+      diff[1] = ABS(xyz_from[1] - xyz_to[1]);
+      diff[2] = ABS(xyz_from[2] - xyz_to[2]);
+      if(diff[0] < MIN(diff[1], diff[2])) {
+        ducti->metro_path = DUCT_YZX;
+        ductj->metro_path = DUCT_ZYX;
+      }
+      else if(diff[1] < MIN(diff[0], diff[2])) {
+        ducti->metro_path = DUCT_XZY;
+        ductj->metro_path = DUCT_ZXY;
+      }
+      else {
+        ducti->metro_path = DUCT_XYZ;
+        ductj->metro_path = DUCT_YXZ;
+      }
+    }
+  }
+#define COPYVALS3(xyz, x, y, z)                                                \
+  *(xyz + 0) = (x);                                                            \
+  *(xyz + 1) = (y);                                                            \
+  *(xyz + 2) = (z)
+  for(i = 0; i < hvaccoll->nhvacductinfo; i++) {
+    hvacductdata *ducti;
+    hvacnodedata *node_from, *node_to;
+    float *xyz0, *xyz1;
+
+    ducti = hvaccoll->hvacductinfo + i;
+    node_from = hvaccoll->hvacnodeinfo + ducti->node_id_from;
+    node_to = hvaccoll->hvacnodeinfo + ducti->node_id_to;
+    if(node_from == NULL || node_to == NULL) continue;
+    xyz0 = node_from->xyz;
+    xyz1 = node_to->xyz;
+    float *dxyz, *dxyz_metro;
+
+    dxyz = ducti->normal;
+    dxyz_metro = ducti->normal_metro;
+    dxyz[0] = xyz1[0] - xyz0[0];
+    dxyz[1] = xyz1[1] - xyz0[1];
+    dxyz[2] = xyz1[2] - xyz0[2];
+    dxyz_metro[0] = 0.0;
+    dxyz_metro[1] = 0.0;
+    dxyz_metro[2] = 0.0;
+    memcpy(ducti->xyz_symbol_metro, xyz0, 3 * sizeof(float));
+    memcpy(ducti->xyz_label_metro, xyz0, 3 * sizeof(float));
+    memcpy(ducti->xyz_met, xyz0, 3 * sizeof(float));
+    memcpy(ducti->xyz_met + 9, xyz1, 3 * sizeof(float));
+    ducti->nxyz_met = 3;
+    switch(ducti->metro_path) {
+    case DUCT_XYZ:
+      COPYVALS3(ducti->xyz_met + 3, xyz1[0], xyz0[1], xyz0[2]);
+      COPYVALS3(ducti->xyz_met + 6, xyz1[0], xyz1[1], xyz0[2]);
+      if(ABS(dxyz[0]) > ABS(dxyz[1])) {
+        ducti->xyz_symbol_metro[0] += 0.5 * dxyz[0];
+        ducti->xyz_label_metro[0] += 0.75 * dxyz[0];
+        dxyz_metro[0] = 1.0;
+      }
+      else {
+        ducti->xyz_symbol_metro[0] += dxyz[0];
+        ducti->xyz_symbol_metro[1] += 0.5 * dxyz[1];
+        ducti->xyz_label_metro[0] += dxyz[0];
+        ducti->xyz_label_metro[1] += 0.75 * dxyz[1];
+        dxyz_metro[1] = 1.0;
+      }
+      break;
+    case DUCT_XZY:
+      COPYVALS3(ducti->xyz_met + 3, xyz1[0], xyz0[1], xyz0[2]);
+      COPYVALS3(ducti->xyz_met + 6, xyz1[0], xyz0[1], xyz1[2]);
+      if(ABS(dxyz[0]) > ABS(dxyz[2])) {
+        ducti->xyz_symbol_metro[0] += 0.50 * dxyz[0];
+        ducti->xyz_label_metro[0] += 0.75 * dxyz[0];
+        dxyz_metro[0] = 1.0;
+      }
+      else {
+        ducti->xyz_symbol_metro[0] += dxyz[0];
+        ducti->xyz_symbol_metro[2] += 0.5 * dxyz[2];
+        ducti->xyz_label_metro[0] += dxyz[0];
+        ducti->xyz_label_metro[2] += 0.75 * dxyz[2];
+        dxyz_metro[2] = 1.0;
+      }
+      break;
+    case DUCT_YXZ:
+      COPYVALS3(ducti->xyz_met + 3, xyz0[0], xyz1[1], xyz0[2]);
+      COPYVALS3(ducti->xyz_met + 6, xyz1[0], xyz1[1], xyz0[2]);
+      if(ABS(dxyz[1]) > ABS(dxyz[0])) {
+        ducti->xyz_symbol_metro[1] += 0.50 * dxyz[1];
+        ducti->xyz_label_metro[1] += 0.75 * dxyz[1];
+        dxyz_metro[1] = 1.0;
+      }
+      else {
+        ducti->xyz_symbol_metro[0] += 0.50 * dxyz[0];
+        ducti->xyz_symbol_metro[1] += dxyz[1];
+        ducti->xyz_label_metro[0] += 0.75 * dxyz[0];
+        ducti->xyz_label_metro[1] += dxyz[1];
+        dxyz_metro[0] = 1.0;
+      }
+      break;
+    case DUCT_YZX:
+      COPYVALS3(ducti->xyz_met + 3, xyz0[0], xyz1[1], xyz0[2]);
+      COPYVALS3(ducti->xyz_met + 6, xyz0[0], xyz1[1], xyz1[2]);
+      if(ABS(dxyz[1]) > ABS(dxyz[2])) {
+        ducti->xyz_symbol_metro[1] += 0.50 * dxyz[1];
+        ducti->xyz_label_metro[1] += 0.75 * dxyz[1];
+        dxyz_metro[1] = 1.0;
+      }
+      else {
+        ducti->xyz_symbol_metro[1] += dxyz[1];
+        ducti->xyz_symbol_metro[2] += 0.50 * dxyz[2];
+        ducti->xyz_label_metro[1] += dxyz[1];
+        ducti->xyz_label_metro[2] += 0.75 * dxyz[2];
+        dxyz_metro[2] = 1.0;
+      }
+      break;
+    case DUCT_ZXY:
+      COPYVALS3(ducti->xyz_met + 3, xyz0[0], xyz0[1], xyz1[2]);
+      COPYVALS3(ducti->xyz_met + 6, xyz1[0], xyz0[1], xyz1[2]);
+      if(ABS(dxyz[2]) > ABS(dxyz[0])) {
+        ducti->xyz_symbol_metro[2] += 0.50 * dxyz[2];
+        ducti->xyz_label_metro[2] += 0.75 * dxyz[2];
+        dxyz_metro[2] = 1.0;
+      }
+      else {
+        ducti->xyz_symbol_metro[0] += 0.50 * dxyz[0];
+        ducti->xyz_symbol_metro[2] += dxyz[2];
+        ducti->xyz_label_metro[0] += 0.75 * dxyz[0];
+        ducti->xyz_label_metro[2] += dxyz[2];
+        dxyz_metro[0] = 1.0;
+      }
+      break;
+    case DUCT_ZYX:
+      COPYVALS3(ducti->xyz_met + 3, xyz0[0], xyz0[1], xyz1[2]);
+      COPYVALS3(ducti->xyz_met + 6, xyz0[0], xyz1[1], xyz1[2]);
+      if(ABS(dxyz[2]) > ABS(dxyz[1])) {
+        ducti->xyz_symbol_metro[2] += 0.50 * dxyz[2];
+        ducti->xyz_label_metro[2] += 0.75 * dxyz[2];
+        dxyz_metro[2] = 1.0;
+      }
+      else {
+        ducti->xyz_symbol_metro[1] += 0.50 * dxyz[1];
+        ducti->xyz_symbol_metro[2] += dxyz[2];
+        ducti->xyz_label_metro[1] += 0.75 * dxyz[1];
+        ducti->xyz_label_metro[2] += dxyz[2];
+        dxyz_metro[1] = 1.0;
+      }
+      break;
+    default:
+      assert(0);
+      break;
+    }
+    GetCellXYZs(ducti->xyz_reg, ducti->nxyz_reg, ducti->nduct_cells,
+                &ducti->xyz_reg_cell, &ducti->nxyz_reg_cell, &ducti->cell_reg);
+    GetCellXYZs(ducti->xyz_met, ducti->nxyz_met, ducti->nduct_cells,
+                &ducti->xyz_met_cell, &ducti->nxyz_met_cell, &ducti->cell_met);
+  }
+  for(i = 0; i < hvaccoll->nhvacductinfo; i++) {
+    SetDuctLabelSymbolXYZ(hvaccoll->hvacductinfo + i);
+  }
+}
+
+int ReadHVACData0(hvacdatacollection *hvaccoll, int flag,
+                  FILE_SIZE *file_size) {
+  FILE *stream = NULL;
+  float *node_buffer = NULL, *duct_buffer = NULL, *ducttimes, *nodetimes;
+  int max_node_buffer = 0, max_duct_buffer = 0;
+  int parms[4], n_nodes, n_node_vars, n_ducts, n_duct_vars;
+  int frame_size, header_size, nframes;
+  int i, iframe;
+  int *duct_ncells;
+
+  if(hvaccoll->hvacductvalsinfo == NULL) return 1;
+  if(hvaccoll->hvacnodevalsinfo == NULL) return 1;
+  FREEMEMORY(hvaccoll->hvacductvalsinfo->times);
+  FREEMEMORY(hvaccoll->hvacnodevalsinfo->times);
+
+  for(i = 0; i < hvaccoll->hvacductvalsinfo->n_duct_vars; i++) {
+    hvacvaldata *hi;
+
+    hi = hvaccoll->hvacductvalsinfo->duct_vars + i;
+    FREEMEMORY(hi->vals);
+  }
+
+  for(i = 0; i < hvaccoll->hvacnodevalsinfo->n_node_vars; i++) {
+    hvacvaldata *hi;
+
+    hi = hvaccoll->hvacnodevalsinfo->node_vars + i;
+    FREEMEMORY(hi->vals);
+  }
+  hvaccoll->hvacductvalsinfo->loaded = 0;
+  hvaccoll->hvacnodevalsinfo->loaded = 0;
+  if(flag == 1 /*TODO: should be 'UNLOAD'*/) return 2;
+
+  stream = fopen(hvaccoll->hvacductvalsinfo->file, "rb");
+  if(stream == NULL) return 3;
+
+  FSEEK(stream, 4, SEEK_CUR);
+  fread(parms, 4, 4, stream);
+  FSEEK(stream, 4, SEEK_CUR);
+  n_nodes = parms[0];
+  n_node_vars = parms[1];
+  n_ducts = parms[2];
+  n_duct_vars = parms[3];
+  header_size = 4 + 4 * 4 + 4; // n_node_out n_node_vars n_duct_out n_ductd_vars
+  header_size += 4 + 4 * n_ducts + 4; // number of cells in each duct
+  frame_size = 4 + 4 + 4;             // time
+  frame_size += n_nodes * (4 + 4 * n_node_vars + 4); // node data
+  frame_size += n_ducts * (4 + 4 * n_duct_vars + 4); // duct data
+  *file_size = GetFileSizeSMV(hvaccoll->hvacductvalsinfo->file);
+  nframes = (*file_size - header_size) / frame_size;
+
+  NewMemory((void **)&duct_ncells, n_ducts * sizeof(int));
+  FSEEK(stream, 4, SEEK_CUR);
+  fread(duct_ncells, 4, n_ducts, stream);
+  FSEEK(stream, 4, SEEK_CUR);
+
+  FREEMEMORY(hvaccoll->hvacductvalsinfo->times);
+  NewMemory((void **)&hvaccoll->hvacductvalsinfo->times,
+            nframes * sizeof(float));
+  hvaccoll->hvacductvalsinfo->ntimes = nframes;
+
+  FREEMEMORY(hvaccoll->hvacnodevalsinfo->times);
+  NewMemory((void **)&hvaccoll->hvacnodevalsinfo->times,
+            nframes * sizeof(float));
+  hvaccoll->hvacnodevalsinfo->ntimes = nframes;
+
+  hvaccoll->hvac_maxcells = duct_ncells[0];
+  for(i = 1; i < n_ducts; i++) {
+    hvaccoll->hvac_maxcells = MAX(hvaccoll->hvac_maxcells, duct_ncells[i]);
+  }
+  hvaccoll->hvac_n_ducts = n_ducts;
+
+  for(i = 0; i < hvaccoll->hvacductvalsinfo->n_duct_vars; i++) {
+    hvacvaldata *hi;
+
+    hi = hvaccoll->hvacductvalsinfo->duct_vars + i;
+    NewMemory((void **)&hi->vals,
+              n_ducts * hvaccoll->hvac_maxcells * nframes * sizeof(float));
+  }
+  for(i = 0; i < hvaccoll->hvacnodevalsinfo->n_node_vars; i++) {
+    hvacvaldata *hi;
+
+    hi = hvaccoll->hvacnodevalsinfo->node_vars + i;
+    FREEMEMORY(hi->vals);
+    NewMemory((void **)&hi->vals, n_nodes * nframes * sizeof(float));
+  }
+
+  rewind(stream);
+  FSEEK(stream, header_size, SEEK_CUR); // skip over header
+
+  ducttimes = hvaccoll->hvacductvalsinfo->times;
+  nodetimes = hvaccoll->hvacnodevalsinfo->times;
+  for(iframe = 0; iframe < nframes; iframe++) {
+    int j;
+    float time;
+
+    FSEEK(stream, 4, SEEK_CUR);
+    fread(&time, 4, 1, stream);
+    FSEEK(stream, 4, SEEK_CUR);
+    ducttimes[iframe] = time;
+    nodetimes[iframe] = time;
+    if(n_node_vars > max_node_buffer) {
+      FREEMEMORY(node_buffer);
+      NewMemory((void **)&node_buffer, (n_node_vars + 100) * sizeof(float));
+      max_node_buffer = n_node_vars + 100;
+    }
+    for(j = 0; j < n_nodes; j++) {
+      int k;
+
+      FSEEK(stream, 4, SEEK_CUR);
+      fread(node_buffer, 4, n_node_vars, stream);
+      FSEEK(stream, 4, SEEK_CUR);
+      for(k = 0; k < n_node_vars; k++) {
+        hvacvaldata *hk;
+
+        hk = hvaccoll->hvacnodevalsinfo->node_vars + k;
+        hk->vals[iframe + j * nframes] = node_buffer[k];
+      }
+    }
+
+    int iduct;
+    for(iduct = 0; iduct < n_ducts; iduct++) {
+      int ntotalvals;
+
+      ntotalvals = n_duct_vars * duct_ncells[iduct];
+      if(ntotalvals > max_duct_buffer) {
+        FREEMEMORY(duct_buffer);
+        NewMemory((void **)&duct_buffer, (ntotalvals + 100) * sizeof(float));
+        max_duct_buffer = ntotalvals + 100;
+      }
+      int icell;
+      for(icell = 0; icell < duct_ncells[iduct]; icell++) {
+        int ivar;
+
+        FSEEK(stream, 4, SEEK_CUR);
+        fread(duct_buffer, 4, n_duct_vars, stream);
+        FSEEK(stream, 4, SEEK_CUR);
+        for(ivar = 0; ivar < n_duct_vars; ivar++) {
+          hvacvaldata *hk;
+
+          hk = hvaccoll->hvacductvalsinfo->duct_vars + ivar;
+          hk->vals[hvacval(hvaccoll, iframe, iduct, icell)] = duct_buffer[ivar];
+        }
+      }
+    }
+  }
+  fclose(stream);
+  FREEMEMORY(duct_buffer);
+  FREEMEMORY(node_buffer);
+
+  for(i = 0; i < n_node_vars; i++) {
+    hvacvaldata *hi;
+    float *vals;
+    int j;
+
+    hi = hvaccoll->hvacnodevalsinfo->node_vars + i;
+
+    vals = hi->vals;
+    hi->valmin = vals[0];
+    hi->valmax = hi->valmin;
+    for(j = 1; j < nframes * n_nodes; j++) {
+      hi->valmin = MIN(vals[j], hi->valmin);
+      hi->valmax = MAX(vals[j], hi->valmax);
+    }
+  }
+  for(i = 0; i < n_duct_vars; i++) {
+    hvacvaldata *hi;
+    int iduct;
+
+    hi = hvaccoll->hvacductvalsinfo->duct_vars + i;
+
+    hi->valmin = hi->vals[0];
+    hi->valmax = hi->valmin;
+    for(iduct = 0; iduct < n_ducts; iduct++) {
+      int icell;
+
+      for(icell = 0; icell < duct_ncells[iduct]; icell++) {
+        int iframe2;
+
+        for(iframe2 = 0; iframe2 < nframes; iframe2++) {
+          int index;
+
+          index = hvacval(hvaccoll, iframe2, iduct, icell);
+          hi->valmin = MIN(hi->vals[index], hi->valmin);
+          hi->valmax = MAX(hi->vals[index], hi->valmax);
+        }
+      }
+    }
+  }
+  FREEMEMORY(duct_ncells);
+  return 0;
+}
+
+/* ------------------ CompareLabel ------------------------ */
+
+int CompareLabel(const void *arg1, const void *arg2) {
+  char *x, *y;
+
+  x = *(char **)arg1;
+  y = *(char **)arg2;
+
+  return strcmp(x, y);
+}
+
+int ParseHVACEntry(hvacdatacollection *hvaccoll, bufferstreamdata *stream,
+                   int hvac_node_color[3], int hvac_duct_color[3]) {
+  char buffer[256];
+  // HVAC
+  //  NODES
+  //  n_nodes
+  if(FGETS(buffer, 255, stream) == NULL) return 1;
+  if(FGETS(buffer, 255, stream) == NULL) return 1;
+  sscanf(buffer, "%i", &hvaccoll->nhvacnodeinfo);
+  hvaccoll->nhvacnodeinfo = MAX(hvaccoll->nhvacnodeinfo, 0);
+  if(hvaccoll->nhvacnodeinfo == 0) return 2;
+
+  FREEMEMORY(hvaccoll->hvacnodeinfo);
+  NewMemory((void **)&hvaccoll->hvacnodeinfo,
+            hvaccoll->nhvacnodeinfo * sizeof(hvacnodedata));
+
+  // node_id duct_label network_label
+  // x y z filter_flag vent_label
+
+  for(int i = 0; i < hvaccoll->nhvacnodeinfo; i++) {
+    hvacnodedata *nodei;
+    char *filter, *node_label, *network_label, *connect_id;
+
+    nodei = hvaccoll->hvacnodeinfo + i;
+
+    if(FGETS(buffer, 255, stream) == NULL) break;
+    sscanf(buffer, "%i", &nodei->node_id);
+    TrimBack(buffer);
+    strtok(buffer, "%");
+    node_label = strtok(NULL, "%");
+    network_label = strtok(NULL, "%");
+    connect_id = strtok(NULL, "%");
+    nodei->node_name = GetCharPtr(node_label);
+    network_label = TrimFrontBack(network_label);
+    if(strcmp(network_label, "null") == 0) {
+      nodei->network_name = GetCharPtr("Unassigned");
+    }
+    else {
+      nodei->network_name = GetCharPtr(network_label);
+    }
+    nodei->duct = NULL;
+    nodei->connect_id = -1;
+    if(connect_id != NULL) sscanf(connect_id, "%i", &nodei->connect_id);
+
+    if(FGETS(buffer, 255, stream) == NULL) break;
+    sscanf(buffer, "%f %f %f", nodei->xyz, nodei->xyz + 1, nodei->xyz + 2);
+    memcpy(nodei->xyz_orig, nodei->xyz, 3 * sizeof(float));
+    strtok(buffer, "%");
+    filter = strtok(NULL, "%");
+    filter = TrimFrontBack(filter);
+    nodei->filter = HVAC_FILTER_NO;
+    strcpy(nodei->c_filter, "");
+    if(filter != NULL && strcmp(filter, "FILTER") == 0) {
+      nodei->filter = HVAC_FILTER_YES;
+      strcpy(nodei->c_filter, "FI");
+      hvaccoll->nhvacfilters++;
+    }
+  }
+  // DUCTS
+  // n_ducts
+  // duct_id node_id1 node_id2 duct_name network_name
+  // fan_type
+  // duct_name
+  // component Fan(F), Aircoil(A), Damper(D), none(-)
+  // waypoint xyz
+  if(FGETS(buffer, 255, stream) == NULL) return 1;
+  if(FGETS(buffer, 255, stream) == NULL) return 1;
+  sscanf(buffer, "%i", &hvaccoll->nhvacductinfo);
+  hvaccoll->nhvacductinfo = MAX(hvaccoll->nhvacductinfo, 0);
+  if(hvaccoll->nhvacductinfo == 0) {
+    FREEMEMORY(hvaccoll->hvacnodeinfo);
+    hvaccoll->nhvacnodeinfo = 0;
+    return 1;
+  }
+
+  FREEMEMORY(hvaccoll->hvacductinfo);
+  NewMemory((void **)&(hvaccoll->hvacductinfo),
+            hvaccoll->nhvacductinfo * sizeof(hvacductdata));
+  for(int i = 0; i < hvaccoll->nhvacductinfo; i++) {
+    hvacductdata *ducti;
+    char *duct_label, *network_label, *hvac_label, *connect_id;
+
+    ducti = hvaccoll->hvacductinfo + i;
+    if(FGETS(buffer, 255, stream) == NULL) break;
+    sscanf(buffer, "%i %i %i", &ducti->duct_id, &ducti->node_id_from,
+           &ducti->node_id_to);
+    ducti->node_id_from--;
+    ducti->node_id_to--;
+
+    ducti->node_from = hvaccoll->hvacnodeinfo + ducti->node_id_from;
+    ducti->node_to = hvaccoll->hvacnodeinfo + ducti->node_id_to;
+
+    if(ducti->node_from->duct == NULL) ducti->node_from->duct = ducti;
+    if(ducti->node_to->duct == NULL) ducti->node_to->duct = ducti;
+
+    strtok(buffer, "%");
+    duct_label = strtok(NULL, "%");
+    network_label = strtok(NULL, "%");
+    connect_id = strtok(NULL, "%");
+    ducti->duct_name = GetCharPtr(duct_label);
+    network_label = TrimFrontBack(network_label);
+    if(strcmp(network_label, "null") == 0) {
+      ducti->network_name = GetCharPtr("Unassigned");
+    }
+    else {
+      ducti->network_name = GetCharPtr(network_label);
+    }
+    ducti->act_times = NULL;
+    ducti->act_states = NULL;
+    ducti->nact_times = 0;
+    ducti->metro_path = DUCT_XYZ;
+    ducti->connect_id = -1;
+    ducti->xyz_reg = NULL;
+    ducti->cell_met = NULL;
+    ducti->cell_reg = NULL;
+    ducti->nxyz_met = 0;
+    ducti->nxyz_reg = 0;
+    ducti->xyz_met_cell = NULL;
+    ducti->xyz_reg_cell = NULL;
+    ducti->nxyz_met_cell = 0;
+    ducti->nxyz_reg_cell = 0;
+
+    if(connect_id != NULL) sscanf(connect_id, "%i", &ducti->connect_id);
+
+    if(FGETS(buffer, 255, stream) == NULL) break;
+    if(FGETS(buffer, 255, stream) == NULL) break;
+    sscanf(buffer, "%i", &ducti->nduct_cells);
+    strtok(buffer, "%");
+    hvac_label = strtok(NULL, "%");
+    hvac_label = TrimFrontBack(hvac_label);
+
+    char *c_component[4] = {"-", "F", "A", "D"};
+    ducti->component = HVAC_NONE;
+    if(hvac_label != NULL) {
+      if(hvac_label[0] == 'F') ducti->component = HVAC_FAN;
+      if(hvac_label[0] == 'A') ducti->component = HVAC_AIRCOIL;
+      if(hvac_label[0] == 'D') ducti->component = HVAC_DAMPER;
+    }
+    if(ducti->component != HVAC_NONE) hvaccoll->nhvaccomponents++;
+    strcpy(ducti->c_component, c_component[ducti->component]);
+
+    if(FGETS(buffer, 255, stream) == NULL) break;
+    if(FGETS(buffer, 255, stream) == NULL) break;
+    int n_waypoints;
+    sscanf(buffer, "%i", &n_waypoints);
+
+    float *waypoints;
+
+    NewMemory((void **)&waypoints, 3 * (n_waypoints + 2) * sizeof(float));
+    ducti->xyz_reg = waypoints;
+    ducti->nxyz_reg = n_waypoints + 2;
+
+    hvacnodedata *node_from, *node_to;
+    float *xyz0, *xyz1;
+
+    node_from = hvaccoll->hvacnodeinfo + ducti->node_id_from;
+    node_to = hvaccoll->hvacnodeinfo + ducti->node_id_to;
+    xyz0 = node_from->xyz;
+    xyz1 = node_to->xyz;
+
+    memcpy(ducti->xyz_reg, xyz0, 3 * sizeof(float)); // first point
+    memcpy(ducti->xyz_reg + 3 * (n_waypoints + 1), xyz1,
+           3 * sizeof(float)); // last point
+
+    waypoints += 3;
+    for(int j = 0; j < n_waypoints;
+        j++) { // points between first and last point
+      if(FGETS(buffer, 255, stream) == NULL) break;
+      sscanf(buffer, "%f %f %f", waypoints, waypoints + 1, waypoints + 2);
+      waypoints += 3;
+    }
+  }
+  char **hvac_network_labels = NULL;
+
+  NewMemory((void **)&hvac_network_labels,
+            (hvaccoll->nhvacnodeinfo + hvaccoll->nhvacductinfo) *
+                sizeof(char *));
+  for(int i = 0; i < hvaccoll->nhvacnodeinfo; i++) {
+    hvac_network_labels[i] = hvaccoll->hvacnodeinfo[i].network_name;
+  }
+  for(int i = 0; i < hvaccoll->nhvacductinfo; i++) {
+    hvac_network_labels[i + hvaccoll->nhvacnodeinfo] =
+        hvaccoll->hvacductinfo[i].network_name;
+  }
+  qsort((char *)hvac_network_labels,
+        (size_t)(hvaccoll->nhvacnodeinfo + hvaccoll->nhvacductinfo),
+        sizeof(char *), CompareLabel);
+  hvaccoll->nhvacinfo = 1;
+  for(int i = 1; i < hvaccoll->nhvacnodeinfo + hvaccoll->nhvacductinfo; i++) {
+    if(strcmp(hvac_network_labels[hvaccoll->nhvacinfo - 1],
+              hvac_network_labels[i]) == 0)
+      continue;
+    hvac_network_labels[hvaccoll->nhvacinfo] = hvac_network_labels[i];
+    hvaccoll->nhvacinfo++;
+  }
+  NewMemory((void **)&hvaccoll->hvacinfo,
+            hvaccoll->nhvacinfo * sizeof(hvacdata));
+  for(int i = 0; i < hvaccoll->nhvacinfo; i++) {
+    hvacdata *hvaci;
+
+    hvaci = hvaccoll->hvacinfo + i;
+    hvaci->network_name = hvac_network_labels[i];
+    hvaci->display = 0;
+    hvaci->show_node_labels = 0;
+    hvaci->show_duct_labels = 0;
+    hvaci->show_filters = NODE_FILTERS_HIDE;
+    hvaci->show_component = DUCT_COMPONENT_HIDE;
+    hvaci->component_size = 1.0;
+    hvaci->filter_size = 1.0;
+    hvaci->node_size = 8.0;
+    hvaci->cell_node_size = 8.0;
+    hvaci->duct_width = 4.0;
+    memcpy(hvaci->node_color, hvac_node_color, 3 * sizeof(int));
+    memcpy(hvaci->duct_color, hvac_duct_color, 3 * sizeof(int));
+  }
+  FREEMEMORY(hvac_network_labels);
+  SetHVACInfo(hvaccoll);
+  return 0;
+}
+
+int ParseHVACValsEntry(hvacdatacollection *hvaccoll, bufferstreamdata *stream) {
+  char buffer[256];
+  FREEMEMORY(hvaccoll->hvacductvalsinfo);
+  NewMemory((void **)&(hvaccoll->hvacductvalsinfo), sizeof(hvacvalsdata));
+  hvaccoll->hvacductvalsinfo->times = NULL;
+  hvaccoll->hvacductvalsinfo->loaded = 0;
+  hvaccoll->hvacductvalsinfo->node_vars = NULL;
+  hvaccoll->hvacductvalsinfo->duct_vars = NULL;
+
+  if(FGETS(buffer, 255, stream) == NULL) return 1;
+  hvaccoll->hvacductvalsinfo->file = GetCharPtr(TrimFrontBack(buffer));
+
+  if(FGETS(buffer, 255, stream) == NULL) return 1;
+  sscanf(buffer, "%i", &(hvaccoll->hvacductvalsinfo)->n_node_vars);
+
+  if(hvaccoll->hvacductvalsinfo->n_node_vars > 0) {
+    NewMemory((void **)&(hvaccoll->hvacductvalsinfo)->node_vars,
+              hvaccoll->hvacductvalsinfo->n_node_vars * sizeof(hvacvaldata));
+    for(int i = 0; i < hvaccoll->hvacductvalsinfo->n_node_vars; i++) {
+      hvacvaldata *hi;
+      flowlabels *labeli;
+
+      hi = hvaccoll->hvacductvalsinfo->node_vars + i;
+      InitHvacData(hi);
+      labeli = &hi->label;
+      ReadLabels(labeli, stream, NULL);
+    }
+  }
+
+  if(FGETS(buffer, 255, stream) == NULL) return 1;
+  sscanf(buffer, "%i", &hvaccoll->hvacductvalsinfo->n_duct_vars);
+
+  if(hvaccoll->hvacductvalsinfo->n_duct_vars > 0) {
+    NewMemory((void **)&hvaccoll->hvacductvalsinfo->duct_vars,
+              hvaccoll->hvacductvalsinfo->n_duct_vars * sizeof(hvacvaldata));
+    for(int i = 0; i < hvaccoll->hvacductvalsinfo->n_duct_vars; i++) {
+      hvacvaldata *hi;
+      flowlabels *labeli;
+
+      hi = hvaccoll->hvacductvalsinfo->duct_vars + i;
+      InitHvacData(hi);
+      labeli = &hi->label;
+      ReadLabels(labeli, stream, NULL);
+    }
+  }
+  FREEMEMORY(hvaccoll->hvacnodevalsinfo);
+  NewMemory((void **)&hvaccoll->hvacnodevalsinfo, sizeof(hvacvalsdata));
+  memcpy(hvaccoll->hvacnodevalsinfo, hvaccoll->hvacductvalsinfo,
+         sizeof(hvacvalsdata));
+  return 0;
+}

--- a/Source/shared/readhvac.h
+++ b/Source/shared/readhvac.h
@@ -1,0 +1,190 @@
+#ifndef READHVAC_H_DEFINED
+#define READHVAC_H_DEFINED
+
+#include "options_common.h"
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "file_util.h"
+#include "stdio_buffer.h"
+
+#define DUCT_COMPONENT_TEXT 0
+#define DUCT_COMPONENT_SYMBOLS 1
+#define DUCT_COMPONENT_HIDE 2
+
+#define NODE_FILTERS_LABELS 0
+#define NODE_FILTERS_SYMBOLS 1
+#define NODE_FILTERS_HIDE 2
+
+#define DUCT_XYZ 0
+#define DUCT_YXZ 1
+#define DUCT_XZY 2
+#define DUCT_ZXY 3
+#define DUCT_YZX 4
+#define DUCT_ZYX 5
+
+#define HVAC_FILTER_NO 0
+#define HVAC_FILTER_YES 1
+#define HVAC_NONE 0
+#define HVAC_FAN 1
+#define HVAC_AIRCOIL 2
+#define HVAC_DAMPER 3
+
+#define HVAC_STATE_INACTIVE 0
+#define HVAC_STATE_ACTIVE 1
+
+/* --------------------------  hvacconnectdata
+ * ------------------------------------ */
+
+typedef struct hvacconnectdata {
+  int index, display;
+} hvacconnectdata;
+
+/* --------------------------  hvacnodedata ------------------------------------
+ */
+
+typedef struct _hvacnodedata {
+  char *node_name, *vent_name, *duct_name, *network_name;
+  char c_filter[10];
+  int node_id, filter, use_node, connect_id;
+  hvacconnectdata *connect;
+  struct _hvacductdata *duct;
+  float xyz[3], xyz_orig[3];
+} hvacnodedata;
+
+/* --------------------------  hvacductdata ------------------------------------
+ */
+
+typedef struct _hvacductdata {
+  char *duct_name, *network_name, c_component[4];
+  int duct_id, component, nduct_cells;
+  int node_id_from, node_id_to, use_duct, connect_id;
+  hvacconnectdata *connect;
+  int nact_times, *act_states, metro_path;
+  float *act_times;
+  float xyz_symbol[3], xyz_symbol_metro[3];
+  float xyz_label[3], xyz_label_metro[3];
+  float normal[3], normal_metro[3];
+  hvacnodedata *node_from, *node_to;
+  float xyz_met[12], *xyz_reg;
+  int nxyz_met, nxyz_reg;
+  float *xyz_met_cell, *xyz_reg_cell;
+  int nxyz_met_cell, nxyz_reg_cell;
+  int *cell_met, *cell_reg;
+} hvacductdata;
+
+/* --------------------------  hvacdata ------------------------------------ */
+
+typedef struct _hvacdata {
+  char *network_name;
+  int display;
+  int show_node_labels, show_duct_labels;
+  int show_filters, show_component;
+  float cell_node_size, node_size, component_size, duct_width, filter_size;
+  int duct_color[3], node_color[3];
+} hvacdata;
+
+/* --------------------------  hvacvaldata ------------------------------------
+ */
+
+typedef struct _hvacvaldata {
+  float *vals, valmin, valmax;
+  int setvalmin, setvalmax;
+  int vis, nvals;
+  char colorlabels[12][11];
+  float colorvalues[12];
+  float levels256[256];
+  flowlabels label;
+} hvacvaldata;
+
+/* --------------------------  _hvacvalsdata
+ * ------------------------------------ */
+
+typedef struct _hvacvalsdata {
+  char *file;
+  int loaded;
+  int n_node_vars, n_duct_vars, ntimes;
+  float *times;
+  hvacvaldata *node_vars, *duct_vars;
+} hvacvalsdata;
+
+typedef struct {
+  hvacnodedata *hvacnodeinfo;
+  int nhvacnodeinfo;
+  hvacductdata *hvacductinfo;
+  int nhvacductinfo;
+  hvacconnectdata *hvacconnectinfo;
+  int nhvacconnectinfo;
+  hvacdata *hvacinfo;
+  int nhvacinfo;
+
+  int nhvacfilters;
+
+  int nhvaccomponents;
+
+  hvacvalsdata *hvacductvalsinfo;
+  int hvacductvar_index;
+  hvacvalsdata *hvacnodevalsinfo;
+  int hvacnodevar_index;
+
+  int hvac_maxcells;
+  int hvac_n_ducts;
+
+} hvacdatacollection;
+
+hvacductdata *GetHVACDuctID(hvacdatacollection *hvaccoll, char *duct_name);
+int GetHVACDuctValIndex(hvacdatacollection *hvaccoll, char *shortlabel);
+
+hvacnodedata *GetHVACNodeID(hvacdatacollection *hvaccoll, char *node_name);
+int GetHVACNodeValIndex(hvacdatacollection *hvaccoll, char *shortlabel);
+
+void InitHvacData(hvacvaldata *hi);
+
+/**
+ * @brief Are any of the hvac items visible (i.e., have display set to true)?
+ *
+ * @param hvaccoll The HVAC collection.
+ * @return 1 if ANY HVAC item is visible. 0 if NO HVAC item is visible.
+ */
+int IsHVACVisible(hvacdatacollection *hvaccoll);
+
+/**
+ * @brief Parse the definition of HVAC nodes etc. from an *.smv file.
+ *
+ * @param hvaccoll The HVAC collection.
+ * @param stream The stream that is currently being parsed. The position of this
+ * stream should be just after the "HVAC" keyword.
+ * @param hvac_node_color Default HVAC node color
+ * @param hvac_duct_color Default HVAC duct color
+ * @return 0 on success, 1 to break parsing loop, 2 to continue to continue
+ * parsing loop.
+ */
+int ParseHVACEntry(hvacdatacollection *hvaccoll, bufferstreamdata *stream,
+                   int hvac_node_color[3], int hvac_duct_color[3]);
+
+/**
+ * @brief Parse the definition of HVAC values from an *.smv file.
+ *
+ * @param hvaccoll The HVAC collection.
+ * @param stream The stream that is currently being parsed. The position of this
+ * stream should be just after the "HVACVALS" keyword.
+ * @return 0 on success, 1 to break parsing loop, 2 to continue to continue
+ * parsing loop.
+ */
+int ParseHVACValsEntry(hvacdatacollection *hvaccoll, bufferstreamdata *stream);
+
+/**
+ * @brief Parse HVAC value data from a *.hvac file.
+ *
+ * @param[inout] hvaccoll The HVAC collection.
+ * @param[in] flag The flag to control whether we load or unload.
+ * @param[out] file_size A location to output the size of the file.
+ */
+int ReadHVACData0(hvacdatacollection *hvaccoll, int flag, FILE_SIZE *file_size);
+#endif

--- a/Source/shared/string_util.c
+++ b/Source/shared/string_util.c
@@ -35,6 +35,22 @@
 
 unsigned int *random_ints, nrandom_ints;
 
+/* ------------------ GetCharPtr ------------------------ */
+
+char *GetCharPtr(char *label) {
+  char *labelptr, labelcopy[256], *labelcopyptr;
+  int lenlabel;
+
+  if (label == NULL || strlen(label) == 0) return NULL;
+  strcpy(labelcopy, label);
+  labelcopyptr = TrimFrontBack(labelcopy);
+  lenlabel = strlen(labelcopyptr);
+  if (lenlabel == 0) return NULL;
+  NewMemory((void **)&labelptr, lenlabel + 1);
+  strcpy(labelptr, labelcopyptr);
+  return labelptr;
+}
+
 /* ----------------------- AppendString ----------------------------- */
 
 char *AppendString(char *S1, char *S2){

--- a/Source/shared/string_util.h
+++ b/Source/shared/string_util.h
@@ -84,7 +84,8 @@ typedef struct {
 #endif
 
 // vvvvvvvvvvvvvvvvvvvvvvvv headers vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-
+EXTERNCPP char          *GetCharPtr(char *label);
+EXTERNCPP char          *GetStringPtr(char *buffer);
 EXTERNCPP char          *GetStringPtr(char *buffer);
 EXTERNCPP char          *GetFloatLabel(float val, char *label);
 EXTERNCPP char          *GetIntLabel(int val, char *label);

--- a/Source/smokeview/IOhvac.c
+++ b/Source/smokeview/IOhvac.c
@@ -9,6 +9,8 @@
 #include "smokeviewvars.h"
 #include "IOobjects.h"
 
+#include "readhvac.h"
+
 #define HVACVAL(itime, iduct, icell) \
   (itime)*hvac_maxcells*hvac_n_ducts + (iduct)*hvac_maxcells + (icell)
 
@@ -18,212 +20,6 @@ unsigned char *hvac_color_states[2] = {hvac_off_color, hvac_on_color};
 
 #define NODE_XYZ 0.1
 
-/* ------------------ CompareHvacConnect ------------------------ */
-
-int CompareHvacConnect(const void *arg1, const void *arg2){
-  hvacconnectdata *hi, *hj;
-  int indexi, indexj;
-
-  hi = (hvacconnectdata *)arg1;
-  hj = (hvacconnectdata *)arg2;
-  indexi = hi->index;
-  indexj = hj->index;
-  if(indexi < indexj)return -1;
-  if(indexi > indexj)return 1;
-  return 0;
-}
-
-/* ------------------ IsHVACVisible ------------------------ */
-
-int IsHVACVisible(void){
-  int i;
-
-  for(i = 0; i < nhvacinfo; i++){
-    hvacdata *hvaci;
-
-    hvaci = hvacinfo + i;
-    if(hvaci->display == 1)return 1;
-  }
-  return 0;
-}
-
-/* ------------------ HaveHVACConnect ------------------------ */
-
-int HaveHVACConnect(int val, hvacconnectdata *vals, int nvals){
-  int i;
-
-  if(val == -1)return 1;
-  for(i = 0;i < nvals;i++){
-    if(val == vals[i].index)return 1;
-  }
-  return 0;
-}
-
-/* ------------------ GetHVACPathXYZ ------------------------ */
-
-void GetHVACPathXYZ(float fraction, float *xyzs, int n, float *xyz){
-  int i;
-  float length=0.0, lengthf;
-  float length1, length2;
-
-  if(fraction<=0.0){
-    memcpy(xyz, xyzs, 3*sizeof(float));
-    return;
-  }
-  if(fraction>=1.0){
-    memcpy(xyz, xyzs+3*(n-1), 3*sizeof(float));
-    return;
-  }
-  for(i=0; i<n-1; i++){
-    float *x1, *x2;
-    float dx, dy, dz;
-
-    x1 = xyzs+3*i;
-    x2 = x1 + 3;
-    dx = x1[0] - x2[0];
-    dy = x1[1] - x2[1];
-    dz = x1[2] - x2[2];
-    length += sqrt(dx*dx+dy*dy+dz*dz);
-  }
-  lengthf = fraction*length;
-  length1 = 0.0;
-  for(i=0; i<n-1; i++){
-    float *x1, *x2;
-    float dx, dy, dz;
-
-    x1 = xyzs+3*i;
-    x2 = x1 + 3;
-    dx = x1[0] - x2[0];
-    dy = x1[1] - x2[1];
-    dz = x1[2] - x2[2];
-    length2 =length1 +  sqrt(dx*dx+dy*dy+dz*dz);
-    if(lengthf>=length1&&lengthf<=length2){
-      float f1;
-
-      f1 = 0.5;
-      if(length2>length1)f1 = (length2-lengthf)/(length2-length1);
-      xyz[0] = f1*x1[0] + (1.0-f1)*x2[0];
-      xyz[1] = f1*x1[1] + (1.0-f1)*x2[1];
-      xyz[2] = f1*x1[2] + (1.0-f1)*x2[2];
-      return;
-    }
-    length1 = length2;
-  }
-  memcpy(xyz, xyzs+3*(n-1), 3*sizeof(float));
-}
-
-/* ------------------ GetCellXYZs ------------------------ */
-
-void GetCellXYZs(float *xyz, int nxyz, int ncells, float **xyz_cellptr, int *nxyz_cell, int **cell_indptr){
-  float length, *xyzi;
-  float *fractions, *fractions_cell, *fractions_both;
-  float *xyz_cell;
-  int *cell_ind;
-  int i;
-
-  length = 0.0;
-  xyzi = xyz;
-  NewMemory((void **)&fractions, nxyz*sizeof(float));
-  NewMemory((void **)&fractions_cell, (ncells+1)*sizeof(float));
-  NewMemory((void **)&fractions_both, (nxyz+ncells+1)*sizeof(float));
-  fractions[0] = 0.0;
-  for(i = 0;i < nxyz-1;i++){
-    float dx, dy, dz, *xyzip1;
-
-    xyzip1 = xyzi + 3;
-    dx = xyzip1[0] - xyzi[0];
-    dy = xyzip1[1] - xyzi[1];
-    dz = xyzip1[2] - xyzi[2];
-    length += sqrt(dx*dx + dy*dy + dz*dz);
-    fractions[i+1] = length;
-    xyzi += 3;
-  }
-  for(i = 1;i < nxyz-1;i++){
-    fractions[i] /= length;
-  }
-  fractions[nxyz-1] = 1.0;
-
-  fractions_cell[0]      = 0.0;
-  for(i=1;i<ncells;i++){
-    fractions_cell[i]=(float)i/(float)ncells;
-  }
-  fractions_cell[ncells] = 1.0;
-
-  int i1, i2, nmerge;
-  for(i1=0,i2=0,nmerge=0;i1<nxyz||i2<ncells;){
-    if(i1>=nxyz){
-      fractions_both[nmerge++] = fractions_cell[i2++];
-      continue;
-    }
-    if(i2>=ncells){
-      fractions_both[nmerge++] = fractions[i1++];
-      continue;
-    }
-    if(fractions[i1]<fractions_cell[i2]){
-      fractions_both[nmerge++] = fractions[i1++];
-      continue;
-    }
-    if(fractions_cell[i2]<fractions[i1]){
-      fractions_both[nmerge++] = fractions_cell[i2++];
-      continue;
-    }
-    fractions_both[nmerge++] = fractions[i1++];
-    i2++;
-  }
-  *nxyz_cell = nmerge;
-  NewMemory((void **)&xyz_cell, 3*nmerge*sizeof(float));
-  NewMemory((void **)&cell_ind, nmerge*sizeof(int));
-  *xyz_cellptr = xyz_cell;
-  *cell_indptr = cell_ind;
-  for(i = 0;i < nmerge;i++){
-    GetHVACPathXYZ(fractions_both[i], xyz, nxyz, xyz_cell + 3*i);
-  }
-  assert(ncells >= 1);
-  for(i = 0;i < nmerge-1;i++){
-    if(ncells > 1){
-      float frac_avg;
-
-      frac_avg = (fractions_both[i] + fractions_both[i + 1]) / 2.0;
-      cell_ind[i] = CLAMP((int)(frac_avg * (float)ncells), 0, ncells - 1);
-    }
-    else{
-      cell_ind[i] = 0;
-    }
-  }
-  FREEMEMORY(fractions);
-  FREEMEMORY(fractions_cell);
-  FREEMEMORY(fractions_both);
-}
-
-/* ------------------ SetDuctLabelSymbolXYZ ------------------------ */
-
-void SetDuctLabelSymbolXYZ(hvacductdata *ducti){
-  int j;
-  float *xyz1, *xyz2;
-
-  if(ducti->nxyz_reg == 2){
-    xyz1 = ducti->node_from->xyz;
-    xyz2 = ducti->node_to->xyz;
-    for(j = 0;j < 3;j++){
-      ducti->xyz_symbol[j] = 0.50 * xyz1[j] + 0.50 * xyz2[j];
-      ducti->xyz_label[j]  = 0.25 * xyz1[j] + 0.75 * xyz2[j];
-    }
-  }
-  else{
-    GetHVACPathXYZ(0.50, ducti->xyz_reg, ducti->nxyz_reg, ducti->xyz_symbol);
-    GetHVACPathXYZ(0.75, ducti->xyz_reg, ducti->nxyz_reg, ducti->xyz_label);
-  }
-}
-
-/* ------------------ InitHvacData ------------------------ */
-
-void InitHvacData(hvacvaldata *hi){
-  hi->vals   = NULL;
-  hi->nvals  = 0;
-  hi->vis    = 0;
-  hi->valmax = 1.0;
-  hi->valmin = 0.0;
-}
 
 /* ------------------ UpdateHVACDuctColorLabels ------------------------ */
 
@@ -232,7 +28,7 @@ void UpdateHVACDuctColorLabels(int index){
   int set_valmin, set_valmax;
   float valmin, valmax;
 
-  hi = hvacductvalsinfo->duct_vars + index;
+  hi = hvaccoll.hvacductvalsinfo->duct_vars + index;
   GLUIGetMinMax(BOUND_HVACDUCT, hi->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
   GetColorbarLabels(valmin, valmax, nrgb, hi->colorlabels, hi->levels256);
 }
@@ -244,7 +40,7 @@ void UpdateHVACNodeColorLabels(int index){
   int set_valmin, set_valmax;
   float valmin, valmax;
 
-  hi = hvacnodevalsinfo->node_vars + index;
+  hi = hvaccoll.hvacnodevalsinfo->node_vars + index;
   GLUIGetMinMax(BOUND_HVACNODE, hi->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
   GetColorbarLabels(valmin, valmax, nrgb, hi->colorlabels, hi->levels256);
 }
@@ -254,21 +50,21 @@ void UpdateHVACNodeColorLabels(int index){
 void UpdateAllHVACColorLabels(void){
   int i;
 
-  for(i = 0; i < hvacductvalsinfo->n_duct_vars; i++){
+  for(i = 0; i < hvaccoll.hvacductvalsinfo->n_duct_vars; i++){
     hvacvaldata *hi;
     int set_valmin, set_valmax;
     float valmin, valmax;
 
-    hi = hvacductvalsinfo->duct_vars + i;
+    hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
     GLUIGetMinMax(BOUND_HVACDUCT, hi->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
     GetColorbarLabels(hi->valmin, hi->valmax, nrgb, hi->colorlabels, hi->levels256);
   }
-  for(i = 0; i < hvacnodevalsinfo->n_node_vars; i++){
+  for(i = 0; i < hvaccoll.hvacnodevalsinfo->n_node_vars; i++){
     hvacvaldata *hi;
     int set_valmin, set_valmax;
     float valmin, valmax;
 
-    hi = hvacnodevalsinfo->node_vars + i;
+    hi = hvaccoll.hvacnodevalsinfo->node_vars + i;
     GLUIGetMinMax(BOUND_HVACNODE, hi->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
     GetColorbarLabels(valmin, valmax, nrgb, hi->colorlabels, hi->levels256);
   }
@@ -277,185 +73,13 @@ void UpdateAllHVACColorLabels(void){
 /* ------------------ ReadHVACData ------------------------ */
 
 void ReadHVACData(int flag){
-  FILE *stream = NULL;
-  float *node_buffer = NULL, *duct_buffer = NULL, *ducttimes, *nodetimes;
-  int max_node_buffer = 0, max_duct_buffer = 0;
-  int parms[4], n_nodes, n_node_vars, n_ducts, n_duct_vars;
-  int frame_size, header_size, nframes;
-  FILE_SIZE file_size;
-  int i, iframe;
-  int *duct_ncells;
   float total_time;
+  FILE_SIZE file_size;
 
   if(flag == LOAD){
     START_TIMER(total_time);
   }
-  if(hvacductvalsinfo == NULL)return;
-  if(hvacnodevalsinfo == NULL)return;
-  FREEMEMORY(hvacductvalsinfo->times);
-  FREEMEMORY(hvacnodevalsinfo->times);
-
-  for(i = 0;i < hvacductvalsinfo->n_duct_vars;i++){
-    hvacvaldata *hi;
-
-    hi = hvacductvalsinfo->duct_vars + i;
-    FREEMEMORY(hi->vals);
-  }
-
-  for(i = 0;i < hvacnodevalsinfo->n_node_vars;i++){
-    hvacvaldata *hi;
-
-    hi = hvacnodevalsinfo->node_vars + i;
-    FREEMEMORY(hi->vals);
-  }
-  hvacductvalsinfo->loaded = 0;
-  hvacnodevalsinfo->loaded = 0;
-  if(flag==UNLOAD)return;
-
-  stream = fopen(hvacductvalsinfo->file, "rb");
-  if(stream == NULL)return;
-
-  FSEEK(stream, 4, SEEK_CUR); fread(parms, 4, 4, stream); FSEEK(stream, 4, SEEK_CUR);
-  n_nodes      = parms[0];
-  n_node_vars  = parms[1];
-  n_ducts      = parms[2];
-  n_duct_vars  = parms[3];
-  header_size  = 4 + 4 * 4 + 4;                       // n_node_out n_node_vars n_duct_out n_ductd_vars
-  header_size += 4 + 4 * n_ducts + 4;                 // number of cells in each duct
-  frame_size   = 4 + 4 + 4;                           // time
-  frame_size  += n_nodes * (4 + 4 * n_node_vars + 4); // node data
-  frame_size  += n_ducts * (4 + 4 * n_duct_vars + 4); // duct data
-  file_size    = GetFileSizeSMV(hvacductvalsinfo->file);
-  nframes      = (file_size - header_size) / frame_size;
-
-  NewMemory((void **)&duct_ncells, n_ducts * sizeof(int));
-  FSEEK(stream, 4, SEEK_CUR); fread(duct_ncells, 4, n_ducts, stream); FSEEK(stream, 4, SEEK_CUR);
-
-  FREEMEMORY(hvacductvalsinfo->times);
-  NewMemory((void **)&hvacductvalsinfo->times, nframes * sizeof(float));
-  hvacductvalsinfo->ntimes = nframes;
-
-  FREEMEMORY(hvacnodevalsinfo->times);
-  NewMemory((void **)&hvacnodevalsinfo->times, nframes * sizeof(float));
-  hvacnodevalsinfo->ntimes = nframes;
-
-  hvac_maxcells = duct_ncells[0];
-  for(i=1;i<n_ducts;i++){
-    hvac_maxcells = MAX(hvac_maxcells, duct_ncells[i]);
-  }
-  hvac_n_ducts   = n_ducts;
-
-  for(i = 0;i < hvacductvalsinfo->n_duct_vars;i++){
-    hvacvaldata *hi;
-
-    hi = hvacductvalsinfo->duct_vars + i;
-    NewMemory((void **)&hi->vals, n_ducts*hvac_maxcells*nframes * sizeof(float));
-  }
-  for(i = 0;i < hvacnodevalsinfo->n_node_vars;i++){
-    hvacvaldata *hi;
-
-    hi = hvacnodevalsinfo->node_vars + i;
-    FREEMEMORY(hi->vals);
-    NewMemory((void **)&hi->vals, n_nodes*nframes * sizeof(float));
-  }
-
-  rewind(stream);
-  FSEEK(stream, header_size, SEEK_CUR); // skip over header
-
-  ducttimes = hvacductvalsinfo->times;
-  nodetimes = hvacnodevalsinfo->times;
-  for(iframe=0;iframe<nframes;iframe++){
-    int j;
-    float time;
-
-    FSEEK(stream, 4, SEEK_CUR); fread(&time, 4, 1, stream); FSEEK(stream, 4, SEEK_CUR);
-    ducttimes[iframe] = time;
-    nodetimes[iframe] = time;
-    if(n_node_vars > max_node_buffer){
-      FREEMEMORY(node_buffer);
-      NewMemory((void **)&node_buffer, (n_node_vars+100) * sizeof(float));
-      max_node_buffer = n_node_vars + 100;
-    }
-    for(j = 0;j < n_nodes;j++){
-      int k;
-
-      FSEEK(stream, 4, SEEK_CUR); fread(node_buffer, 4, n_node_vars, stream); FSEEK(stream, 4, SEEK_CUR);
-      for(k=0;k<n_node_vars;k++){
-        hvacvaldata *hk;
-
-        hk = hvacnodevalsinfo->node_vars + k;
-        hk->vals[iframe + j * nframes] = node_buffer[k];
-      }
-    }
-
-    int iduct;
-    for(iduct = 0;iduct < n_ducts;iduct++){
-      int ntotalvals;
-
-      ntotalvals = n_duct_vars*duct_ncells[iduct];
-      if(ntotalvals > max_duct_buffer){
-        FREEMEMORY(duct_buffer);
-        NewMemory((void **)&duct_buffer, (ntotalvals + 100) * sizeof(float));
-        max_duct_buffer = ntotalvals + 100;
-      }
-      int icell;
-      for(icell = 0;icell < duct_ncells[iduct];icell++){
-        int ivar;
-
-        FSEEK(stream, 4, SEEK_CUR); fread(duct_buffer, 4, n_duct_vars, stream); FSEEK(stream, 4, SEEK_CUR);
-        for(ivar = 0;ivar < n_duct_vars;ivar++){
-          hvacvaldata *hk;
-
-          hk = hvacductvalsinfo->duct_vars + ivar;
-          hk->vals[HVACVAL(iframe,iduct,icell)] = duct_buffer[ivar];
-        }
-      }
-    }
-  }
-  fclose(stream);
-  FREEMEMORY(duct_buffer);
-  FREEMEMORY(node_buffer);
-
-  for(i = 0;i < n_node_vars;i++){
-    hvacvaldata *hi;
-    float *vals;
-    int j;
-
-    hi = hvacnodevalsinfo->node_vars+i;
-
-    vals = hi->vals;
-    hi->valmin = vals[0];
-    hi->valmax = hi->valmin;
-    for(j=1;j<nframes*n_nodes;j++){
-      hi->valmin = MIN(vals[j],hi->valmin);
-      hi->valmax = MAX(vals[j],hi->valmax);
-    }
-  }
-  for(i = 0;i < n_duct_vars;i++){
-    hvacvaldata *hi;
-    int iduct;
-
-    hi = hvacductvalsinfo->duct_vars+i;
-
-    hi->valmin = hi->vals[0];
-    hi->valmax = hi->valmin;
-    for(iduct=0;iduct<n_ducts;iduct++){
-      int icell;
-
-      for(icell=0;icell<duct_ncells[iduct];icell++){
-	      int iframe2;
-
-        for(iframe2=0;iframe2<nframes;iframe2++){
-          int index;
-
-          index = HVACVAL(iframe2, iduct, icell);
-          hi->valmin = MIN(hi->vals[index],hi->valmin);
-          hi->valmax = MAX(hi->vals[index],hi->valmax);
-        }
-      }
-    }
-  }
-  FREEMEMORY(duct_ncells);
+  ReadHVACData0(&hvaccoll,flag, &file_size);
   if(flag == LOAD){
     UpdateAllHVACColorLabels();
     GetGlobalHVACNodeBounds(1);
@@ -464,7 +88,7 @@ void ReadHVACData(int flag){
     GLUISetValTypeIndex(BOUND_HVACDUCT, 0);
 
     STOP_TIMER(total_time);
-    PRINTF("Loading %s", hvacductvalsinfo->file);
+    PRINTF("Loading %s", hvaccoll.hvacductvalsinfo->file);
     if(file_size > 1000000000){
       PRINTF(" - %.1f GB/%.1f s\n", (float)file_size / 1000000000., total_time);
     }
@@ -474,265 +98,10 @@ void ReadHVACData(int flag){
     else{
       PRINTF(" - %.0f KB/%.1f s\n", (float)file_size / 1000., total_time);
     }
-    hvacductvalsinfo->loaded = 1;
+    hvaccoll.hvacductvalsinfo->loaded = 1;
   }
   if(flag == BOUNDS_ONLY){
     ReadHVACData(UNLOAD);
-  }
-}
-
-/* ------------------ SetHVACInfo ------------------------ */
-
-void SetHVACInfo(void){
-  int i;
-
-  if(hvacconnectinfo == NULL){
-    NewMemory((void **)&hvacconnectinfo, (nhvacnodeinfo+nhvacductinfo+1)*sizeof(hvacconnectdata));
-    nhvacconnectinfo = 0;
-    for(i = 0;i < nhvacductinfo;i++){
-      hvacductdata *ducti;
-
-      ducti = hvacductinfo + i;
-      if(HaveHVACConnect(ducti->connect_id, hvacconnectinfo, nhvacconnectinfo) == 1)continue;
-      hvacconnectinfo[nhvacconnectinfo].index = ducti->connect_id;
-      hvacconnectinfo[nhvacconnectinfo].display = 0;
-      nhvacconnectinfo++;
-    }
-    for(i = 0;i < nhvacnodeinfo;i++){
-      hvacnodedata *nodei;
-
-      nodei = hvacnodeinfo + i;
-      if(HaveHVACConnect(nodei->connect_id, hvacconnectinfo, nhvacconnectinfo) == 1)continue;
-      hvacconnectinfo[nhvacconnectinfo].index = nodei->connect_id;
-      hvacconnectinfo[nhvacconnectinfo].display = 1;
-      nhvacconnectinfo++;
-    }
-    if(nhvacconnectinfo > 0){
-      ResizeMemory((void **)&hvacconnectinfo, nhvacconnectinfo * sizeof(hvacconnectdata));
-      qsort((int *)hvacconnectinfo, nhvacconnectinfo, sizeof(hvacconnectdata), CompareHvacConnect);
-      for(i = 0;i < nhvacductinfo;i++){
-        hvacductdata *ducti;
-        int j;
-
-        ducti = hvacductinfo + i;
-        ducti->connect = NULL;
-        for(j = 0;j<nhvacconnectinfo;j++){
-          hvacconnectdata *hj;
-
-          hj = hvacconnectinfo + j;
-          if(ducti->connect_id == hj->index){
-            ducti->connect = hj;
-            break;
-          }
-        }
-      }
-      for(i = 0;i < nhvacnodeinfo;i++){
-        hvacnodedata *nodei;
-        int j;
-
-        nodei = hvacnodeinfo + i;
-        nodei->connect = NULL;
-        for(j = 0;j<nhvacconnectinfo;j++){
-          hvacconnectdata *hj;
-
-          hj = hvacconnectinfo + j;
-          if(nodei->connect_id == hj->index){
-            nodei->connect = hj;
-            break;
-          }
-        }
-      }
-    }
-    else{
-      FREEMEMORY(hvacconnectinfo);
-    }
-  }
-  for(i = 0;i < nhvacnodeinfo;i++){
-    hvacnodedata *nodei;
-
-    nodei = hvacnodeinfo + i;
-    memcpy(nodei->xyz, nodei->xyz_orig, 3*sizeof(float));
-  }
-
-  for(i = 0;i < nhvacductinfo;i++){
-    int j;
-    hvacductdata *ducti;
-    hvacnodedata *from_i, *to_i;
-    float *xyz_from;
-    float *xyz_to;
-
-    ducti  = hvacductinfo + i;
-    from_i = ducti->node_from;
-    to_i   = ducti->node_to;
-    if(from_i == NULL || to_i == NULL)continue;
-    xyz_from = from_i->xyz;
-    xyz_to   = to_i->xyz;
-    for(j = 0;j < nhvacductinfo;j++){
-      hvacductdata *ductj;
-      hvacnodedata *from_j, *to_j;
-      float diff[3];
-
-      if(i == j)continue;
-      ductj = hvacductinfo + j;
-      from_j = ductj->node_from;
-      to_j   = ductj->node_to;
-      if(from_j == NULL || to_j == NULL)continue;
-      if(from_i != from_j && from_i != to_j && to_i != from_j && to_i != to_j)continue;
-      diff[0] = ABS(xyz_from[0] - xyz_to[0]);
-      diff[1] = ABS(xyz_from[1] - xyz_to[1]);
-      diff[2] = ABS(xyz_from[2] - xyz_to[2]);
-      if(diff[0] < MIN(diff[1], diff[2])){
-        ducti->metro_path = DUCT_YZX;
-        ductj->metro_path = DUCT_ZYX;
-      }
-      else if(diff[1] < MIN(diff[0], diff[2])){
-        ducti->metro_path = DUCT_XZY;
-        ductj->metro_path = DUCT_ZXY;
-      }
-      else{
-        ducti->metro_path = DUCT_XYZ;
-        ductj->metro_path = DUCT_YXZ;
-      }
-    }
-  }
-#define COPYVALS3(xyz, x, y, z) \
-  *(xyz+0) = (x);\
-  *(xyz+1) = (y);\
-  *(xyz+2) = (z)
-  for(i=0;i<nhvacductinfo;i++){
-    hvacductdata *ducti;
-    hvacnodedata *node_from, *node_to;
-    float *xyz0, *xyz1;
-
-    ducti = hvacductinfo + i;
-    node_from = hvacnodeinfo + ducti->node_id_from;
-    node_to = hvacnodeinfo + ducti->node_id_to;
-    if(node_from == NULL || node_to == NULL)continue;
-    xyz0 = node_from->xyz;
-    xyz1 = node_to->xyz;
-    float *dxyz, *dxyz_metro;
-
-    dxyz = ducti->normal;
-    dxyz_metro = ducti->normal_metro;
-    dxyz[0] = xyz1[0] - xyz0[0];
-    dxyz[1] = xyz1[1] - xyz0[1];
-    dxyz[2] = xyz1[2] - xyz0[2];
-    dxyz_metro[0] = 0.0;
-    dxyz_metro[1] = 0.0;
-    dxyz_metro[2] = 0.0;
-    memcpy(ducti->xyz_symbol_metro, xyz0, 3 * sizeof(float));
-    memcpy(ducti->xyz_label_metro,  xyz0, 3 * sizeof(float));
-    memcpy(ducti->xyz_met,          xyz0, 3 * sizeof(float));
-    memcpy(ducti->xyz_met+9,        xyz1, 3 * sizeof(float));
-    ducti->nxyz_met = 3;
-    switch(ducti->metro_path){
-      case DUCT_XYZ:
-        COPYVALS3(ducti->xyz_met + 3, xyz1[0], xyz0[1], xyz0[2]);
-        COPYVALS3(ducti->xyz_met + 6, xyz1[0], xyz1[1], xyz0[2]);
-        if(ABS(dxyz[0]) > ABS(dxyz[1])){
-          ducti->xyz_symbol_metro[0] += 0.5*dxyz[0];
-          ducti->xyz_label_metro[0]  += 0.75*dxyz[0];
-          dxyz_metro[0] = 1.0;
-        }
-        else{
-          ducti->xyz_symbol_metro[0] += dxyz[0];
-          ducti->xyz_symbol_metro[1] += 0.5*dxyz[1];
-          ducti->xyz_label_metro[0]  += dxyz[0];
-          ducti->xyz_label_metro[1]  += 0.75*dxyz[1];
-          dxyz_metro[1] = 1.0;
-        }
-        break;
-      case DUCT_XZY:
-        COPYVALS3(ducti->xyz_met + 3, xyz1[0], xyz0[1], xyz0[2]);
-        COPYVALS3(ducti->xyz_met + 6, xyz1[0], xyz0[1], xyz1[2]);
-        if(ABS(dxyz[0]) > ABS(dxyz[2])){
-          ducti->xyz_symbol_metro[0] += 0.50*dxyz[0];
-          ducti->xyz_label_metro[0]  += 0.75*dxyz[0];
-          dxyz_metro[0] = 1.0;
-        }
-        else{
-          ducti->xyz_symbol_metro[0] += dxyz[0];
-          ducti->xyz_symbol_metro[2] += 0.5*dxyz[2];
-          ducti->xyz_label_metro[0]  += dxyz[0];
-          ducti->xyz_label_metro[2]  += 0.75*dxyz[2];
-          dxyz_metro[2] = 1.0;
-        }
-        break;
-      case DUCT_YXZ:
-        COPYVALS3(ducti->xyz_met + 3, xyz0[0], xyz1[1], xyz0[2]);
-        COPYVALS3(ducti->xyz_met + 6, xyz1[0], xyz1[1], xyz0[2]);
-        if(ABS(dxyz[1]) > ABS(dxyz[0])){
-          ducti->xyz_symbol_metro[1] += 0.50*dxyz[1];
-          ducti->xyz_label_metro[1]  += 0.75*dxyz[1];
-          dxyz_metro[1] = 1.0;
-        }
-        else{
-          ducti->xyz_symbol_metro[0] += 0.50*dxyz[0];
-          ducti->xyz_symbol_metro[1] += dxyz[1];
-          ducti->xyz_label_metro[0]  += 0.75*dxyz[0];
-          ducti->xyz_label_metro[1]  += dxyz[1];
-          dxyz_metro[0] = 1.0;
-        }
-        break;
-      case DUCT_YZX:
-        COPYVALS3(ducti->xyz_met + 3, xyz0[0], xyz1[1], xyz0[2]);
-        COPYVALS3(ducti->xyz_met + 6, xyz0[0], xyz1[1], xyz1[2]);
-        if(ABS(dxyz[1]) > ABS(dxyz[2])){
-          ducti->xyz_symbol_metro[1] += 0.50*dxyz[1];
-          ducti->xyz_label_metro[1]  += 0.75*dxyz[1];
-          dxyz_metro[1] = 1.0;
-        }
-        else{
-          ducti->xyz_symbol_metro[1] += dxyz[1];
-          ducti->xyz_symbol_metro[2] += 0.50*dxyz[2];
-          ducti->xyz_label_metro[1]  += dxyz[1];
-          ducti->xyz_label_metro[2]  += 0.75*dxyz[2];
-          dxyz_metro[2] = 1.0;
-        }
-        break;
-      case DUCT_ZXY:
-        COPYVALS3(ducti->xyz_met + 3, xyz0[0], xyz0[1], xyz1[2]);
-        COPYVALS3(ducti->xyz_met + 6, xyz1[0], xyz0[1], xyz1[2]);
-        if(ABS(dxyz[2]) > ABS(dxyz[0])){
-          ducti->xyz_symbol_metro[2] += 0.50*dxyz[2];
-          ducti->xyz_label_metro[2]  += 0.75*dxyz[2];
-          dxyz_metro[2] = 1.0;
-        }
-        else{
-          ducti->xyz_symbol_metro[0] += 0.50*dxyz[0];
-          ducti->xyz_symbol_metro[2] += dxyz[2];
-          ducti->xyz_label_metro[0]  += 0.75 * dxyz[0];
-          ducti->xyz_label_metro[2]  += dxyz[2];
-          dxyz_metro[0] = 1.0;
-        }
-        break;
-      case DUCT_ZYX:
-        COPYVALS3(ducti->xyz_met + 3, xyz0[0], xyz0[1], xyz1[2]);
-        COPYVALS3(ducti->xyz_met + 6, xyz0[0], xyz1[1], xyz1[2]);
-        if(ABS(dxyz[2]) > ABS(dxyz[1])){
-          ducti->xyz_symbol_metro[2] += 0.50*dxyz[2];
-          ducti->xyz_label_metro[2]  += 0.75 * dxyz[2];
-          dxyz_metro[2] = 1.0;
-        }
-        else{
-          ducti->xyz_symbol_metro[1] += 0.50*dxyz[1];
-          ducti->xyz_symbol_metro[2] += dxyz[2];
-          ducti->xyz_label_metro[1]  += 0.75 * dxyz[1];
-          ducti->xyz_label_metro[2]  += dxyz[2];
-          dxyz_metro[1] = 1.0;
-        }
-        break;
-      default:
-        assert(FFALSE);
-        break;
-    }
-    GetCellXYZs(ducti->xyz_reg, ducti->nxyz_reg, ducti->nduct_cells,
-      &ducti->xyz_reg_cell, &ducti->nxyz_reg_cell, &ducti->cell_reg);
-    GetCellXYZs(ducti->xyz_met, ducti->nxyz_met, ducti->nduct_cells,
-      &ducti->xyz_met_cell, &ducti->nxyz_met_cell, &ducti->cell_met);
-  }
-  for(i = 0;i < nhvacductinfo;i++){
-    SetDuctLabelSymbolXYZ(hvacductinfo + i);
   }
 }
 
@@ -976,62 +345,6 @@ void DrawHVACFilter(hvacductdata *ducti, float *xyz, float size){
   glPopMatrix();
 }
 
-/* ------------------ GetHVACDuctID ------------------------ */
-
-hvacductdata *GetHVACDuctID(char *duct_name){
-  int i;
-
-  for(i = 0;i < nhvacductinfo;i++){
-    hvacductdata *ducti;
-
-    ducti = hvacductinfo + i;
-    if(strcmp(ducti->duct_name, duct_name) == 0)return ducti;
-  }
-  return NULL;
-}
-
-/* ------------------ GetHVACDuctValIndex ------------------------ */
-
-int GetHVACDuctValIndex(char *shortlabel){
-  int i;
-
-  for(i = 0;i < hvacductvalsinfo->n_duct_vars;i++){
-    hvacvaldata *hi;
-
-    hi = hvacductvalsinfo->duct_vars + i;
-    if(strcmp(hi->label.shortlabel, shortlabel) == 0)return i;
-  }
-  return -1;
-}
-
-/* ------------------ GetHVACNodeValIndex ------------------------ */
-
-int GetHVACNodeValIndex(char *shortlabel){
-  int i;
-
-  for(i = 0;i < hvacnodevalsinfo->n_node_vars;i++){
-    hvacvaldata *hi;
-
-    hi = hvacnodevalsinfo->node_vars + i;
-    if(strcmp(hi->label.shortlabel, shortlabel) == 0)return i;
-  }
-  return -1;
-}
-
-/* ------------------ GetHVACNodeID ------------------------ */
-
-hvacnodedata *GetHVACNodeID(char *node_name){
-  int i;
-
-  for(i = 0;i < nhvacnodeinfo;i++){
-    hvacnodedata *nodei;
-
-    nodei = hvacnodeinfo + i;
-    if(strcmp(nodei->duct_name, node_name) == 0)return nodei;
-  }
-  return NULL;
-}
-
 /* ------------------ DrawHVAC ------------------------ */
 
 void DrawHVAC(hvacdata *hvaci){
@@ -1040,8 +353,8 @@ void DrawHVAC(hvacdata *hvaci){
   unsigned char hvac_cell_color[3] = {128, 128, 128};
   float *last_color = NULL;
 
-  if((hvacductvar_index >= 0||hvacnodevar_index>=0)&&global_times!=NULL){
-    frame_index = GetTimeInterval(GetTime(), hvacductvalsinfo->times, hvacductvalsinfo->ntimes);
+  if((hvaccoll.hvacductvar_index >= 0||hvaccoll.hvacnodevar_index>=0)&&global_times!=NULL){
+    frame_index = GetTimeInterval(GetTime(), hvaccoll.hvacductvalsinfo->times, hvaccoll.hvacductvalsinfo->ntimes);
   }
 
   glPushMatrix();
@@ -1053,29 +366,29 @@ void DrawHVAC(hvacdata *hvaci){
   float valmin, valmax;
   int set_valmin, set_valmax;
   hvacvaldata *ductvar;
-  if(global_times != NULL && hvacductvar_index>=0){
-    ductvar = hvacductvalsinfo->duct_vars + hvacductvar_index;
+  if(global_times != NULL && hvaccoll.hvacductvar_index>=0){
+    ductvar = hvaccoll.hvacductvalsinfo->duct_vars + hvaccoll.hvacductvar_index;
     GLUIGetOnlyMinMax(BOUND_HVACDUCT, ductvar->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
   }
 
   glLineWidth(hvaci->duct_width);
   glBegin(GL_LINES);
-  if(hvacductvar_index < 0||global_times==NULL){
+  if(hvaccoll.hvacductvar_index < 0||global_times==NULL){
     uc_color[0] = CLAMP(hvaci->duct_color[0], 0, 255);
     uc_color[1] = CLAMP(hvaci->duct_color[1], 0, 255);
     uc_color[2] = CLAMP(hvaci->duct_color[2], 0, 255);
     glColor3ubv(uc_color);
   }
-  for(i = 0; i < nhvacductinfo; i++){
+  for(i = 0; i < hvaccoll.nhvacductinfo; i++){
     hvacductdata *ducti;
     hvacnodedata *node_from, *node_to;
 
-    ducti = hvacductinfo + i;
+    ducti = hvaccoll.hvacductinfo + i;
     if(hvac_show_networks==1&&strcmp(hvaci->network_name, ducti->network_name) != 0)continue;
     if(hvac_show_connections==1&&ducti->connect != NULL && ducti->connect->display == 0)continue;
 
-    node_from = hvacnodeinfo + ducti->node_id_from;
-    node_to = hvacnodeinfo + ducti->node_id_to;
+    node_from = hvaccoll.hvacnodeinfo + ducti->node_id_from;
+    node_to = hvaccoll.hvacnodeinfo + ducti->node_id_to;
     if(node_from == NULL || node_to == NULL)continue;
     float *xyzs;
     int nxyzs, j, *cell_index;
@@ -1090,7 +403,7 @@ void DrawHVAC(hvacdata *hvaci){
       cell_index = ducti->cell_reg;
       nxyzs      = ducti->nxyz_reg_cell-1;
     }
-    if(global_times != NULL && hvacductvar_index >= 0){
+    if(global_times != NULL && hvaccoll.hvacductvar_index >= 0){
       for(j = 0;j < nxyzs;j++){
         float *xyz, *this_color;
         int cell;
@@ -1128,12 +441,12 @@ void DrawHVAC(hvacdata *hvaci){
     glColor3ubv(hvac_cell_color);
     glPointSize(hvaci->cell_node_size);
     glBegin(GL_POINTS);
-    for(i = 0; i < nhvacductinfo; i++){
+    for(i = 0; i < hvaccoll.nhvacductinfo; i++){
       hvacductdata *ducti;
       float *xyzs;
       int nxyzs, j;
 
-      ducti = hvacductinfo + i;
+      ducti = hvaccoll.hvacductinfo + i;
       if(ducti->nduct_cells <= 1)continue;
 
       if(hvac_metro_view == 1){
@@ -1155,20 +468,20 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac duct points");
   }
   if(hvaci->show_duct_labels == 1){
-    for(i = 0; i < nhvacductinfo; i++){
+    for(i = 0; i < hvaccoll.nhvacductinfo; i++){
       hvacductdata *ducti;
       hvacnodedata *node_from, *node_to;
       float xyz[3];
       char label[256];
       float offset;
 
-      ducti = hvacductinfo + i;
+      ducti = hvaccoll.hvacductinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, ducti->network_name) != 0)continue;
       if(hvac_show_connections == 1 && ducti->connect != NULL && ducti->connect->display == 0)continue;
 
       strcpy(label, ducti->duct_name);
-      node_from = hvacnodeinfo + ducti->node_id_from;
-      node_to   = hvacnodeinfo + ducti->node_id_to;
+      node_from = hvaccoll.hvacnodeinfo + ducti->node_id_from;
+      node_to   = hvaccoll.hvacnodeinfo + ducti->node_id_to;
       if(node_from == NULL || node_to == NULL)continue;
       if(hvac_metro_view==1){
         memcpy(xyz, ducti->xyz_label_metro, 3*sizeof(float));
@@ -1182,20 +495,20 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac duct labels");
   }
   if(hvaci->show_component == DUCT_COMPONENT_TEXT){
-    for(i = 0; i < nhvacductinfo; i++){
+    for(i = 0; i < hvaccoll.nhvacductinfo; i++){
       hvacductdata *ducti;
       hvacnodedata *node_from, *node_to;
       float xyz[3];
       char label[256];
 
-      ducti = hvacductinfo + i;
+      ducti = hvaccoll.hvacductinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, ducti->network_name) != 0)continue;
       if(hvac_show_connections == 1 && ducti->connect != NULL && ducti->connect->display == 0)continue;
 
       strcpy(label, "");
       strcat(label, ducti->c_component);
-      node_from = hvacnodeinfo + ducti->node_id_from;
-      node_to   = hvacnodeinfo + ducti->node_id_to;
+      node_from = hvaccoll.hvacnodeinfo + ducti->node_id_from;
+      node_to   = hvaccoll.hvacnodeinfo + ducti->node_id_to;
       if(node_from == NULL || node_to == NULL)continue;
       if(hvac_metro_view == 1){
         memcpy(xyz, ducti->xyz_symbol_metro, 3*sizeof(float));
@@ -1209,16 +522,16 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac duct component text");
   }
   if(hvaci->show_component == DUCT_COMPONENT_SYMBOLS){
-    for(i = 0; i < nhvacductinfo; i++){
+    for(i = 0; i < hvaccoll.nhvacductinfo; i++){
       hvacductdata *ducti;
       hvacnodedata *node_from, *node_to;
       float *xyz;
 
-      ducti = hvacductinfo + i;
+      ducti = hvaccoll.hvacductinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, ducti->network_name) != 0)continue;
       if(hvac_show_connections == 1 && ducti->connect != NULL && ducti->connect->display == 0)continue;
-      node_from = hvacnodeinfo + ducti->node_id_from;
-      node_to   = hvacnodeinfo + ducti->node_id_to;
+      node_from = hvaccoll.hvacnodeinfo + ducti->node_id_from;
+      node_to   = hvaccoll.hvacnodeinfo + ducti->node_id_to;
       if(node_from == NULL || node_to == NULL)continue;
       float size;
       int state;
@@ -1255,27 +568,27 @@ void DrawHVAC(hvacdata *hvaci){
   // draw nodes
   glPointSize(hvaci->node_size);
   glBegin(GL_POINTS);
-  if(hvacnodevar_index < 0 || global_times == NULL){
+  if(hvaccoll.hvacnodevar_index < 0 || global_times == NULL){
     uc_color[0] = CLAMP(hvaci->node_color[0], 0, 255);
     uc_color[1] = CLAMP(hvaci->node_color[1], 0, 255);
     uc_color[2] = CLAMP(hvaci->node_color[2], 0, 255);
     glColor3ubv(uc_color);
   }
-  for(i = 0; i < nhvacnodeinfo; i++){
+  for(i = 0; i < hvaccoll.nhvacnodeinfo; i++){
     hvacnodedata *nodei;
 
-    nodei = hvacnodeinfo + i;
+    nodei = hvaccoll.hvacnodeinfo + i;
     if(hvac_show_networks == 1 && strcmp(hvaci->network_name, nodei->network_name) != 0)continue;
     if(hvac_show_connections == 1 && nodei->connect != NULL && nodei->connect->display == 0)continue;
-    if(global_times != NULL && hvacnodevar_index >= 0){
+    if(global_times != NULL && hvaccoll.hvacnodevar_index >= 0){
       hvacvaldata *nodevar;
       unsigned char ival;
 
       //        duct: i
       //        time: itime
       //   var index: hvacductvar_index
-      nodevar = hvacnodevalsinfo->node_vars + hvacnodevar_index;
-      ival = HVACCOLORCONV(nodevar->vals[frame_index + i * hvacnodevalsinfo->ntimes], nodevar->valmin, nodevar->valmax);
+      nodevar = hvaccoll.hvacnodevalsinfo->node_vars + hvaccoll.hvacnodevar_index;
+      ival = HVACCOLORCONV(nodevar->vals[frame_index + i * hvaccoll.hvacnodevalsinfo->ntimes], nodevar->valmin, nodevar->valmax);
       glColor3fv(rgb_full[ival]);
     }
     glVertex3fv(nodei->xyz);
@@ -1288,12 +601,12 @@ void DrawHVAC(hvacdata *hvaci){
   uc_color[2] = CLAMP(hvaci->node_color[2], 0, 255);
   glColor3ubv(uc_color);
   if(hvaci->show_node_labels == 1){
-    for(i = 0; i < nhvacnodeinfo; i++){
+    for(i = 0; i < hvaccoll.nhvacnodeinfo; i++){
       hvacnodedata* nodei;
       char label[256];
       float offset;
 
-      nodei = hvacnodeinfo + i;
+      nodei = hvaccoll.hvacnodeinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, nodei->network_name) != 0)continue;
       if(hvac_show_connections == 1 && nodei->connect != NULL && nodei->connect->display == 0)continue;
       offset = 0.01/xyzmaxdiff;
@@ -1303,12 +616,12 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac node labels");
   }
   if(hvaci->show_filters == NODE_FILTERS_LABELS){
-    for(i = 0; i < nhvacnodeinfo; i++){
+    for(i = 0; i < hvaccoll.nhvacnodeinfo; i++){
       hvacnodedata *nodei;
       char label[256];
       float offset;
 
-      nodei = hvacnodeinfo + i;
+      nodei = hvaccoll.hvacnodeinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, nodei->network_name) != 0)continue;
       if(hvac_show_connections == 1 && nodei->connect != NULL && nodei->connect->display == 0)continue;
       strcpy(label, nodei->c_filter);
@@ -1318,13 +631,13 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac node filter labels");
   }
   if(hvaci->show_filters == NODE_FILTERS_SYMBOLS){
-    for(i = 0; i < nhvacnodeinfo; i++){
+    for(i = 0; i < hvaccoll.nhvacnodeinfo; i++){
       hvacnodedata *nodei;
       float size;
 
       size  = xyzmaxdiff / 25.0;
       size *= hvaci->filter_size;
-      nodei = hvacnodeinfo + i;
+      nodei = hvaccoll.hvacnodeinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, nodei->network_name) != 0)continue;
       if(hvac_show_connections == 1 && nodei->connect != NULL && nodei->connect->display == 0)continue;
       if(nodei->filter == HVAC_FILTER_NO)continue;
@@ -1340,10 +653,10 @@ void DrawHVAC(hvacdata *hvaci){
 void DrawHVACS(void){
   int i;
 
-  for(i=0; i<nhvacinfo; i++){
+  for(i=0; i<hvaccoll.nhvacinfo; i++){
     hvacdata *hvaci;
 
-    hvaci = hvacinfo + i;
+    hvaci = hvaccoll.hvacinfo + i;
     if(hvac_show_networks==1&&hvaci->display==0)continue;
     DrawHVAC(hvaci);
   }

--- a/Source/smokeview/IOscript.c
+++ b/Source/smokeview/IOscript.c
@@ -2961,7 +2961,7 @@ void ScriptSetCbar(scriptdata *scripti){
 void ScriptShowHVACDuctVal(scriptdata *scripti){
   int ductvalindex;
 
-  ductvalindex = GetHVACDuctValIndex(scripti->cval);
+  ductvalindex = GetHVACDuctValIndex(&hvaccoll, scripti->cval);
   if(ductvalindex>=0){
     HVACDuctValueMenu(ductvalindex);
   }
@@ -2975,7 +2975,7 @@ void ScriptShowHVACDuctVal(scriptdata *scripti){
 void ScriptShowHVACNodeVal(scriptdata *scripti){
   int nodevalindex;
 
-  nodevalindex = GetHVACNodeValIndex(scripti->cval);
+  nodevalindex = GetHVACNodeValIndex(&hvaccoll, scripti->cval);
   if(nodevalindex>=0){
     HVACNodeValueMenu(nodevalindex);
   }

--- a/Source/smokeview/callbacks.c
+++ b/Source/smokeview/callbacks.c
@@ -2880,7 +2880,7 @@ void Keyboard(unsigned char key, int flag){
       break;
     case '&':
       if(keystate==GLUT_ACTIVE_ALT){
-        if(nhvacinfo > 0){
+        if(hvaccoll.nhvacinfo > 0){
           ToggleMetroMode();
           PRINTF("HVAC metro view mode=%i\n", hvac_metro_view);
         }

--- a/Source/smokeview/colortimebar.c
+++ b/Source/smokeview/colortimebar.c
@@ -2097,8 +2097,8 @@ void UpdateShowColorbar(int *showcfast_arg, int *show_slice_colorbar_arg,
   int showcfast_local = 0;
   int show_slice_colorbar_local = 0;
 
-  if(hvacductvar_index >= 0)*show_hvacduct_colorbar_arg = 1;
-  if(hvacnodevar_index >= 0)*show_hvacnode_colorbar_arg = 1;
+  if(hvaccoll.hvacductvar_index >= 0)*show_hvacduct_colorbar_arg = 1;
+  if(hvaccoll.hvacnodevar_index >= 0)*show_hvacnode_colorbar_arg = 1;
   if(showzone==1&&zonecolortype==ZONETEMP_COLOR)showcfast_local = 1;
   if(showslice==1||(showcfast_local==0&&showvslice==1&&vslicecolorbarflag==1))show_slice_colorbar_local = 1;
   if(show_slice_colorbar_local==1&&showcfast_local==1&&strcmp(slicebounds[slicefile_labelindex].label->shortlabel, "TEMP")==0)show_slice_colorbar_local=0;
@@ -3380,12 +3380,12 @@ void DrawVerticalColorbarRegLabels(void){
 
   // -------------- HVAC node left labels ------------
 
-  if(show_hvacnode_colorbar_local==1 && hvacnodevar_index>=0){
+  if(show_hvacnode_colorbar_local==1 && hvaccoll.hvacnodevar_index>=0){
     hvacvaldata *hi;
     float tttval, tttmin, tttmax;
     float hvacrange;
 
-    hi = hvacnodevalsinfo->node_vars + hvacnodevar_index;
+    hi = hvaccoll.hvacnodevalsinfo->node_vars + hvaccoll.hvacnodevar_index;
     iposition = -1;
     tttmin = hi->levels256[0];
     tttmax = hi->levels256[255];
@@ -3429,12 +3429,12 @@ void DrawVerticalColorbarRegLabels(void){
 
   // -------------- HVAC duct left labels ------------
 
-  if(show_hvacduct_colorbar_local==1 && hvacductvar_index>=0){
+  if(show_hvacduct_colorbar_local==1 && hvaccoll.hvacductvar_index>=0){
     hvacvaldata *hi;
     float tttval, tttmin, tttmax;
     float hvacrange;
 
-    hi = hvacductvalsinfo->duct_vars + hvacductvar_index;
+    hi = hvaccoll.hvacductvalsinfo->duct_vars + hvaccoll.hvacductvar_index;
     iposition = -1;
     tttmin = hi->levels256[0];
     tttmax = hi->levels256[255];
@@ -3478,11 +3478,11 @@ void DrawVerticalColorbarRegLabels(void){
 
   // -------------- HVAC file node top labels ------------
 
-  if(show_hvacnode_colorbar_local==1 && hvacnodevar_index>=0){
+  if(show_hvacnode_colorbar_local==1 && hvaccoll.hvacnodevar_index>=0){
     char *slabel, *unitlabel;
     hvacvaldata *hi;
 
-    hi = hvacnodevalsinfo->node_vars + hvacnodevar_index;
+    hi = hvaccoll.hvacnodevalsinfo->node_vars + hvaccoll.hvacnodevar_index;
     slabel = hi->label.shortlabel;
     unitlabel = hi->label.unit;
 
@@ -3502,11 +3502,11 @@ void DrawVerticalColorbarRegLabels(void){
 
   // -------------- HVAC file duct top labels ------------
 
-  if(show_hvacduct_colorbar_local==1 && hvacductvar_index >=0){
+  if(show_hvacduct_colorbar_local==1 && hvaccoll.hvacductvar_index >=0){
     char *slabel, *unitlabel;
     hvacvaldata *hi;
 
-    hi = hvacductvalsinfo->duct_vars + hvacductvar_index;
+    hi = hvaccoll.hvacductvalsinfo->duct_vars + hvaccoll.hvacductvar_index;
     slabel = hi->label.shortlabel;
     unitlabel = hi->label.unit;
 

--- a/Source/smokeview/getdatabounds.c
+++ b/Source/smokeview/getdatabounds.c
@@ -1534,10 +1534,10 @@ void GetHVACDuctBounds(char *shortlabel, float *valminptr, float *valmaxptr){
 
   *valminptr = 1.0;
   *valmaxptr = 0.0;
-  for(i=0;i< hvacductvalsinfo->n_duct_vars;i++){
+  for(i=0;i< hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
     hvacvaldata *hi;
 
-    hi = hvacductvalsinfo->duct_vars + i;
+    hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
     if(strcmp(shortlabel, hi->label.shortlabel)!=0)continue;
     if(valmin<valmax){
       valmin = MIN(valmin,hi->valmin);
@@ -1560,10 +1560,10 @@ void GetHVACNodeBounds(char *shortlabel, float *valminptr, float *valmaxptr){
 
   *valminptr = 1.0;
   *valmaxptr = 0.0;
-  for(i = 0;i < hvacnodevalsinfo->n_node_vars;i++){
+  for(i = 0;i < hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
     hvacvaldata *hi;
 
-    hi = hvacnodevalsinfo->node_vars + i;
+    hi = hvaccoll.hvacnodevalsinfo->node_vars + i;
     if(strcmp(shortlabel, hi->label.shortlabel) != 0)continue;
     if(valmin < valmax){
       valmin = MIN(valmin, hi->valmin);
@@ -1585,7 +1585,7 @@ void GetGlobalHVACDuctBounds(int flag){
 
   if(no_bounds == 1 && force_bounds==0)flag = 0;
   int nhvacboundsmax = 0;
-  if(hvacductvalsinfo != NULL)nhvacboundsmax = hvacductvalsinfo->n_duct_vars;
+  if(hvaccoll.hvacductvalsinfo != NULL)nhvacboundsmax = hvaccoll.hvacductvalsinfo->n_duct_vars;
   if(nhvacboundsmax == 0)return;
   if(flag==0)ReadHVACData(BOUNDS_ONLY);
   for(i = 0;i < nhvacductbounds;i++){
@@ -1646,7 +1646,7 @@ void GetGlobalHVACNodeBounds(int flag){
 
   if(no_bounds == 1 && force_bounds==0)flag = 0;
   int nhvacboundsmax = 0;
-  if(hvacnodevalsinfo != NULL)nhvacboundsmax = hvacnodevalsinfo->n_duct_vars + hvacnodevalsinfo->n_node_vars;
+  if(hvaccoll.hvacnodevalsinfo != NULL)nhvacboundsmax = hvaccoll.hvacnodevalsinfo->n_duct_vars + hvaccoll.hvacnodevalsinfo->n_node_vars;
   if(nhvacboundsmax == 0)return;
   if(flag == 0)ReadHVACData(BOUNDS_ONLY);
   for(i = 0;i < nhvacnodebounds;i++){

--- a/Source/smokeview/glui_bounds.cpp
+++ b/Source/smokeview/glui_bounds.cpp
@@ -5229,7 +5229,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
   // ----------------------------------- HVAC ducts ----------------------------------------
 
-  if(nhvacinfo > 0&&nhvacductbounds_cpp>0){
+  if(hvaccoll.nhvacinfo > 0&&nhvacductbounds_cpp>0){
     glui_active = 1;
     ROLLOUT_hvacduct = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds, "HVAC ducts", false, HVACDUCT_ROLLOUT, BoundRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_hvacduct, glui_bounds);
@@ -5242,7 +5242,7 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
 
   // ----------------------------------- HVAC nodes ----------------------------------------
 
-  if(nhvacinfo > 0 && nhvacnodebounds_cpp > 0){
+  if(hvaccoll.nhvacinfo > 0 && nhvacnodebounds_cpp > 0){
     glui_active = 1;
     ROLLOUT_hvacnode = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds, "HVAC nodes", false, HVACNODE_ROLLOUT, BoundRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_hvacnode, glui_bounds);

--- a/Source/smokeview/glui_geometry.cpp
+++ b/Source/smokeview/glui_geometry.cpp
@@ -409,13 +409,13 @@ extern "C" void GLUIUpdateVertexInfo(float *xyz1, float *xyz2){
 void Glui2HVAC(void){
   int i;
 
-  for(i = 0;i < nhvacinfo;i++){
+  for(i = 0;i < hvaccoll.nhvacinfo;i++){
     if(hvac_network_ductnode_index==-1||hvac_network_ductnode_index==i){
       int display;
       hvacdata *hvaci;
       char *network_name;
 
-      hvaci = hvacinfo + i;
+      hvaci = hvaccoll.hvacinfo + i;
       display      = hvaci->display;
       network_name = hvaci->network_name;
       memcpy(hvaci, glui_hvac, sizeof(hvacdata));
@@ -431,13 +431,13 @@ extern "C" void GLUIHVAC2Glui(int index){
   hvacdata *hvaci;
   int i;
 
-  if(index >= nhvacinfo)return;
+  if(index >= hvaccoll.nhvacinfo)return;
   if(index < 0){
     Glui2HVAC();
     return;
   }
 
-  hvaci = hvacinfo + index;
+  hvaci = hvaccoll.hvacinfo + index;
   memcpy(glui_hvac, hvaci, sizeof(hvacdata));
   for(i=0;i<3;i++){
     SPINNER_hvac_duct_color[i]->set_int_val(glui_hvac->duct_color[i]);
@@ -467,8 +467,8 @@ extern "C" void GLUIUpdateTerrain(void){
 /* ------------------ GLUIUpdateHVACVarLists ------------------------ */
 
 extern "C" void GLUIUpdateHVACVarLists(void){
-  if(LIST_hvacductvar_index!=NULL)LIST_hvacductvar_index->set_int_val(hvacductvar_index);
-  if(LIST_hvacnodevar_index!=NULL)LIST_hvacnodevar_index->set_int_val(hvacnodevar_index);
+  if(LIST_hvacductvar_index!=NULL)LIST_hvacductvar_index->set_int_val(hvaccoll.hvacductvar_index);
+  if(LIST_hvacnodevar_index!=NULL)LIST_hvacnodevar_index->set_int_val(hvaccoll.hvacnodevar_index);
 }
 
 /* ------------------ HvacCB ------------------------ */
@@ -488,15 +488,15 @@ void HvacCB(int var){
       GLUIShowBoundsDialog(DLG_HVACNODE);
       break;
     case HVAC_NODE_LIST:
-      if(hvacnodevar_index>=0){
-        if(hvacnodevalsinfo->loaded == 0)ReadHVACData(LOAD);
-        HVACNodeValueMenu(hvacnodevar_index);
+      if(hvaccoll.hvacnodevar_index>=0){
+        if(hvaccoll.hvacnodevalsinfo->loaded == 0)ReadHVACData(LOAD);
+        HVACNodeValueMenu(hvaccoll.hvacnodevar_index);
       }
       break;
     case HVAC_DUCT_LIST:
-      if(hvacductvar_index>=0){
-        if(hvacductvalsinfo->loaded == 0)ReadHVACData(LOAD);
-        HVACDuctValueMenu(hvacductvar_index);
+      if(hvaccoll.hvacductvar_index>=0){
+        if(hvaccoll.hvacductvalsinfo->loaded == 0)ReadHVACData(LOAD);
+        HVACDuctValueMenu(hvaccoll.hvacductvar_index);
       }
     break;
     case HVAC_DUCTNODE_NETWORK:
@@ -535,7 +535,7 @@ void HvacCB(int var){
     case HVAC_SHOW_NETWORKS:
       if(hvac_show_networks==1){
         PANEL_hvac_network->enable();
-        if(nhvacconnectinfo > 0){
+        if(hvaccoll.nhvacconnectinfo > 0){
           PANEL_hvac_connections->disable();
           hvac_show_connections = 0;
           CHECKBOX_hvac_show_connection->set_int_val(hvac_show_connections);
@@ -558,10 +558,10 @@ void HvacCB(int var){
       break;
     case HVAC_SHOWALL_NETWORK:
     case HVAC_HIDEALL_NETWORK:
-      for(i=0;i<nhvacinfo;i++){
+      for(i=0;i<hvaccoll.nhvacinfo;i++){
         hvacdata *hvaci;
 
-        hvaci = hvacinfo + i;
+        hvaci = hvaccoll.hvacinfo + i;
         if(var==HVAC_SHOWALL_NETWORK)hvaci->display = 1;
         if(var==HVAC_HIDEALL_NETWORK)hvaci->display = 0;
         CHECKBOX_hvac_show_networks[i]->set_int_val(hvaci->display);
@@ -569,10 +569,10 @@ void HvacCB(int var){
       break;
     case HVAC_SHOWALL_CONNECTIONS:
     case HVAC_HIDEALL_CONNECTIONS:
-      for(i = 0; i < nhvacconnectinfo; i++){
+      for (i = 0; i < hvaccoll.nhvacconnectinfo; i++){
         hvacconnectdata *hi;
 
-        hi = hvacconnectinfo + i;
+        hi = hvaccoll.hvacconnectinfo + i;
         if(var==HVAC_SHOWALL_CONNECTIONS)hi->display = 1;
         if(var==HVAC_HIDEALL_CONNECTIONS)hi->display = 0;
         CHECKBOX_hvac_show_connections[i]->set_int_val(hi->display);
@@ -607,23 +607,23 @@ extern "C" void GLUIGeometrySetup(int main_window){
   glui_geometry = GLUI_Master.create_glui("Geometry",0,dialogX0,dialogY0);
   if(showedit_dialog==0)glui_geometry->hide();
 
-  if(nhvacinfo > 0){
-    NewMemory((void **)&glui_hvac, sizeof(hvacdata));
-    memcpy(glui_hvac, hvacinfo, sizeof(hvacdata));
+  if(hvaccoll.nhvacinfo > 0){
+    NewMemory(( void ** )&glui_hvac, sizeof(hvacdata));
+    memcpy(glui_hvac, hvaccoll.hvacinfo, sizeof(hvacdata));
     ROLLOUT_hvac = glui_geometry->add_rollout("HVAC", false, HVAC_ROLLOUT, GeomRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_hvac, glui_geometry);
     ADDPROCINFO(geomprocinfo, ngeomprocinfo, ROLLOUT_hvac, HVAC_ROLLOUT, glui_geometry);
 
-    NewMemory((void **)&CHECKBOX_hvac_show_networks, nhvacinfo*sizeof(GLUI_Checkbox *));
+    NewMemory((void **)&CHECKBOX_hvac_show_networks, hvaccoll.nhvacinfo*sizeof(GLUI_Checkbox *));
     PANEL_hvac_options = glui_geometry->add_panel_to_panel(ROLLOUT_hvac, "", false);
     PANEL_hvac_options->set_alignment(GLUI_ALIGN_LEFT);
     CHECKBOX_hvac_metro_view = glui_geometry->add_checkbox_to_panel(PANEL_hvac_options, "metro view", &hvac_metro_view, HVAC_METRO_VIEW, HvacCB);
     CHECKBOX_hvac_cell_view = glui_geometry->add_checkbox_to_panel(PANEL_hvac_options, "show cells", &hvac_cell_view, HVAC_CELL_VIEW, HvacCB);
-    if(nhvacconnectinfo > 0){
+    if(hvaccoll.nhvacconnectinfo > 0){
       CHECKBOX_hvac_show_network = glui_geometry->add_checkbox_to_panel(PANEL_hvac_options, "Show by network", &hvac_show_networks, HVAC_SHOW_NETWORKS, HvacCB);
       CHECKBOX_hvac_show_connection = glui_geometry->add_checkbox_to_panel(PANEL_hvac_options, "Show by connection", &hvac_show_connections, HVAC_SHOW_CONNECTIONS, HvacCB);
     }
-    if(nhvacconnectinfo > 0){
+    if(hvaccoll.nhvacconnectinfo > 0){
       PANEL_hvac_group1 = glui_geometry->add_panel_to_panel(ROLLOUT_hvac, "", false);
       PANEL_hvac_network = glui_geometry->add_panel_to_panel(PANEL_hvac_group1, "networks");
     }
@@ -631,31 +631,31 @@ extern "C" void GLUIGeometrySetup(int main_window){
       hvac_show_networks = 1;
       PANEL_hvac_network = glui_geometry->add_panel_to_panel(ROLLOUT_hvac, "networks");
     }
-    for(i = 0; i < nhvacinfo; i++){
+    for (i = 0; i < hvaccoll.nhvacinfo; i++){
       hvacdata* hvaci;
 
-      hvaci = hvacinfo + i;
+      hvaci = hvaccoll.hvacinfo + i;
       CHECKBOX_hvac_show_networks[i] = glui_geometry->add_checkbox_to_panel(PANEL_hvac_network, hvaci->network_name, &hvaci->display);
     }
-    if(nhvacinfo > 1){
+    if(hvaccoll.nhvacinfo > 1){
       glui_geometry->add_button_to_panel(PANEL_hvac_network, "show all", HVAC_SHOWALL_NETWORK, HvacCB);
       glui_geometry->add_button_to_panel(PANEL_hvac_network, "hide all", HVAC_HIDEALL_NETWORK, HvacCB);
       //      glui_geometry->add_checkbox_to_panel(ROLLOUT_hvac, "copy settings to all networks", &hvac_copy_all, HVAC_COPY_ALL, HvacCB);
     }
 
-    if(nhvacconnectinfo>0){
-      NewMemory((void **)&CHECKBOX_hvac_show_connections, nhvacconnectinfo*sizeof(GLUI_Checkbox *));
+    if(hvaccoll.nhvacconnectinfo>0){
+      NewMemory((void **)&CHECKBOX_hvac_show_connections, hvaccoll.nhvacconnectinfo*sizeof(GLUI_Checkbox *));
       glui_geometry->add_column_to_panel(PANEL_hvac_group1, false);
       PANEL_hvac_connections = glui_geometry->add_panel_to_panel(PANEL_hvac_group1, "connections");
-      for(i = 0; i < nhvacconnectinfo; i++){
+      for (i = 0; i < hvaccoll.nhvacconnectinfo; i++){
         hvacconnectdata *hi;
         char label[100];
 
-        hi = hvacconnectinfo + i;
+        hi = hvaccoll.hvacconnectinfo + i;
         snprintf(label, sizeof(label), "%i", hi->index);
         CHECKBOX_hvac_show_connections[i] = glui_geometry->add_checkbox_to_panel(PANEL_hvac_connections, label, &hi->display);
       }
-      if(nhvacconnectinfo > 1){
+      if(hvaccoll.nhvacconnectinfo > 1){
         glui_geometry->add_button_to_panel(PANEL_hvac_connections, "show all", HVAC_SHOWALL_CONNECTIONS, HvacCB);
         glui_geometry->add_button_to_panel(PANEL_hvac_connections, "hide all", HVAC_HIDEALL_CONNECTIONS, HvacCB);
       }
@@ -663,10 +663,10 @@ extern "C" void GLUIGeometrySetup(int main_window){
 
     LIST_hvac_network_ductnode_index = glui_geometry->add_listbox_to_panel(ROLLOUT_hvac, "set duct/node properties for:", &hvac_network_ductnode_index, HVAC_DUCTNODE_NETWORK, HvacCB);
     LIST_hvac_network_ductnode_index->add_item(-1, "all networks");
-    for(i = 0; i<nhvacinfo; i++){
+    for(i = 0; i<hvaccoll.nhvacinfo; i++){
       hvacdata *hvaci;
 
-      hvaci = hvacinfo + i;
+      hvaci = hvaccoll.hvacinfo + i;
       LIST_hvac_network_ductnode_index->add_item(i, hvaci->network_name);
     }
 
@@ -685,13 +685,13 @@ extern "C" void GLUIGeometrySetup(int main_window){
     glui_geometry->add_radiobutton_to_group(RADIO_hvac_show_component_labels, "hide");
     SPINNER_hvac_component_size = glui_geometry->add_spinner_to_panel(PANEL_hvac_components, "size", GLUI_SPINNER_FLOAT, &glui_hvac->component_size, HVAC_PROPS, HvacCB);
 
-    if(hvacductvalsinfo!=NULL&&hvacductvalsinfo->n_duct_vars>0){
-      LIST_hvacductvar_index = glui_geometry->add_listbox_to_panel(PANEL_hvac_duct, "quantity:", &hvacductvar_index, HVAC_DUCT_LIST, HvacCB);
+    if(hvaccoll.hvacductvalsinfo!=NULL&&hvaccoll.hvacductvalsinfo->n_duct_vars>0){
+      LIST_hvacductvar_index = glui_geometry->add_listbox_to_panel(PANEL_hvac_duct, "quantity:", &hvaccoll.hvacductvar_index, HVAC_DUCT_LIST, HvacCB);
       LIST_hvacductvar_index->add_item(-1, "");
-      for(i = 0;i < hvacductvalsinfo->n_duct_vars;i++){
+      for(i = 0;i < hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
         hvacvaldata *hi;
 
-        hi = hvacductvalsinfo->duct_vars + i;
+        hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
         LIST_hvacductvar_index->add_item(i, hi->label.shortlabel);
       }
       glui_geometry->add_button_to_panel(PANEL_hvac_duct, _("Set duct bounds"), HVACDUCT_SET_BOUNDS, HvacCB);
@@ -717,13 +717,13 @@ extern "C" void GLUIGeometrySetup(int main_window){
       SPINNER_hvac_duct_color[i]->set_int_limits(0, 255);
       SPINNER_hvac_node_color[i]->set_int_limits(0, 255);
     }
-    if(hvacnodevalsinfo!=NULL&&hvacnodevalsinfo->n_node_vars>0){
-      LIST_hvacnodevar_index = glui_geometry->add_listbox_to_panel(PANEL_hvac_node, "quantity:", &hvacnodevar_index, HVAC_NODE_LIST, HvacCB);
+    if(hvaccoll.hvacnodevalsinfo!=NULL&&hvaccoll.hvacnodevalsinfo->n_node_vars>0){
+      LIST_hvacnodevar_index = glui_geometry->add_listbox_to_panel(PANEL_hvac_node, "quantity:", &hvaccoll.hvacnodevar_index, HVAC_NODE_LIST, HvacCB);
       LIST_hvacnodevar_index->add_item(-1, "");
-      for(i = 0;i < hvacnodevalsinfo->n_node_vars;i++){
+      for(i = 0;i < hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
         hvacvaldata *hi;
 
-        hi = hvacnodevalsinfo->node_vars + i;
+        hi = hvaccoll.hvacnodevalsinfo->node_vars + i;
         LIST_hvacnodevar_index->add_item(i, hi->label.shortlabel);
       }
       glui_geometry->add_button_to_panel(PANEL_hvac_node, _("Set duct bounds"), HVACDUCT_SET_BOUNDS, HvacCB);

--- a/Source/smokeview/showscene.c
+++ b/Source/smokeview/showscene.c
@@ -396,7 +396,7 @@ void ShowScene2(int mode){
 
   /* ++++++++++++++++++++++++ draw HVAC networks +++++++++++++++++++++++++ */
 
-  if(nhvacinfo > 0){
+  if (hvaccoll.nhvacinfo > 0) {
     DrawHVACS();
   }
 

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -340,12 +340,9 @@ EXTERNCPP void SetupPlot2DUnitData(void);
 
 EXTERNCPP void TimeAveragePlot2DData(float *times, float *vals, float *vals_avg, int nvals, float time_interval);
 
-EXTERNCPP void SetHVACInfo(void);
 EXTERNCPP void DrawHVACS(void);
 EXTERNCPP hvacnodedata *GetHVACNode(hvacdata *hvaci, int node_id);
-EXTERNCPP void InitHvacData(hvacvaldata *hi);
 EXTERNCPP void ReadHVACData(int flag);
-EXTERNCPP int IsHVACVisible(void);
 EXTERNCPP void UpdateHVACDuctColorLabels(int index);
 EXTERNCPP void UpdateNodeLabel(colorbardata *cbi);
 EXTERNCPP int IsColorbarSplit(colorbardata *cbi);
@@ -609,13 +606,8 @@ EXTERNCPP void InitVolrenderScript(char *prefix, char *tour_label, int startfram
 EXTERNCPP void UpdateGluiBoundaryUnits(void);
 EXTERNCPP void UpdateGluiSliceUnits(void);
 EXTERNCPP void HVACMenu(int value);
-EXTERNCPP int GetHVACDuctValIndex(char *shortlabel);
-EXTERNCPP int GetHVACNodeValIndex(char *shortlabel);
 EXTERNCPP void ToggleMetroMode(void);
 EXTERNCPP void UpdateClipPlanes(void);
-EXTERNCPP hvacductdata *GetHVACDuctID(char *duct_name);
-EXTERNCPP hvacnodedata *GetHVACNodeID(char *node_name);
-EXTERNCPP void GetCellXYZs(float *xyz, int nxyz, int ncells, float **xyz_cellptr, int *nxyz_cell, int **cell_indptr);
 EXTERNCPP void HVACDuctValueMenu(int value);
 EXTERNCPP void HVACNodeValueMenu(int value);
 

--- a/Source/smokeview/smokeviewdefs.h
+++ b/Source/smokeview/smokeviewdefs.h
@@ -18,16 +18,6 @@ EXTERNCPP void _Sniff_Errors(const char *whereat, const char *file, int line);
 #define MENU_HVAC_LOAD     0
 #define MENU_HVAC_UNLOAD   1
 
-#define HVAC_FILTER_NO  0
-#define HVAC_FILTER_YES 1
-#define HVAC_NONE    0
-#define HVAC_FAN     1
-#define HVAC_AIRCOIL 2
-#define HVAC_DAMPER  3
-
-#define HVAC_STATE_INACTIVE 0
-#define HVAC_STATE_ACTIVE   1
-
 #define SPLIT_COLORBAR         1
 
 #define LABELS_vcolorbar 34

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -13,6 +13,7 @@
 #include "contourdefs.h"
 #include "histogram.h"
 #include "structures.h"
+#include "readhvac.h"
 #include "readobject.h"
 #ifndef CPP
 #include <zlib.h>
@@ -119,27 +120,23 @@ SVEXTERN int SVDECL(update_frame, 0);
 #endif
 
 // hvac data
-SVEXTERN int SVDECL(hvacductvar_index, -1), SVDECL(hvacnodevar_index, -1);
-SVEXTERN int SVDECL(nhvacnodeinfo, 0), SVDECL(nhvacductinfo, 0), SVDECL(nhvacinfo, 0);
 SVEXTERN int SVDECL(hvac_show_connections, 0), SVDECL(hvac_show_networks, 1);
-SVEXTERN int SVDECL(nhvacconnectinfo, 0);
-SVEXTERN hvacconnectdata SVDECL(*hvacconnectinfo, NULL);
-SVEXTERN hvacvalsdata SVDECL(*hvacductvalsinfo, NULL);
-SVEXTERN hvacvalsdata SVDECL(*hvacnodevalsinfo, NULL);
-SVEXTERN hvacdata SVDECL(*hvacinfo, NULL);
-SVEXTERN hvacnodedata SVDECL(*hvacnodeinfo, NULL);
-SVEXTERN hvacductdata SVDECL(*hvacductinfo, NULL);
 SVEXTERN int SVDECL(hvac_metro_view, 0), SVDECL(hvac_cell_view, 0);
 
 SVEXTERN hvacdata SVDECL(*glui_hvac, NULL);
 SVEXTERN int SVDECL(hvac_network_ductnode_index, -1);
-SVEXTERN int SVDECL(nhvacfilters, 0), SVDECL(nhvaccomponents, 0);
 #define HVAC_NCIRC 72
 SVEXTERN float SVDECL(*hvac_circ_x, NULL), SVDECL(*hvac_circ_y, NULL);
 #ifdef INMAIN
+SVEXTERN hvacdatacollection hvaccoll = {
+  .hvacductvar_index= -1,
+  .hvacnodevar_index= -1,
+  0
+};
 SVEXTERN int hvac_duct_color[3] = { 63,0,15};
 SVEXTERN int hvac_node_color[3] = { 63,0,15};
 #else
+SVEXTERN hvacdatacollection hvaccoll;
 SVEXTERN int hvac_duct_color[3];
 SVEXTERN int hvac_node_color[3];
 #endif

--- a/Source/smokeview/structures.h
+++ b/Source/smokeview/structures.h
@@ -15,6 +15,7 @@
 
 #include "readgeom.h"
 #include "readobject.h"
+#include "shared_structures.h"
 
 /* --------------------------  circdata ------------------------------------ */
 
@@ -873,94 +874,6 @@ typedef struct _partdata {
 typedef struct _compdata {
   int offset, size;
 } compdata;
-
-
-#define DUCT_COMPONENT_TEXT    0
-#define DUCT_COMPONENT_SYMBOLS 1
-#define DUCT_COMPONENT_HIDE    2
-
-#define NODE_FILTERS_LABELS  0
-#define NODE_FILTERS_SYMBOLS 1
-#define NODE_FILTERS_HIDE    2
-
-#define DUCT_XYZ 0
-#define DUCT_YXZ 1
-#define DUCT_XZY 2
-#define DUCT_ZXY 3
-#define DUCT_YZX 4
-#define DUCT_ZYX 5
-
-
-/* --------------------------  hvacconnectdata ------------------------------------ */
-
-typedef struct hvacconnectdata {
-  int index, display;
-} hvacconnectdata;
-
-
-/* --------------------------  hvacnodedata ------------------------------------ */
-
-typedef struct _hvacnodedata {
-  char *node_name, *vent_name, *duct_name, *network_name;
-  char c_filter[10];
-  int node_id, filter, use_node, connect_id;
-  hvacconnectdata *connect;
-  struct _hvacductdata *duct;
-  float xyz[3], xyz_orig[3];
-} hvacnodedata;
-
-/* --------------------------  hvacductdata ------------------------------------ */
-
-typedef struct _hvacductdata {
-  char *duct_name, *network_name, c_component[4];
-  int duct_id, component, nduct_cells;
-  int node_id_from, node_id_to, use_duct, connect_id;
-  hvacconnectdata *connect;
-  int nact_times, *act_states, metro_path;
-  float *act_times;
-  float xyz_symbol[3], xyz_symbol_metro[3];
-  float xyz_label[3],  xyz_label_metro[3];
-  float normal[3], normal_metro[3];
-  hvacnodedata* node_from, * node_to;
-  float xyz_met[12], *xyz_reg;
-  int   nxyz_met, nxyz_reg;
-  float *xyz_met_cell, *xyz_reg_cell;
-  int   nxyz_met_cell, nxyz_reg_cell;
-  int    *cell_met,    *cell_reg;
-} hvacductdata;
-
-/* --------------------------  hvacdata ------------------------------------ */
-
-typedef struct _hvacdata {
-  char *network_name;
-  int display;
-  int show_node_labels, show_duct_labels;
-  int show_filters, show_component;
-  float cell_node_size, node_size, component_size, duct_width, filter_size;
-  int duct_color[3], node_color[3];
-} hvacdata;
-
-/* --------------------------  hvacvaldata ------------------------------------ */
-
-typedef struct _hvacvaldata{
-  float *vals, valmin, valmax;
-  int setvalmin, setvalmax;
-  int vis, nvals;
-  char  colorlabels[12][11];
-  float colorvalues[12];
-  float levels256[256];
-  flowlabels label;
-} hvacvaldata;
-
-/* --------------------------  _hvacvalsdata ------------------------------------ */
-
-typedef struct _hvacvalsdata {
-  char *file;
-  int loaded;
-  int n_node_vars, n_duct_vars, ntimes;
-  float *times;
-  hvacvaldata *node_vars, *duct_vars;
-} hvacvalsdata;
 
 /* --------------------------  menudata ------------------------------------ */
 

--- a/Source/smokeview/update.c
+++ b/Source/smokeview/update.c
@@ -366,7 +366,7 @@ void UpdateShow(void){
 
   if(vis_hrr_plot==1&&hrrptr!=NULL)showhrrflag = 1;
 
-  if(hvacductvar_index >= 0 || hvacnodevar_index >= 0){
+  if(hvaccoll.hvacductvar_index >= 0 || hvaccoll.hvacnodevar_index >= 0){
     showhvacflag = 1;
   }
 
@@ -672,8 +672,8 @@ void UpdateShow(void){
     if(slicecolorbarflag==1||vslicecolorbarflag==1)num_colorbars++;
     if(patchflag==1&&wall_cell_color_flag==0)num_colorbars++;
     if(ReadZoneFile==1)num_colorbars++;
-    if(hvacductvar_index >= 0)num_colorbars++;
-    if(hvacnodevar_index >= 0)num_colorbars++;
+    if(hvaccoll.hvacductvar_index >= 0)num_colorbars++;
+    if(hvaccoll.hvacnodevar_index >= 0)num_colorbars++;
 
     if(tisoflag==1){
       showiso_colorbar = 1;
@@ -1271,11 +1271,11 @@ void UpdateTimes(void){
       MergeGlobalTimes(stimes, 2);
     }
   }
-  if(hvacductvar_index >= 0){
-    MergeGlobalTimes(hvacductvalsinfo->times, hvacductvalsinfo->ntimes);
+  if(hvaccoll.hvacductvar_index >= 0){
+    MergeGlobalTimes(hvaccoll.hvacductvalsinfo->times, hvaccoll.hvacductvalsinfo->ntimes);
   }
-  if(hvacnodevar_index >= 0){
-    MergeGlobalTimes(hvacnodevalsinfo->times, hvacnodevalsinfo->ntimes);
+  if(hvaccoll.hvacnodevar_index >= 0){
+    MergeGlobalTimes(hvaccoll.hvacnodevalsinfo->times, hvaccoll.hvacnodevalsinfo->ntimes);
   }
   if(use_tload_begin==1){
     MergeGlobalTimes(&tload_begin, 1);
@@ -1735,7 +1735,7 @@ int GetPlotStateSub(int choice){
       break;
     case DYNAMIC_PLOTS:
     case DYNAMIC_PLOTS_NORECURSE:
-      if(hvacductvar_index>=0||hvacnodevar_index>=0){
+      if(hvaccoll.hvacductvar_index>=0||hvaccoll.hvacnodevar_index>=0){
         stept = 1;
         return DYNAMIC_PLOTS;
       }

--- a/Source/smvq/CMakeLists.txt
+++ b/Source/smvq/CMakeLists.txt
@@ -58,6 +58,8 @@ add_executable(smvq smvq.c
     ../shared/getdata.c
     ../shared/color2rgb.c
     ../shared/readimage.c
+    ../shared/readhvac.c
+    ../shared/readcad.c
     ../shared/readgeom.c
     ../shared/readobject.c
     ../smokeview/colortable.c

--- a/Source/smvq/CMakeLists.txt
+++ b/Source/smvq/CMakeLists.txt
@@ -59,7 +59,6 @@ add_executable(smvq smvq.c
     ../shared/color2rgb.c
     ../shared/readimage.c
     ../shared/readhvac.c
-    ../shared/readcad.c
     ../shared/readgeom.c
     ../shared/readobject.c
     ../smokeview/colortable.c

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -99,6 +99,30 @@ if ((NOT MACOSX) AND UNIX)
     target_link_libraries(test_objects m)
 endif()
 
+# parse_hvac_vals
+add_executable(parse_hvac_vals parse_hvac_vals.c
+    ../Source/shared/readhvac.c
+    ../Source/shared/file_util.c
+    ../Source/shared/string_util.c
+    ../Source/shared/stdio_buffer.c
+    ../Source/shared/getdata.c
+    ../Source/shared/dmalloc.c
+    ../Source/shared/sha256.c
+    ../Source/shared/sha1.c
+    ../Source/shared/md5.c
+)
+
+target_include_directories(parse_hvac_vals PRIVATE
+    ../Tests
+    ../Source/shared
+)
+if (WIN32)
+    target_include_directories(parse_hvac_vals PRIVATE ../Source/pthreads)
+endif()
+if ((NOT MACOSX) AND UNIX)
+    target_link_libraries(parse_hvac_vals m)
+endif()
+
 # mem_test
 add_executable(mem_test mem_test.c
     ../Source/shared/dmalloc.c
@@ -127,15 +151,18 @@ add_test(NAME "Simple BNDF - Complete"
 # Arguments to this tests are <bndf path> <number of frames in bndf>
 # Simple slice is a finished slice file with 3 frames
 add_test(NAME "Simple PRT5 - Complete"
-COMMAND parse_simple_part ${CMAKE_SOURCE_DIR}/Tests/fig/smv/Tests/simple_part.prt5 3)
+    COMMAND parse_simple_part ${CMAKE_SOURCE_DIR}/Tests/fig/smv/Tests/simple_part.prt5 3)
 
 # Arguments to this tests are <bndf path> <number of frames in bndf>
 # Simple slice is a finished slice file with 3 frames
 add_test(NAME "Simple PL3d - Complete"
-COMMAND parse_simple_pl3d ${CMAKE_SOURCE_DIR}/Tests/fig/smv/Tests/simple_pl3d.q)
+    COMMAND parse_simple_pl3d ${CMAKE_SOURCE_DIR}/Tests/fig/smv/Tests/simple_pl3d.q)
 
 add_test(NAME "Test Object API"
-COMMAND test_objects ${CMAKE_SOURCE_DIR}/Tests/bad_objects.svo)
+    COMMAND test_objects ${CMAKE_SOURCE_DIR}/Tests/bad_objects.svo)
+
+add_test(NAME "Simple HVAC Vals - Complete"
+	COMMAND parse_hvac_vals ${CMAKE_SOURCE_DIR}/Tests/fig/smv/Tests/simple_hvac.hvac)
 
 add_test(NAME "Mem Test"
     COMMAND mem_test)

--- a/Tests/get_test_data.ps1
+++ b/Tests/get_test_data.ps1
@@ -1,4 +1,4 @@
-$commit = "bf2446b600b4062196923a74cd2cf67c3b7be76d"
+$commit = "83e6a770f511e315af21be5868d758b99f0a83ad"
 
 $zip_path = "$env:temp\test-data.zip"
 $unzip_path = "$env:temp\test-data-out"

--- a/Tests/get_test_data.sh
+++ b/Tests/get_test_data.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-COMMIT=bf2446b600b4062196923a74cd2cf67c3b7be76d
+COMMIT=83e6a770f511e315af21be5868d758b99f0a83ad
 
 TEMP_DIR=$(mktemp -d)
 ZIP_PATH=$TEMP_DIR/test-data.zip

--- a/Tests/parse_hvac_vals.c
+++ b/Tests/parse_hvac_vals.c
@@ -1,0 +1,122 @@
+#include "options.h"
+
+// TODO: sort out imports
+#include "MALLOCC.h"
+#include "getdata.h"
+#include <stdlib.h>
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "MALLOCC.h"
+#include "datadefs.h"
+#include "histogram.h"
+#include "isodefs.h"
+#include "string_util.h"
+
+#include "file_util.h"
+#include "stdio_buffer.h"
+
+#include "readhvac.h"
+
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
+void init_vals(hvacdatacollection *hvaccoll, const char *file) {
+  NewMemory((void **)&(hvaccoll->hvacductvalsinfo), sizeof(hvacvalsdata));
+  hvaccoll->hvacductvalsinfo->times = NULL;
+  hvaccoll->hvacductvalsinfo->loaded = 0;
+  hvaccoll->hvacductvalsinfo->node_vars = NULL;
+  hvaccoll->hvacductvalsinfo->duct_vars = NULL;
+  hvaccoll->hvacductvalsinfo->file = strdup(file);
+  hvaccoll->hvacductvalsinfo->n_node_vars = 0;
+
+  hvaccoll->hvacductvalsinfo->n_duct_vars = 4;
+
+  if (hvaccoll->hvacductvalsinfo->n_duct_vars > 0) {
+    NewMemory((void **)&hvaccoll->hvacductvalsinfo->duct_vars,
+              hvaccoll->hvacductvalsinfo->n_duct_vars * sizeof(hvacvaldata));
+    {
+      hvacvaldata *hi = hvaccoll->hvacductvalsinfo->duct_vars;
+      InitHvacData(hi);
+      hi->label.longlabel = "DUCT VELOCITY";
+      hi->label.shortlabel = "vel_d";
+      hi->label.unit = "m/s";
+    }
+    {
+      hvacvaldata *hi = hvaccoll->hvacductvalsinfo->duct_vars + 1;
+      InitHvacData(hi);
+      hi->label.longlabel = "DUCT LOSS";
+      hi->label.shortlabel = "loss_d";
+      hi->label.unit = "";
+    }
+    {
+      hvacvaldata *hi = hvaccoll->hvacductvalsinfo->duct_vars + 2;
+      InitHvacData(hi);
+      hi->label.longlabel = "OXYGEN DUCT VOLUME FRACTION";
+      hi->label.shortlabel = "X_d_O2";
+      hi->label.unit = "mol/mol";
+    }
+    {
+      hvacvaldata *hi = hvaccoll->hvacductvalsinfo->duct_vars + 3;
+      InitHvacData(hi);
+      hi->label.longlabel = "NITROGEN DUCT VOLUME FRACTION";
+      hi->label.shortlabel = "X_d_N2";
+      hi->label.unit = "mol/mol";
+    }
+  }
+
+  FREEMEMORY(hvaccoll->hvacnodevalsinfo);
+  NewMemory((void **)&hvaccoll->hvacnodevalsinfo, sizeof(hvacvalsdata));
+  memcpy(hvaccoll->hvacnodevalsinfo, hvaccoll->hvacductvalsinfo,
+         sizeof(hvacvalsdata));
+}
+
+int main(int argc, char **argv) {
+  initMALLOC();
+  FILE *file;
+  int error = 0;
+
+  char *val_spec = "HVACVALS\
+ HVAC_damper.hvac                                                                                                                                                                                                                                          \
+ 0\
+ 4\
+ DUCT VELOCITY\
+ vel_d\
+ m/s\
+ DUCT LOSS\
+ loss_d\
+ \
+ OXYGEN DUCT VOLUME FRACTION\
+ X_d_O2\
+ mol/mol\
+ NITROGEN DUCT VOLUME FRACTION\
+ X_d_N2\
+ mol/mol";
+
+  fprintf(stderr, "file: %s\n", argv[1]);
+  hvacdatacollection hvaccoll = {0};
+  init_vals(&hvaccoll, argv[1]);
+
+  FILE_SIZE file_size;
+  int ret = ReadHVACData0(&hvaccoll, 0, &file_size);
+  if (ret) return ret;
+  for (int i = 0; i < hvaccoll.hvacductvalsinfo->n_duct_vars; i++) {
+    hvacvaldata *hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
+    fprintf(stderr, "%s\n", hi->label.longlabel);
+    fprintf(stderr, "  shortlabel: %s\n", hi->label.shortlabel);
+    fprintf(stderr, "  units: %s\n", hi->label.unit);
+    fprintf(stderr, "  nvals: %d\n", hi->nvals);
+    for (int j = 0; j < hi->nvals + 100; j++) {
+      fprintf(stderr, "    %d: %g\n", j, hi->vals[j]);
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
Functions for parsing *.hvac files are moved to shared and hvac values are combined into a struct in order to reduce the number of globals.

This includes a test to parse *.hvac files which pulls an example from the `fig` repo.