### PR TITLE
use stderr for logging in shared/

### DIFF
--- a/Source/shared/IOframe.c
+++ b/Source/shared/IOframe.c
@@ -7,14 +7,14 @@
 #include "IOframe.h"
 #include "file_util.h"
 
-// The routines is this file read data files consisting of a header followed by one or 
-// more data frames.  Each data frame starts with a time value followed by a number 
-// data of values.  The number of values in a frame may vary.  The frame data structures 
-// are initialized using FRAMEInit.  This routine is passed a file name,  a file type 
+// The routines is this file read data files consisting of a header followed by one or
+// more data frames.  Each data frame starts with a time value followed by a number
+// data of values.  The number of values in a frame may vary.  The frame data structures
+// are initialized using FRAMEInit.  This routine is passed a file name,  a file type
 // parameter (C or Fortran) and a routine that determines the size of each data frame.
-// FDS generated files use the Fortran file type. Each Fortran generated data record 
+// FDS generated files use the Fortran file type. Each Fortran generated data record
 // is prefixed and suffixed with four bytes. Files compressed with smokezip use the
-// C file type. The FRAMEsetup routine is then called when a file is read in define the 
+// C file type. The FRAMEsetup routine is then called when a file is read in define the
 // header and data frame sizes.  These operations are consolidated by the FRAMELoadFrame routine.
 
   /* ------------------ FRAMEInit ------------------------ */
@@ -204,7 +204,7 @@ void FRAMESetTimes(framedata *fi, int iframe, int nframes){
 #ifdef pp_FRAME_DEBUG2
     float time;
     time = fi->times[i];
-    printf("time[%i]=%f\n", i,time);
+    fprintf(stderr, "time[%i]=%f\n", i,time);
 #endif
   }
 }
@@ -330,7 +330,7 @@ int FRAMEGetNFrames(char *file, int type){
   return nframes;
 }
 
-//******* The following routines define header and frame sizes for each file type 
+//******* The following routines define header and frame sizes for each file type
 //        (3d smoke, slice, isosurface, and particle - boundary file routine not implemente)
 /* ------------------ GetSmoke3DFrameInfo ------------------------ */
 
@@ -426,7 +426,7 @@ void GetSmoke3DFrameInfo(bufferdata *bufferinfo, int *headersizeptr, int **frame
 
 /* ------------------ GetBoundaryFrameInfo ------------------------ */
 
-void GetBoundaryFrameInfo(bufferdata *bufferinfo, int *headersizeptr, int **framesptr, int *nframesptr, 
+void GetBoundaryFrameInfo(bufferdata *bufferinfo, int *headersizeptr, int **framesptr, int *nframesptr,
                           int **subframeoffsetsptr, int **subframesizesptr, int *nsubframesptr,
                           int *compression_type, FILE_SIZE *filesizeptr){
   FILE *stream;
@@ -596,7 +596,7 @@ void GetSliceFrameInfo(bufferdata *bufferinfo, int *headersizeptr, int **framesp
     *framesptr = NULL;
   }
 
-  headersize = 3*(4+30+4);  // 3 30 byte labels 
+  headersize = 3*(4+30+4);  // 3 30 byte labels
   fseek_m(stream, headersize, SEEK_CUR);
 
   fseek_m(stream, 4, SEEK_CUR);returncode = fread_m(ijk, 4, 6, stream);fseek_m(stream, 4, SEEK_CUR);
@@ -755,8 +755,8 @@ void GetGeomDataFrameInfo(bufferdata *bufferinfo, int *headersizeptr, int **fram
   }
 
   if(*compression_type != FRAME_ZLIB){
-    headersize  = 4+4+4;  // 1 
-    headersize += 4+4+4;  // version 
+    headersize  = 4+4+4;  // 1
+    headersize += 4+4+4;  // version
   }
   else{
     headersize  = 4;  // 1
@@ -889,7 +889,7 @@ void GetPartFrameInfo(bufferdata *bufferinfo, int *headersizeptr, int **framespt
       fseek_m(stream, 4, SEEK_CUR);returncode = fread_m(&nplim, 4, 1, stream);fseek_m(stream, 4, SEEK_CUR);
       framesize += 4 + 4 + 4;             // nplim
 
-//      printf("nplim %i: %i\n",i, nplim);
+//      fprintf(stderr, "nplim %i: %i\n",i, nplim);
       skip  = 4 + 3*nplim*sizeof(float) + 4;          // xp, yp, zp
       skip += 4 +   nplim*sizeof(int)   + 4;          // tag
       if(nquants[2*i] > 0){

--- a/Source/shared/dmalloc.c
+++ b/Source/shared/dmalloc.c
@@ -99,7 +99,7 @@ void PrintMemoryError(size_t size, const char *varname, const char *file, int li
     if(file2 != NULL)file = file2+1;
     fprintf(stderr," at %s(%i)\n",file,linenumber);
   }
-  printf("\n");
+  fprintf(stderr, "\n");
   assert(1==0); // force smokeview to abort when in debug mode
 }
 
@@ -134,7 +134,7 @@ mallocflag _NewMemoryNOTHREAD(void **ppv, size_t size, int memory_id){
   //  float total, maxmem;
   //  total = MMtotalmemory/1000000000.0;
   //  maxmem = MMmaxmemory / 1000000000.0;
-  //  printf("memory allocated: %f GB out of %f GB\n",total,maxmem);
+  //  fprintf(stderr, "memory allocated: %f GB out of %f GB\n",total,maxmem);
   if(MMmaxmemory == 0 || MMtotalmemory + size <= MMmaxmemory){
     this_ptr = (void *)malloc(infoblocksize + size + sizeofDebugByte);
   }
@@ -364,7 +364,7 @@ mallocflag __NewMemory(void **ppv, size_t size, int memory_id, const char *varna
 #endif
 
 #ifdef pp_MEM_DEBUG_PRINT
-  printf("file: %s line: %i\n", file, linenumber);
+  fprintf(stderr, "file: %s line: %i\n", file, linenumber);
 #endif
   LOCK_MEM;
   return_code=_NewMemoryNOTHREAD(ppb,size,memory_id);
@@ -479,17 +479,17 @@ void _PrintAllMemoryInfo(void){
   blockinfo *pbi;
   int n=0,size=0;
 
-  printf("\n\n");
-  printf("********************************************\n");
-  printf("********************************************\n");
-  printf("********************************************\n");
+  fprintf(stderr, "\n\n");
+  fprintf(stderr, "********************************************\n");
+  fprintf(stderr, "********************************************\n");
+  fprintf(stderr, "********************************************\n");
   for(pbi = pbiHead; pbi != NULL; pbi = pbi->pbiNext)
   {
     n++;
     size += pbi->size;
-    printf("%s allocated in %s at line %i\n",pbi->varname,pbi->filename,pbi->linenumber);
+    fprintf(stderr, "%s allocated in %s at line %i\n",pbi->varname,pbi->filename,pbi->linenumber);
   }
-  printf("nblocks=%i sizeblocks=%i\n",n,size);
+  fprintf(stderr, "nblocks=%i sizeblocks=%i\n",n,size);
 }
 
 /* ------------------ GetBlockInfo_nofail ------------------------ */

--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -128,7 +128,7 @@ void CopyFILE(char *destdir, char *file_in, char *file_out, int mode){
     fclose(streamin);
     return;
   }
-  PRINTF("  Copying %s to %s\n",file_in,file_out);
+  fprintf(stderr, "  Copying %s to %s\n",file_in,file_out);
   for(;;){
     int end_of_file;
 
@@ -651,7 +651,7 @@ void PrintTime(const char *filepath, int line, float *timer, const char *label, 
   }
   if(label != NULL){
     if(stop_flag == 1)STOP_TIMER(*timer);
-    if(*timer > 0.1)printf("%s/%i/%s %.1f s\n", file, line, label, *timer);
+    if(*timer > 0.1)fprintf(stderr, "%s/%i/%s %.1f s\n", file, line, label, *timer);
   }
   START_TIMER(*timer);
 }

--- a/Source/shared/fopen.c
+++ b/Source/shared/fopen.c
@@ -48,13 +48,13 @@ void RemoveOpenFile(FILE *stream){
 
     oi = openinfo + i;
     if(oi->stream == stream){
-      printf("close file:%s\n", oi->file);
+      fprintf(stderr, "close file:%s\n", oi->file);
       oi->stream = NULL;
       remove_index = i;
     }
   }
   if(remove_index < 0){
-    printf("file is not in list\n");
+    fprintf(stderr, "file is not in list\n");
     return;
   }
   int nmove;
@@ -76,9 +76,9 @@ void RemoveOpenFile(FILE *stream){
       opendata *oi;
 
       oi = openinfo + i;
-      printf("file: %s\n", oi->file);
-      printf("source: %s\n", oi->source);
-      printf("line: %i\n\n", oi->line);
+      fprintf(stderr, "file: %s\n", oi->file);
+      fprintf(stderr, "source: %s\n", oi->source);
+      fprintf(stderr, "line: %i\n\n", oi->line);
     }
   }
   UNLOCK_FOPEN;
@@ -109,7 +109,7 @@ int fclose_counting(FILE *stream)
     RemoveOpenFile(stream);
     open_files--;
     if(open_files < 0){
-      printf("file count negative\n");
+      fprintf(stderr, "file count negative\n");
     }
   }
   return status;

--- a/Source/shared/getdata.c
+++ b/Source/shared/getdata.c
@@ -135,7 +135,7 @@ void getzonesize(const char *zonefilename, int *nzonet, int *nrooms,
   file = FOPEN(zonefilename, "rb");
 
   if(file == NULL){
-    printf(" The zone file name, %s does not exist\n", zonefilename);
+    fprintf(stderr, " The zone file name, %s does not exist\n", zonefilename);
     *error = 1;
     return;
   }
@@ -190,13 +190,13 @@ void getpatchsizes1(FILE **file, const char *patchfilename, int *npatch,
   *error = 0;
   assert(file!=NULL);
   if(file == NULL){
-    printf("***Error: null pointer in getpatchsizes1 routine\n");
+    fprintf(stderr, "***Error: null pointer in getpatchsizes1 routine\n");
     *error = 1;
     return;
   }
   *file = FOPEN(patchfilename, "rb");
   if(*file == NULL){
-    printf(" The boundary file name, %s does not exist\n", patchfilename);
+    fprintf(stderr, " The boundary file name, %s does not exist\n", patchfilename);
     *error = 1;
     return;
   }
@@ -412,7 +412,7 @@ void getboundaryheader1(const char *boundaryfilename, FILE **file, int *npatch,
   *error = 0;
   *file = FOPEN(boundaryfilename, "rb");
   if(*file == NULL){
-    printf(" The boundary file name, %s does not exist\n", boundaryfilename);
+    fprintf(stderr, " The boundary file name, %s does not exist\n", boundaryfilename);
     *error = 1;
     return;
   }
@@ -471,7 +471,7 @@ FILE *openboundary(const char *boundaryfilename, int version, int *error){
   int npatch;
   FILE *file = FOPEN(boundaryfilename, "rb");
   if(file == NULL){
-    printf(" The boundary file name, %s does not exist\n", boundaryfilename);
+    fprintf(stderr, " The boundary file name, %s does not exist\n", boundaryfilename);
     *error = 1;
     return file;
   }
@@ -608,7 +608,7 @@ void getzonedata(const char *zonefilename, int *nzonet, int *nrooms,
 
   FILE *file = FOPEN(zonefilename, "rb");
   if(file == NULL){
-    printf(" The zone file name, %s does not exist\n", zonefilename);
+    fprintf(stderr, " The zone file name, %s does not exist\n", zonefilename);
     *error = 1;
     return;
   }
@@ -780,7 +780,7 @@ void writeslicedata(const char *slicefilename, int is1, int is2, int js1,
   nysp = js2 + 1 - js1;
   nzsp = ks2 + 1 - ks1;
   nframe = nxsp * nysp * nzsp;
-  if(redirect_flag == 0) printf("output slice data to %s\n", slicefilename);
+  if(redirect_flag == 0) fprintf(stderr, "output slice data to %s\n", slicefilename);
   int i;
   for(i = 0; i < ntimes; i++){
     fortwrite(times + i, sizeof(float), 1, file);
@@ -950,7 +950,7 @@ void getplot3dq(const char *qfilename, int nx, int ny, int nz, float *qq, float 
     *error = 0;
     FILE *file = FOPEN(qfilename, "rb");
     if(file == NULL){
-      printf(" The file name, %s does not exist\n", qfilename);
+      fprintf(stderr, " The file name, %s does not exist\n", qfilename);
       exit(1);
     }
     *error = fortread(npts, sizeof(*npts), 3, file);
@@ -966,9 +966,9 @@ void getplot3dq(const char *qfilename, int nx, int ny, int nz, float *qq, float 
       if(*error) goto end;
     } else{
       *error = 1;
-      printf(" *** Fatal error in getplot3dq ***\n");
-      printf(" Grid size found in plot3d file was: %d,%d,%d\n", (int)nxpts, (int)nypts, (int)nzpts);
-      printf(" Was expecting: %d,%d,%d\n", nx, ny, nz);
+      fprintf(stderr, " *** Fatal error in getplot3dq ***\n");
+      fprintf(stderr, " Grid size found in plot3d file was: %d,%d,%d\n", (int)nxpts, (int)nypts, (int)nzpts);
+      fprintf(stderr, " Was expecting: %d,%d,%d\n", nx, ny, nz);
       exit(1);
     }
   end:

--- a/Source/shared/options_common.h
+++ b/Source/shared/options_common.h
@@ -94,11 +94,11 @@
 
 #ifdef pp_TRACE
 #define BTRACE \
-  printf("entering, file: %s, line: %d\n",__FILE__,__LINE__)
+  fprintf(stderr, "entering, file: %s, line: %d\n",__FILE__,__LINE__)
 #define TTRACE \
-  printf("in, file: %s, line: %d\n",__FILE__,__LINE__)
+  fprintf(stderr, "in, file: %s, line: %d\n",__FILE__,__LINE__)
 #define ETRACE \
-  printf("leaving, file: %s, line: %d\n",__FILE__,__LINE__)
+  fprintf(stderr, "leaving, file: %s, line: %d\n",__FILE__,__LINE__)
 #else
 #define BTRACE
 #define TTRACE

--- a/Source/shared/readgeom.c
+++ b/Source/shared/readgeom.c
@@ -602,7 +602,7 @@ void DecimateTerrain(vertdata *verts, int nverts, tridata *triangles,
       tri->ival = ival;
     }
   }
-  printf("ncount1=%i ncount2=%i\n", ntriangles, ncount2);
+  fprintf(stderr, "ncount1=%i ncount2=%i\n", ntriangles, ncount2);
   FREEMEMORY(tri_new);
 }
 

--- a/Source/shared/smokestream.c
+++ b/Source/shared/smokestream.c
@@ -328,16 +328,16 @@ int StreamAllLoaded(streamdata *stream){
 
 void StreamFrameSizeOutput(size_t file_size, float *time){
   if(file_size>1000000000){
-    PRINTF("(%.1f GB", (float)file_size/1000000000.);
+    fprintf(stderr, "(%.1f GB", (float)file_size/1000000000.);
   }
   else if(file_size>1000000){
-    PRINTF("(%.1f MB", (float)file_size/1000000.);
+    fprintf(stderr, "(%.1f MB", (float)file_size/1000000.);
   }
   else{
-    PRINTF("(%.0f KB", (float)file_size/1000.);
+    fprintf(stderr, "(%.0f KB", (float)file_size/1000.);
   }
-  if(time!=NULL)PRINTF("/%.1f s", *time);
-  PRINTF(")\n");
+  if(time!=NULL)fprintf(stderr, "/%.1f s", *time);
+  fprintf(stderr, ")\n");
 }
 
 /* ------------------  StreamReadList ------------------------ */
@@ -376,7 +376,7 @@ void StreamReadList(streamdata **streams, int nstreams){
       }
       if(stream_pause==1)PauseTime(0.5);
       if(count_streams>0&&stream_output==1){
-        printf("Loading frame(%i streams): %i\n", count_streams, frame_index);
+        fprintf(stderr, "Loading frame(%i streams): %i\n", count_streams, frame_index);
       }
     }
     // check if all frames have been loaded, if so then we are finished if not then load some more
@@ -397,13 +397,13 @@ void StreamReadList(streamdata **streams, int nstreams){
         streamdata *streami;
 
         streami = streams[stream_index];
-        printf("Loaded %s", streami->file);
+        fprintf(stderr, "Loaded %s", streami->file);
         StreamFrameSizeOutput(streami->filesize, &(streami->load_time));
         total_filesize += streami->filesize;
         total_time     += streami->load_time;
       }
       if(nstreams>1){
-        printf("Loaded total(%f)", totaltime);
+        fprintf(stderr, "Loaded total(%f)", totaltime);
         StreamFrameSizeOutput(total_filesize, &total_time);
       }
       return;
@@ -425,12 +425,11 @@ void StreamCheck(streamdata *framestream){
     offset = framestream->frame_offsets[i]+4;
     fseek(filestream, offset, SEEK_SET);
     fread(&time, 4, 1, filestream);
-    printf("%f ", time);
-    if(i%10==0)printf("\n");
+    fprintf(stderr, "%f ", time);
+    if(i%10==0)fprintf(stderr, "\n");
   }
-  printf("\n");
+  fprintf(stderr, "\n");
   fclose(filestream);
 }
 
 #endif
-

--- a/Source/shared/stdio_buffer.c
+++ b/Source/shared/stdio_buffer.c
@@ -16,7 +16,7 @@ void OutputFileBuffer(filedata *fileinfo){
 
     buffer = fileinfo->lines[i];
     if(buffer==NULL||strlen(buffer)==0)continue;
-    printf("%s\n", buffer);
+    fprintf(stderr, "%s\n", buffer);
   }
 }
 
@@ -34,7 +34,7 @@ bufferstreamdata *AppendFileBuffer(bufferstreamdata *stream, char *file){
 
   file1 = stream->fileinfo;
   file2 = stream2->fileinfo;
-  
+
   if(NewMemory((void **)&buffer, file1->filesize + file2->filesize)==0){
     return stream;
   }

--- a/Source/smokeview/getdatabounds.c
+++ b/Source/smokeview/getdatabounds.c
@@ -1045,7 +1045,7 @@ void BoundsUpdate(int file_type){
     strcat(label2, "SLICE");
     strcat(label3, "SLICE");
 #ifdef pp_BOUND_DEBUG
-    printf("BoundsUpdate(SLICE)\n");
+    fprintf(stderr, "BoundsUpdate(SLICE)\n");
 #endif
   }
   else if(file_type == BOUND_PATCH){
@@ -1053,7 +1053,7 @@ void BoundsUpdate(int file_type){
     strcat(label2, "PATCH");
     strcat(label3, "PATCH");
 #ifdef pp_BOUND_DEBUG
-    printf("BoundsUpdate(PATCH)\n");
+    fprintf(stderr, "BoundsUpdate(PATCH)\n");
 #endif
   }
   else if(file_type == BOUND_PLOT3D){
@@ -1061,7 +1061,7 @@ void BoundsUpdate(int file_type){
     strcat(label2, "PLOT3D");
     strcat(label3, "PLOT3D");
 #ifdef pp_BOUND_DEBUG
-    printf("BoundsUpdate(PLOT3D)\n");
+    fprintf(stderr, "BoundsUpdate(PLOT3D)\n");
 #endif
   }
   INIT_PRINT_TIMER(bound_setup);


### PR DESCRIPTION
Generally, the shared code (e.g. `dmalloc.c`) uses stderr for logging, but isn't consistent and sometimes stdout is used. This changes all of uses of stdout for logging to stderr within shared/ (and one instance in smokeview/).

This is particularly useful for programs (in particular `smvq`) that outputs data to stdout, allowing us to separate logging from output data. For example `smvq CHID.smv | further-processing | filter > result.json`.