### PR TITLE
add a trailing slash to GetSmvRootDir

### DIFF
--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -1103,6 +1103,7 @@ char *GetBinDir(){
   // NB: This uses on older function in order to support "char *".
   // PathCchRemoveFileSpec would be better but requires switching to "wchar *".
   PathRemoveFileSpecA(buffer);
+  PathAddBackslashA(buffer);
   return buffer;
 }
 #elif __linux__
@@ -1137,6 +1138,10 @@ char *GetBinPath(){
 char *GetBinDir(){
   char *buffer = GetBinPath();
   dirname(buffer);
+  int pathlen = strlen(buffer);
+  RESIZEMEMORY(buffer, pathlen + 2);
+  buffer[pathlen] = '/';
+  buffer[pathlen + 1] = '\0';
   return buffer;
 }
 #else
@@ -1172,8 +1177,11 @@ char *GetBinDir(){
   // The BSD and OSX version of dirname uses an internal buffer, therefore we
   // need to copy the string out.
   char *dir_buffer = dirname(buffer);
-  RESIZEMEMORY(buffer, (strlen(dir_buffer) + 1) * sizeof(char));
+  int pathlen = strlen(buffer);
+  RESIZEMEMORY(buffer, (pathlen + 2) * sizeof(char));
   STRCPY(buffer, dir_buffer);
+  buffer[pathlen] = '/';
+  buffer[pathlen + 1] = '\0';
   return buffer;
 }
 #endif

--- a/Source/shared/readobject.c
+++ b/Source/shared/readobject.c
@@ -1367,6 +1367,7 @@ int ReadObjectDefs(object_collection *objectscoll, const char *file,
   //   PRINTF("- complete");
   //   PRINTF("\n\n");
   // }
+  PRINTF("%d object definitions read from %s\n", ndevices, file);
   return ndevices;
 }
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -139,6 +139,29 @@ target_include_directories(mem_test PRIVATE
     ../Source/shared
 )
 
+# test_root_dir
+add_executable(test_root_dir test_root_dir.c
+    ../Source/shared/dmalloc.c
+    ../Source/shared/readobject.c
+    ../Source/shared/string_util.c
+    ../Source/shared/file_util.c
+    ../Source/shared/stdio_buffer.c
+    ../Source/shared/sha256.c
+    ../Source/shared/sha1.c
+    ../Source/shared/md5.c
+)
+
+target_include_directories(test_root_dir PRIVATE
+    ../Tests
+    ../Source/shared
+)
+if (WIN32)
+    target_include_directories(test_root_dir PRIVATE ../Source/pthreads)
+endif()
+if ((NOT MACOSX) AND UNIX)
+    target_link_libraries(test_root_dir m)
+endif()
+
 # Arguments to this tests are <slice path> <number of frames in slice>
 # Simple slice is a finished slice file with 3 frames
 add_test(NAME "Simple Slice - Complete"
@@ -172,3 +195,6 @@ COMMAND test_objects ${CMAKE_SOURCE_DIR}/Tests/bad_objects.svo)
 
 add_test(NAME "Mem Test"
     COMMAND mem_test)
+
+add_test(NAME "Test Root Dir"
+    COMMAND test_root_dir)

--- a/Tests/test_root_dir.c
+++ b/Tests/test_root_dir.c
@@ -1,0 +1,27 @@
+#include "options.h"
+
+#include "getdata.h"
+
+#include "MALLOCC.h"
+
+#include "file_util.h"
+#include "string_util.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
+int main(int argc, char **argv) {
+  initMALLOC();
+  {
+    char *root = GetSmvRootDir();
+    int root_len = strlen(root);
+    assert(root_len > 0);
+    assert(root[root_len - 1] == dirseparator[0]);
+  }
+  return 0;
+}


### PR DESCRIPTION
A lot of places in the code assume a trailing slash on the SMV install directory. This ensures that GetSmvRootDir always returns with a trailing slash.

Test included.

This also logs which object files are read as it was the origin of the issue.