### PR TITLE
ci: bootstrap vcpkg

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -146,6 +146,7 @@ jobs:
           cd C:\vcpkg
           git fetch
           git checkout 2024.03.25
+          .\\bootstrap-vcpkg.bat
       - name: build smokeview
         shell: cmd
         run: |


### PR DESCRIPTION
This addresses an issue with the Github actions image possibly not having 7zip (causing actions to fail).