### PR TITLE
smokeview source: use GL_H and GLU_H headers in scontour2d.c instead …

### DIFF
--- a/Source/shared/scontour2d.c
+++ b/Source/shared/scontour2d.c
@@ -1,11 +1,13 @@
 #include "options.h"
 #include <stdlib.h>
 #include <stdio.h>
-#ifdef pp_DRAW
-#include GLUT_H
-#endif
 #include "scontour2d.h"
 #include "dmalloc.h"
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#include GLU_H
+#include GL_H
 
 #define SOLID 0
 #define GAS 1
@@ -707,8 +709,6 @@ void GetContourAreas(const contour *ci){
   }
 }
 
-#ifdef pp_DRAW
-
 /*  ------------------ DrawContours ------------------------ */
 
 void DrawContours(const contour *ci){
@@ -809,5 +809,3 @@ void DrawLineContours(const contour *ci, float linewidth){
     }
   }
 }
-#endif
-

--- a/Source/smokeview/options.h
+++ b/Source/smokeview/options.h
@@ -40,9 +40,6 @@
 #endif
 #endif
 
-//*** options: all platforms
-#define pp_DRAW             // turn on glut/opengl drawing routines in shared files (currently just scontour2d.c )
-
 //*** options: Linux
 
 #ifdef pp_LINUX


### PR DESCRIPTION
…of  GLUT_H