### PR TITLE
smokeview source: fix to boundary file mesh interface drawing routine…

### DIFF
--- a/Source/smokeview/IOboundary.c
+++ b/Source/smokeview/IOboundary.c
@@ -4254,6 +4254,11 @@ void DrawBoundaryMeshInterface(meshdata *meshi, int mode){
 
       bc = patch_mesh->blockageinfoptrs[ib];
       if(bc->showtimelist != NULL && bc->showtimelist[itimes] == 0)continue;
+#ifdef pp_PATCH_FACTOR
+      int *ijk;
+      ijk = bc->ijk;
+      if(ijk[0] == ijk[1] || ijk[2] == ijk[3] || ijk[4] == ijk[5])continue;
+#endif
       if(pfi->ib[0] == pfi->ib[1]){
         icol_start = bc->ijk[2];
         icol_end   = bc->ijk[3];

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -17,7 +17,7 @@
 #endif
 //#define pp_FDS            // create a 1 mesh input file
 //#define pp_PATCH_DEBUG    // add boundary file debugging widgets
-//#define pp_PATCH_FACTOR   // set boundary file patch offsets to zero
+#define pp_PATCH_FACTOR     // set boundary file patch offsets to zero
 
 #ifdef pp_FRAME          // turn on each frame type if pp_FRAME is set
 #define pp_BOUNDFRAME    // turn on frame code for boundary files


### PR DESCRIPTION
… so it doesn't draw 2 overlapping patch images