### PR TITLE
split colorbar functions into shared

### DIFF
--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -48,7 +48,7 @@ bin = .
 
 csrc = callbacks.c camera.c color2rgb.c readimage.c readgeom.c readobject.c readcad.c colortimebar.c compress.c csphere.c dmalloc.c \
       drawGeometry.c file_util.c getdata.c getdatabounds.c getdatacolors.c glew.c  \
-      histogram.c infoheader.c readlabel.c readtour.c readhvac.c readslice.c readsmoke.c \
+      histogram.c infoheader.c readlabel.c readtour.c readhvac.c readslice.c readsmoke.c colorbars.c colorbar_defs.c \
       IOboundary.c IOgeometry.c IOhvac.c IOiso.c IOobjects.c IOpart.c IOplot2d.c IOplot3d.c \
       IOscript.c IOshooter.c IOslice.c IOsmoke.c IOtour.c IOvolsmoke.c IOwui.c IOzone.c IOframe.o isobox.c \
       main.c md5.c menus.c output.c readsmv.c renderhtml.c renderimage.c scontour2d.c sha1.c \

--- a/Source/shared/CMakeLists.txt
+++ b/Source/shared/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(libsmv STATIC
     stdio_buffer.c
     getdata.c
     color2rgb.c
+    colorbars.c
+    colorbar_defs.c
     readimage.c
     readcad.c
     readgeom.c

--- a/Source/shared/colorbar_defs.c
+++ b/Source/shared/colorbar_defs.c
@@ -1,0 +1,697 @@
+#include <string.h>
+
+#include "dmalloc.h"
+#include "colorbars.h"
+
+// rainbow colorbar
+void CreateColorbarRainbow(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "Rainbow");
+  cbi->nnodes = 5;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 255;
+
+  cbi->node_index[1] = 64;
+  cbi->node_rgb[3] = 0;
+  cbi->node_rgb[4] = 192;
+  cbi->node_rgb[5] = 192;
+
+  cbi->node_index[2] = 128;
+  cbi->node_rgb[6] = 0;
+  cbi->node_rgb[7] = 255;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 192;
+  cbi->node_rgb[9] = 192;
+  cbi->node_rgb[10] = 192;
+  cbi->node_rgb[11] = 0;
+
+  cbi->node_index[4] = 255;
+  cbi->node_rgb[12] = 255;
+  cbi->node_rgb[13] = 0;
+  cbi->node_rgb[14] = 0;
+  strcpy(cbi->colorbar_type, "rainbow");
+}
+// original rainbow colorbar
+void CreateColorbarOriginalRainbow(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "Rainbow_orig");
+  cbi->nnodes = 5;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 255;
+
+  cbi->node_index[1] = 64;
+  cbi->node_rgb[3] = 0;
+  cbi->node_rgb[4] = 255;
+  cbi->node_rgb[5] = 255;
+
+  cbi->node_index[2] = 128;
+  cbi->node_rgb[6] = 0;
+  cbi->node_rgb[7] = 255;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 192;
+  cbi->node_rgb[9] = 255;
+  cbi->node_rgb[10] = 255;
+  cbi->node_rgb[11] = 0;
+
+  cbi->node_index[4] = 255;
+  cbi->node_rgb[12] = 255;
+  cbi->node_rgb[13] = 0;
+  cbi->node_rgb[14] = 0;
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// Rainbow 2 colorbar
+void CreateColorbarRainbow2(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "Rainbow 2");
+  cbi->nnodes = 12;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 4;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 108;
+
+  cbi->node_index[1] = 20;
+  cbi->node_rgb[3] = 6;
+  cbi->node_rgb[4] = 3;
+  cbi->node_rgb[5] = 167;
+
+  cbi->node_index[2] = 60;
+  cbi->node_rgb[6] = 24;
+  cbi->node_rgb[7] = 69;
+  cbi->node_rgb[8] = 240;
+
+  cbi->node_index[3] = 70;
+  cbi->node_rgb[9] = 31;
+  cbi->node_rgb[10] = 98;
+  cbi->node_rgb[11] = 214;
+
+  cbi->node_index[4] = 80;
+  cbi->node_rgb[12] = 5;
+  cbi->node_rgb[13] = 125;
+  cbi->node_rgb[14] = 170;
+
+  cbi->node_index[5] = 96;
+  cbi->node_rgb[15] = 48;
+  cbi->node_rgb[16] = 155;
+  cbi->node_rgb[17] = 80;
+
+  cbi->node_index[6] = 112;
+  cbi->node_rgb[18] = 82;
+  cbi->node_rgb[19] = 177;
+  cbi->node_rgb[20] = 8;
+
+  cbi->node_index[7] = 163;
+  cbi->node_rgb[21] = 240;
+  cbi->node_rgb[22] = 222;
+  cbi->node_rgb[23] = 3;
+
+  cbi->node_index[8] = 170;
+  cbi->node_rgb[24] = 249;
+  cbi->node_rgb[25] = 214;
+  cbi->node_rgb[26] = 7;
+
+  cbi->node_index[9] = 200;
+  cbi->node_rgb[27] = 252;
+  cbi->node_rgb[28] = 152;
+  cbi->node_rgb[29] = 22;
+
+  cbi->node_index[10] = 230;
+  cbi->node_rgb[30] = 254;
+  cbi->node_rgb[31] = 67;
+  cbi->node_rgb[32] = 13;
+
+  cbi->node_index[11] = 255;
+  cbi->node_rgb[33] = 215;
+  cbi->node_rgb[34] = 5;
+  cbi->node_rgb[35] = 13;
+  strcpy(cbi->colorbar_type, "deprecated");
+}
+// yellow/red
+void CreateColorbarYellowRed(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "yellow->red");
+  cbi->nnodes = 2;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 255;
+  cbi->node_rgb[1] = 255;
+  cbi->node_rgb[2] = 0;
+
+  cbi->node_index[1] = 255;
+  cbi->node_rgb[3] = 255;
+  cbi->node_rgb[4] = 0;
+  cbi->node_rgb[5] = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// blue/green/red
+void CreateColorbarBlueRedGreen(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "blue->green->red");
+  cbi->nnodes = 3;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 255;
+
+  cbi->node_index[1] = 128;
+  cbi->node_rgb[3] = 0;
+  cbi->node_rgb[4] = 255;
+  cbi->node_rgb[5] = 0;
+
+  cbi->node_index[2] = 255;
+  cbi->node_rgb[6] = 255;
+  cbi->node_rgb[7] = 0;
+  cbi->node_rgb[8] = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// blue/yellow/white
+void CreateColorbarBlueYellowWhite(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "blue->yellow->white");
+  cbi->nnodes = 4;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 151;
+  cbi->node_rgb[2] = 255;
+
+  cbi->node_index[1] = 113;
+  cbi->node_rgb[3] = 255;
+  cbi->node_rgb[4] = 0;
+  cbi->node_rgb[5] = 0;
+
+  cbi->node_index[2] = 212;
+  cbi->node_rgb[6] = 255;
+  cbi->node_rgb[7] = 255;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 255;
+  cbi->node_rgb[9] = 255;
+  cbi->node_rgb[10] = 255;
+  cbi->node_rgb[11] = 255;
+  strcpy(cbi->colorbar_type, "deprecated");
+}
+// blue->red split
+void CreateColorbarBlueRedSplit(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "blue->red split");
+  cbi->nnodes = 4;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 255;
+
+  cbi->node_index[1] = 127;
+  cbi->node_rgb[3] = 0;
+  cbi->node_rgb[4] = 255;
+  cbi->node_rgb[5] = 255;
+
+  cbi->node_index[2] = 128;
+  cbi->node_rgb[6] = 255;
+  cbi->node_rgb[7] = 255;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 255;
+  cbi->node_rgb[9] = 255;
+  cbi->node_rgb[10] = 0;
+  cbi->node_rgb[11] = 0;
+
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "divergent");
+}
+// AFAC split
+void CreateColorbarAfacSplit(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "AFAC split");
+  cbi->nnodes = 8;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 178;
+  cbi->node_rgb[2] = 90;
+
+  cbi->node_index[1] = 80;
+  cbi->node_rgb[3] = 0;
+  cbi->node_rgb[4] = 178;
+  cbi->node_rgb[5] = 90;
+
+  cbi->node_index[2] = 81;
+  cbi->node_rgb[6] = 255;
+  cbi->node_rgb[7] = 243;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 100;
+  cbi->node_rgb[9] = 255;
+  cbi->node_rgb[10] = 243;
+  cbi->node_rgb[11] = 0;
+
+  cbi->node_index[4] = 101;
+  cbi->node_rgb[12] = 250;
+  cbi->node_rgb[13] = 150;
+  cbi->node_rgb[14] = 38;
+
+  cbi->node_index[5] = 140;
+  cbi->node_rgb[15] = 250;
+  cbi->node_rgb[16] = 150;
+  cbi->node_rgb[17] = 38;
+
+  cbi->node_index[6] = 141;
+  cbi->node_rgb[18] = 209;
+  cbi->node_rgb[19] = 34;
+  cbi->node_rgb[20] = 41;
+
+  cbi->node_index[7] = 255;
+  cbi->node_rgb[21] = 209;
+  cbi->node_rgb[22] = 34;
+  cbi->node_rgb[23] = 41;
+
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "divergent");
+}
+// black->white
+void CreateColorbarBlackWhite(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "black->white");
+
+  cbi->nnodes = 2;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 0;
+
+  cbi->node_index[1] = 255;
+  cbi->node_rgb[3] = 255;
+  cbi->node_rgb[4] = 255;
+  cbi->node_rgb[5] = 255;
+  strcpy(cbi->colorbar_type, "original");
+}
+// FED
+void CreateColorbarFed(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "FED");
+
+  cbi->nnodes = 6;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 96;
+  cbi->node_rgb[1] = 96;
+  cbi->node_rgb[2] = 255;
+
+  cbi->node_index[1] = 26; // 0.295276,0.307087
+  cbi->node_rgb[3] = 96;
+  cbi->node_rgb[4] = 96;
+  cbi->node_rgb[5] = 255;
+
+  cbi->node_index[2] = 26;
+  cbi->node_rgb[6] = 255;
+  cbi->node_rgb[7] = 255;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 85; // 0.992126,1.003937
+  cbi->node_rgb[9] = 255;
+  cbi->node_rgb[10] = 255;
+  cbi->node_rgb[11] = 0;
+
+  cbi->node_index[4] = 85;
+  cbi->node_rgb[12] = 255;
+  cbi->node_rgb[13] = 155;
+  cbi->node_rgb[14] = 0;
+
+  cbi->node_index[5] = 255;
+  cbi->node_rgb[15] = 255;
+  cbi->node_rgb[16] = 155;
+  cbi->node_rgb[17] = 0;
+
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// fire (original)
+void CreateColorbarFireOriginal(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "fire");
+
+  cbi->nnodes = 4;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 0;
+
+  cbi->node_index[1] = 127;
+  cbi->node_rgb[3] = 0;
+  cbi->node_rgb[4] = 0;
+  cbi->node_rgb[5] = 0;
+
+  cbi->node_index[2] = 128;
+  cbi->node_rgb[6] = 255;
+  cbi->node_rgb[7] = 128;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 255;
+  cbi->node_rgb[9] = 255;
+  cbi->node_rgb[10] = 128;
+  cbi->node_rgb[11] = 0;
+
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// fire 2
+void CreateColorbarFire2(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "fire 2");
+
+  cbi->nnodes = 10;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 0;
+
+  cbi->node_index[1] = 127;
+  cbi->node_rgb[3] = 38;
+  cbi->node_rgb[4] = 0;
+  cbi->node_rgb[5] = 0;
+
+  cbi->node_index[2] = 128;
+  cbi->node_rgb[6] = 219;
+  cbi->node_rgb[7] = 68;
+  cbi->node_rgb[8] = 21;
+
+  cbi->node_index[3] = 160;
+  cbi->node_rgb[9] = 255;
+  cbi->node_rgb[10] = 125;
+  cbi->node_rgb[11] = 36;
+
+  cbi->node_index[4] = 183;
+  cbi->node_rgb[12] = 255;
+  cbi->node_rgb[13] = 157;
+  cbi->node_rgb[14] = 52;
+
+  cbi->node_index[5] = 198;
+  cbi->node_rgb[15] = 255;
+  cbi->node_rgb[16] = 170;
+  cbi->node_rgb[17] = 63;
+
+  cbi->node_index[6] = 214;
+  cbi->node_rgb[18] = 255;
+  cbi->node_rgb[19] = 198;
+  cbi->node_rgb[20] = 93;
+
+  cbi->node_index[7] = 229;
+  cbi->node_rgb[21] = 255;
+  cbi->node_rgb[22] = 208;
+  cbi->node_rgb[23] = 109;
+
+  cbi->node_index[8] = 244;
+  cbi->node_rgb[24] = 255;
+  cbi->node_rgb[25] = 234;
+  cbi->node_rgb[26] = 161;
+
+  cbi->node_index[9] = 255;
+  cbi->node_rgb[27] = 255;
+  cbi->node_rgb[28] = 255;
+  cbi->node_rgb[29] = 238;
+
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// fire 3
+void CreateColorbarFire3(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "fire 3");
+
+  cbi->nnodes = 4;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 0;
+
+  cbi->node_index[1] = 108;
+  cbi->node_rgb[3] = 255;
+  cbi->node_rgb[4] = 127;
+  cbi->node_rgb[5] = 0;
+
+  cbi->node_index[2] = 156;
+  cbi->node_rgb[6] = 255;
+  cbi->node_rgb[7] = 255;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 255;
+  cbi->node_rgb[9] = 255;
+  cbi->node_rgb[10] = 255;
+  cbi->node_rgb[11] = 255;
+  strcpy(cbi->colorbar_type, "original");
+}
+// cool
+void CreateColorbarCool(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "cool");
+
+  cbi->nnodes = 7;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 0;
+
+  cbi->node_index[1] = 90;
+  cbi->node_rgb[3] = 64;
+  cbi->node_rgb[4] = 64;
+  cbi->node_rgb[5] = 255;
+
+  cbi->node_index[2] = 110;
+  cbi->node_rgb[6] = 155;
+  cbi->node_rgb[7] = 35;
+  cbi->node_rgb[8] = 33;
+
+  cbi->node_index[3] = 120;
+  cbi->node_rgb[9] = 108;
+  cbi->node_rgb[10] = 19;
+  cbi->node_rgb[11] = 43;
+
+  cbi->node_index[4] = 130;
+  cbi->node_rgb[12] = 208;
+  cbi->node_rgb[13] = 93;
+  cbi->node_rgb[14] = 40;
+
+  cbi->node_index[5] = 160;
+  cbi->node_rgb[15] = 255;
+  cbi->node_rgb[16] = 178;
+  cbi->node_rgb[17] = 0;
+
+  cbi->node_index[6] = 255;
+  cbi->node_rgb[18] = 255;
+  cbi->node_rgb[19] = 255;
+  cbi->node_rgb[20] = 255;
+  strcpy(cbi->colorbar_type, "deprecated");
+}
+// fire line (level set)
+void CreateColorbarFireLineLevelSet(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "fire line (level set)");
+
+  cbi->nnodes = 6;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 1;
+  cbi->node_rgb[2] = 2;
+
+  cbi->node_index[1] = 120;
+  cbi->node_rgb[3] = 0;
+  cbi->node_rgb[4] = 1;
+  cbi->node_rgb[5] = 2;
+
+  cbi->node_index[2] = 120;
+  cbi->node_rgb[6] = 255;
+  cbi->node_rgb[7] = 0;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 136;
+  cbi->node_rgb[9] = 255;
+  cbi->node_rgb[10] = 0;
+  cbi->node_rgb[11] = 0;
+
+  cbi->node_index[4] = 136;
+  cbi->node_rgb[12] = 64;
+  cbi->node_rgb[13] = 64;
+  cbi->node_rgb[14] = 64;
+
+  cbi->node_index[5] = 255;
+  cbi->node_rgb[15] = 64;
+  cbi->node_rgb[16] = 64;
+  cbi->node_rgb[17] = 64;
+
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// fire line (wall thickness)
+void CreateColorbarFireLineWallThickness(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "fire line (wall thickness)");
+
+  cbi->nnodes = 4;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 0;
+
+  cbi->node_index[1] = 32;
+  cbi->node_rgb[3] = 0;
+  cbi->node_rgb[4] = 0;
+  cbi->node_rgb[5] = 0;
+
+  cbi->node_index[2] = 32;
+  cbi->node_rgb[6] = 253;
+  cbi->node_rgb[7] = 254;
+  cbi->node_rgb[8] = 255;
+
+  cbi->node_index[3] = 255;
+  cbi->node_rgb[9] = 253;
+  cbi->node_rgb[10] = 254;
+  cbi->node_rgb[11] = 255;
+
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// split
+void CreateColorbarSplit(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "split");
+  // TODO: It would seem this would be fine, but not sure.
+  int colorsplit[12] = {0, 0, 0, 64, 64, 255, 0, 192, 0, 255, 0, 0};
+
+  cbi->nnodes = 4;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_index[1] = 127;
+  cbi->node_index[2] = 128;
+  cbi->node_index[3] = 255;
+  for (int i = 0; i < 12; i++) {
+    cbi->node_rgb[i] = colorsplit[i];
+  }
+
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// Methanol
+void CreateColorbarMethanol(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "Methanol");
+
+  cbi->nnodes = 4;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 9;
+  cbi->node_rgb[1] = 190;
+  cbi->node_rgb[2] = 255;
+
+  cbi->node_index[1] = 192;
+  cbi->node_rgb[3] = 9;
+  cbi->node_rgb[4] = 190;
+  cbi->node_rgb[5] = 255;
+
+  cbi->node_index[2] = 200;
+  cbi->node_rgb[6] = 9;
+  cbi->node_rgb[7] = 190;
+  cbi->node_rgb[8] = 255;
+
+  cbi->node_index[3] = 255;
+  cbi->node_rgb[9] = 9;
+  cbi->node_rgb[10] = 190;
+  cbi->node_rgb[11] = 255;
+  strcpy(cbi->colorbar_type, "original");
+}
+// Propane
+void CreateColorbarPropane(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "Propane");
+
+  cbi->nnodes = 5;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 0;
+
+  cbi->node_index[1] = 140;
+  cbi->node_rgb[3] = 235;
+  cbi->node_rgb[4] = 120;
+  cbi->node_rgb[5] = 0;
+
+  cbi->node_index[2] = 160;
+  cbi->node_rgb[6] = 250;
+  cbi->node_rgb[7] = 180;
+  cbi->node_rgb[8] = 0;
+
+  cbi->node_index[3] = 190;
+  cbi->node_rgb[9] = 252;
+  cbi->node_rgb[10] = 248;
+  cbi->node_rgb[11] = 70;
+
+  cbi->node_index[4] = 255;
+  cbi->node_rgb[12] = 255;
+  cbi->node_rgb[13] = 255;
+  cbi->node_rgb[14] = 255;
+
+  cbi->can_adjust = 0;
+  strcpy(cbi->colorbar_type, "original");
+}
+// CO2
+void CreateColorbarCo2(colorbardata *cbi) {
+  memset(cbi, 0, sizeof(colorbardata));
+  strcpy(cbi->menu_label, "CO2");
+
+  cbi->nnodes = 3;
+  cbi->nodehilight = 0;
+
+  cbi->node_index[0] = 0;
+  cbi->node_rgb[0] = 0;
+  cbi->node_rgb[1] = 0;
+  cbi->node_rgb[2] = 255;
+
+  cbi->node_index[1] = 192;
+  cbi->node_rgb[3] = 0;
+  cbi->node_rgb[4] = 0;
+  cbi->node_rgb[5] = 255;
+
+  cbi->node_index[2] = 255;
+  cbi->node_rgb[6] = 255;
+  cbi->node_rgb[7] = 255;
+  cbi->node_rgb[8] = 255;
+  strcpy(cbi->colorbar_type, "original");
+  cbi->can_adjust = 0;
+}

--- a/Source/shared/colorbars.c
+++ b/Source/shared/colorbars.c
@@ -1,0 +1,755 @@
+#include <ctype.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "options.h"
+
+#include "dmalloc.h"
+#include "colorbars.h"
+#include "datadefs.h"
+
+#include "file_util.h"
+#include "string_util.h"
+
+void TrimBack(char *line);
+int STRCMP(const char *s1, const char *s2);
+void Rgb2Lab(unsigned char *rgb_arg, float *lab);
+void Rgbf2Lab(float *rgbf_arg, float *lab);
+
+/* ------------------ GetColorbar ------------------------ */
+
+colorbardata *GetColorbar(colorbar_collection *colorbars, const char *menu_label) {
+  for (int i = 0; i < colorbars->ncolorbars; i++) {
+    colorbardata *cb = colorbars->colorbarinfo + i;
+    if (strcmp(cb->menu_label, menu_label) == 0) return cb;
+  }
+  return NULL;
+}
+
+/* ------------------ AdjustColorBar ------------------------ */
+
+void AdjustColorBar(colorbardata *cbi) {
+  int i;
+
+  cbi->node_dist[0] = 0.0;
+  for (i = 1; i < cbi->nnodes; i++) {
+    unsigned char *rgb1_local, *rgb2_local;
+    float lab1[3], lab2[3], dist;
+
+    rgb2_local = cbi->node_rgb + 3 * i;
+    rgb1_local = rgb2_local - 3;
+    Rgb2Lab(rgb1_local, lab1);
+    Rgb2Lab(rgb2_local, lab2);
+    float dx, dy, dz;
+
+    DDIST3(lab1, lab2, dist);
+    cbi->node_dist[i] = cbi->node_dist[i - 1] + dist;
+  }
+
+  float total_dist;
+  int nnodes;
+
+  total_dist = cbi->node_dist[cbi->nnodes - 1];
+  nnodes = cbi->node_index[cbi->nnodes - 1];
+
+  if (total_dist > 0.0) {
+    for (i = 1; i < cbi->nnodes - 1; i++) {
+      int inode;
+
+      inode = nnodes * (cbi->node_dist[i] / total_dist);
+      cbi->node_index[i] = inode;
+    }
+  }
+  cbi->adjusted = 1;
+}
+
+/* ------------------ IsColorbarSplit ------------------------ */
+
+int IsColorbarSplit(colorbardata *cbi) {
+  int i;
+
+  for (i = 0; i < cbi->nnodes - 1; i++) {
+    if (cbi->node_index[i] + 1 == cbi->node_index[i + 1]) return 1;
+    if (cbi->node_index[i] == cbi->node_index[i + 1]) return 1;
+  }
+  return 0;
+}
+
+/* ------------------ AdjustColorBarLab ------------------------ */
+
+void AdjustColorBarLab(colorbardata *cbi) {
+  if (cbi->can_adjust == 0 || IsColorbarSplit(cbi) == 1) return;
+  AdjustColorBar(cbi);
+}
+
+/* ------------------ FRgb2Lab ------------------------ */
+
+void FRgb2Lab(float *rgb_arg, float *lab) {
+
+  // Convert RGB values to XYZ
+  float var_R = rgb_arg[0] / 255.0f;
+  float var_G = rgb_arg[1] / 255.0f;
+  float var_B = rgb_arg[2] / 255.0f;
+
+  if (var_R > 0.04045f) {
+    var_R = pow((var_R + 0.055f) / 1.055f, 2.4f);
+  }
+  else {
+    var_R /= 12.92f;
+  }
+  if (var_G > 0.04045f) {
+    var_G = pow((var_G + 0.055f) / 1.055f, 2.4f);
+  }
+  else {
+    var_G /= 12.92f;
+  }
+  if (var_B > 0.04045f) {
+    var_B = pow((var_B + 0.055f) / 1.055f, 2.4f);
+  }
+  else {
+    var_B /= 12.92f;
+  }
+
+  var_R *= 100.0f;
+  var_G *= 100.0f;
+  var_B *= 100.0f;
+
+  float X = var_R * 0.4124f + var_G * 0.3576f + var_B * 0.1805f;
+  float Y = var_R * 0.2126f + var_G * 0.7152f + var_B * 0.0722f;
+  float Z = var_R * 0.0193f + var_G * 0.1192f + var_B * 0.9505f;
+
+  // Convert XYZ to CIELAB
+  float var_X = X / 95.047f;
+  float var_Y = Y / 100.0f;
+  float var_Z = Z / 108.883f;
+
+  if (var_X > 0.008856f) {
+    var_X = pow(var_X, 1.0f / 3.0f);
+  }
+  else {
+    var_X = (7.787f * var_X) + (16.0f / 116.0f);
+  }
+  if (var_Y > 0.008856f) {
+    var_Y = pow(var_Y, 1.0f / 3.0f);
+  }
+  else {
+    var_Y = (7.787f * var_Y) + (16.0f / 116.0f);
+  }
+  if (var_Z > 0.008856f) {
+    var_Z = pow(var_Z, 1.0f / 3.0f);
+  }
+  else {
+    var_Z = (7.787f * var_Z) + (16.0f / 116.0f);
+  }
+
+  lab[0] = (116.0f * var_Y) - 16.0f;
+  lab[1] = 500.0f * (var_X - var_Y);
+  lab[2] = 200.0f * (var_Y - var_Z);
+}
+
+/* ------------------ Rgb2Dist ------------------------ */
+
+void Rgb2Dist(colorbardata *cbi) {
+  int i;
+
+  float total_dist, *colorbar_dist;
+  int jstart, *dist_ind;
+
+  colorbar_dist = cbi->colorbar_dist;
+  dist_ind = cbi->dist_ind;
+
+  colorbar_dist[0] = 0.0;
+  for (i = 1; i < 256; i++) {
+    float dist_lab, lab2[3], *rgb1f, *rgb2f, lab1[3];
+    float dx, dy, dz;
+
+    rgb1f = cbi->colorbar_rgb + 3 * (i - 1);
+    rgb2f = cbi->colorbar_rgb + 3 * i;
+    Rgbf2Lab(rgb1f, lab1);
+    Rgbf2Lab(rgb2f, lab2);
+    DDIST3(lab1, lab2, dist_lab);
+    colorbar_dist[i] = colorbar_dist[i - 1] + dist_lab;
+  }
+  total_dist = colorbar_dist[255];
+
+  dist_ind[0] = 1;
+  dist_ind[255] = 1;
+  for (i = 1; i < 255; i++) {
+    dist_ind[i] = 0;
+  }
+  jstart = 0;
+  for (i = 1; i < 16; i++) {
+    float val;
+    int j;
+
+    val = (float)i * total_dist / 16.0;
+    for (j = jstart; j < 255; j++) {
+      if (colorbar_dist[j] <= val && val <= colorbar_dist[j + 1]) {
+        dist_ind[j] = 1;
+        jstart = j;
+        break;
+      }
+    }
+  }
+}
+
+/* ------------------ Lab2Rgb ------------------------ */
+
+void Lab2Rgb(unsigned char *rgb_arg, float *frgb_arg, float *lab) {
+  float L, a, b;
+
+  L = lab[0];
+  a = lab[1];
+  b = lab[2];
+
+  // Convert CIELAB to XYZ
+  float var_Y = (L + 16.0f) / 116.0f;
+  float var_X = a / 500.0f + var_Y;
+  float var_Z = var_Y - b / 200.0f;
+
+  if (pow(var_Y, 3.0f) > 0.008856f) {
+    var_Y = pow(var_Y, 3.0f);
+  }
+  else {
+    var_Y = (var_Y - 16.0f / 116.0f) / 7.787f;
+  }
+  if (pow(var_X, 3.0f) > 0.008856f) {
+    var_X = pow(var_X, 3.0f);
+  }
+  else {
+    var_X = (var_X - 16.0f / 116.0f) / 7.787f;
+  }
+  if (pow(var_Z, 3.0f) > 0.008856f) {
+    var_Z = pow(var_Z, 3.0f);
+  }
+  else {
+    var_Z = (var_Z - 16.0f / 116.0f) / 7.787f;
+  }
+
+  float X = var_X * 0.95047f;
+  float Y = var_Y;
+  float Z = var_Z * 1.08883f;
+
+  // Convert XYZ to RGB
+  float var_R = X * 3.2406f - Y * 1.5372f - Z * 0.4986f;
+  float var_G = -X * 0.9689f + Y * 1.8758f + Z * 0.0415f;
+  float var_B = X * 0.0557f - Y * 0.2040f + Z * 1.0570f;
+
+  if (var_R > 0.0031308f) {
+    var_R = 1.055f * pow(var_R, 1.0f / 2.4f) - 0.055f;
+  }
+  else {
+    var_R *= 12.92f;
+  }
+  if (var_G > 0.0031308f) {
+    var_G = 1.055f * pow(var_G, 1.0f / 2.4f) - 0.055f;
+  }
+  else {
+    var_G *= 12.92f;
+  }
+  if (var_B > 0.0031308f) {
+    var_B = 1.055f * pow(var_B, 1.0f / 2.4f) - 0.055f;
+  }
+  else {
+    var_B *= 12.92f;
+  }
+
+  frgb_arg[0] = CLAMP(var_R * 255.0f, 0.0, 255.0f);
+  frgb_arg[1] = CLAMP(var_G * 255.0f, 0.0, 255.0f);
+  frgb_arg[2] = CLAMP(var_B * 255.0f, 0.0, 255.0f);
+  rgb_arg[0] = (unsigned char)CLAMP(frgb_arg[0] + 0.5, 0, 255);
+  rgb_arg[1] = (unsigned char)CLAMP(frgb_arg[1] + 0.5, 0, 255);
+  rgb_arg[2] = (unsigned char)CLAMP(frgb_arg[2] + 0.5, 0, 255);
+}
+
+/* ------------------ Rgb2Lab ------------------------ */
+
+void Rgb2Lab(unsigned char *rgb_arg, float *lab) {
+  float frgb_arg[3];
+
+  frgb_arg[0] = (float)rgb_arg[0];
+  frgb_arg[1] = (float)rgb_arg[1];
+  frgb_arg[2] = (float)rgb_arg[2];
+  FRgb2Lab(frgb_arg, lab);
+}
+
+/* ------------------ Rgbf2Lab ------------------------ */
+
+void Rgbf2Lab(float *rgbf_arg, float *lab) {
+  float frgb_arg[3];
+
+  frgb_arg[0] = rgbf_arg[0] * 255.0;
+  frgb_arg[1] = rgbf_arg[1] * 255.0;
+  frgb_arg[2] = rgbf_arg[2] * 255.0;
+  FRgb2Lab(frgb_arg, lab);
+}
+
+/* ------------------ Lab2XYZ ------------------------ */
+
+void Lab2XYZ(float *xyz, float *lab) {
+  xyz[0] = lab[0] / 100.0;
+  xyz[1] = (lab[1] + 87.9) / 183.28;
+  xyz[2] = (lab[2] + 126.39) / 211.11;
+}
+
+// matches following website
+// http://colormine.org/convert/rgb-to-lab
+
+/* ------------------ CheckLab ------------------------ */
+void CheckLab(void) {
+  int i, diff;
+  int hist[256];
+  float sum = 0.0;
+  float *labxyz;
+  float *lab_check_xyz;
+  unsigned char *labrgb, *lab_check_rgb255;
+
+  for (i = 0; i < 256; i++) {
+    hist[i] = 0;
+  }
+
+  NewMemory((void **)&lab_check_xyz, 3 * 17 * 17 * 17 * sizeof(float));
+  NewMemory((void **)&lab_check_rgb255, 3 * 17 * 17 * 17);
+  labxyz = lab_check_xyz;
+  labrgb = lab_check_rgb255;
+  for (i = 0; i < 256; i++) {
+    int j;
+
+    printf("i=%i\n", i);
+    for (j = 0; j < 256; j++) {
+      int k;
+
+      for (k = 0; k < 256; k++) {
+        unsigned char rgbval[3], rgbnew[3];
+        float lab[3], lab2[3], dist2, frgb[3];
+
+        rgbval[0] = (unsigned char)k;
+        rgbval[1] = (unsigned char)j;
+        rgbval[2] = (unsigned char)i;
+        Rgb2Lab(rgbval, lab);
+        Lab2Rgb(rgbnew, frgb, lab);
+        Rgb2Lab(rgbnew, lab2);
+        diff = ABS(rgbval[0] - rgbnew[0]);
+        diff = MAX(diff, ABS(rgbval[1] - rgbnew[1]));
+        diff = MAX(diff, ABS(rgbval[2] - rgbnew[2]));
+        dist2 = ABS(lab2[0] - lab[0]);
+        dist2 = MAX(dist2, ABS(lab2[1] - lab[1]));
+        dist2 = MAX(dist2, ABS(lab2[2] - lab[2]));
+        sum += dist2;
+        hist[diff]++;
+      }
+    }
+  }
+  for (i = 0; i <= 256; i += 16) {
+    int j;
+
+    for (j = 0; j <= 256; j += 16) {
+      int k;
+
+      for (k = 0; k <= 256; k += 16) {
+        unsigned char rgbval[3];
+        float lab[3];
+
+        rgbval[0] = MIN((unsigned char)k, 255);
+        rgbval[1] = MIN((unsigned char)j, 255);
+        rgbval[2] = MIN((unsigned char)i, 255);
+        Rgb2Lab(rgbval, lab);
+        memcpy(labxyz, lab, 3 * sizeof(float));
+        memcpy(labrgb, rgbval, 3);
+        labxyz += 3;
+        labrgb += 3;
+      }
+    }
+  }
+  for (i = 0; i < 256; i++) {
+    printf("%i ", hist[i]);
+  }
+  printf("\n");
+  printf("lab avg diff=%f\n", sum / (float)(256 * 256 * 256));
+  FREEMEMORY(lab_check_xyz);
+  FREEMEMORY(lab_check_rgb255);
+}
+
+/* ------------------ GetColorDist ------------------------ */
+
+void GetColorDist(colorbardata *cbi, int option, float *min, float *max) {
+  int i;
+
+  for (i = 1; i < 255; i++) {
+    cbi->colorbar_dist_delta[i - 1] =
+        cbi->colorbar_dist[i] - cbi->colorbar_dist[i - 1];
+  }
+  *min = cbi->colorbar_dist_delta[0];
+  *max = *min;
+  for (i = 1; i < 255 - 1; i++) {
+    *min = MIN(*min, cbi->colorbar_dist_delta[i]);
+    *max = MAX(*max, cbi->colorbar_dist_delta[i]);
+  }
+}
+
+/* ------------------ RemapColorbar ------------------------ */
+
+unsigned char SetAlpha(unsigned char *node_rgb) {
+  if ((node_rgb[0] == 0 && node_rgb[1] == 1 && node_rgb[2] == 2) ||
+      (node_rgb[0] == 253 && node_rgb[1] == 254 && node_rgb[2] == 255)) {
+    return 0;
+  }
+  return 255;
+}
+
+/* ------------------ RemapColorbar ------------------------ */
+
+void RemapColorbar(colorbardata *cbi, int show_extreme_mindata,
+                   unsigned char rgb_below_min[3], int show_extreme_maxdata,
+                   unsigned char rgb_above_max[3]) {
+  int i;
+  float *colorbar_rgb;
+  unsigned char *node_rgb;
+  unsigned char *colorbar_alpha;
+  float *colorbar_lab;
+  int interp;
+
+  interp = cbi->interp;
+  CheckMemory;
+  colorbar_rgb = cbi->colorbar_rgb;
+  node_rgb = cbi->node_rgb;
+  colorbar_lab = cbi->colorbar_lab;
+  colorbar_alpha = cbi->colorbar_alpha;
+
+  AdjustColorBarLab(cbi);
+
+  for (i = 0; i < cbi->node_index[0]; i++) {
+    colorbar_rgb[0 + 3 * i] = node_rgb[0] / 255.0;
+    colorbar_rgb[1 + 3 * i] = node_rgb[1] / 255.0;
+    colorbar_rgb[2 + 3 * i] = node_rgb[2] / 255.0;
+    colorbar_alpha[i] = SetAlpha(node_rgb);
+  }
+  for (i = 0; i < cbi->nnodes - 1; i++) {
+    int i1, i2, j;
+    float lab1[3], lab2[3];
+
+    i1 = cbi->node_index[i];
+    i2 = cbi->node_index[i + 1];
+    if (i2 == i1) continue;
+    node_rgb = cbi->node_rgb + 3 * i;
+    Rgb2Lab(node_rgb, lab1);
+    Rgb2Lab(node_rgb + 3, lab2);
+    for (j = i1; j < i2; j++) {
+      float factor;
+
+      factor = (float)(j - i1) / (float)(i2 - i1);
+      float *labj;
+
+      labj = colorbar_lab + 3 * j;
+      labj[0] = MIX(factor, lab2[0], lab1[0]);
+      labj[1] = MIX(factor, lab2[1], lab1[1]);
+      labj[2] = MIX(factor, lab2[2], lab1[2]);
+      if (interp == INTERP_LAB) {
+        unsigned char rgb_val[3];
+        float frgb[3];
+
+        Lab2Rgb(rgb_val, frgb, labj);
+        colorbar_rgb[0 + 3 * j] = frgb[0] / 255.0;
+        colorbar_rgb[1 + 3 * j] = frgb[1] / 255.0;
+        colorbar_rgb[2 + 3 * j] = frgb[2] / 255.0;
+      }
+      else {
+        colorbar_rgb[0 + 3 * j] = MIX(factor, node_rgb[3], node_rgb[0]) / 255.0;
+        colorbar_rgb[1 + 3 * j] = MIX(factor, node_rgb[4], node_rgb[1]) / 255.0;
+        colorbar_rgb[2 + 3 * j] = MIX(factor, node_rgb[5], node_rgb[2]) / 255.0;
+      }
+      colorbar_alpha[j] = SetAlpha(node_rgb);
+    }
+  }
+  node_rgb = cbi->node_rgb + 3 * (cbi->nnodes - 1);
+  for (i = cbi->node_index[cbi->nnodes - 1]; i < 256; i++) {
+    colorbar_rgb[0 + 3 * i] = node_rgb[0] / 255.0;
+    colorbar_rgb[1 + 3 * i] = node_rgb[1] / 255.0;
+    colorbar_rgb[2 + 3 * i] = node_rgb[2] / 255.0;
+    colorbar_alpha[i] = SetAlpha(node_rgb);
+  }
+  if (show_extreme_mindata == 1) {
+    colorbar_rgb[0] = rgb_below_min[0];
+    colorbar_rgb[1] = rgb_below_min[1];
+    colorbar_rgb[2] = rgb_below_min[2];
+  }
+  if (show_extreme_maxdata == 1) {
+    colorbar_rgb[0 + 3 * 255] = rgb_above_max[0];
+    colorbar_rgb[1 + 3 * 255] = rgb_above_max[1];
+    colorbar_rgb[2 + 3 * 255] = rgb_above_max[2];
+  }
+  Rgb2Dist(cbi);
+  CheckMemory;
+}
+
+/* ------------------ ReadCSVColorbar ------------------------ */
+
+int ReadCSVColorbar(colorbardata *colorbar, const char *filepath,
+                     const char *colorbar_type, int type) {
+  int n = 0;
+  char buffer[255];
+  int have_name = 0;
+
+  // Open the file
+  FILE *stream = fopen(filepath, "r");
+  if (stream == NULL) return 1;
+  if (fgets(buffer, 255, stream) == NULL) {
+    fclose(stream);
+    return 1;
+  }
+  char *fname_buffer;
+  NEWMEMORY(fname_buffer, (strlen(filepath) + 1) * sizeof(char));
+  GetBaseFileName(fname_buffer, filepath);
+  strcpy(colorbar->menu_label, filepath);
+  FREEMEMORY(fname_buffer);
+  colorbar->nodehilight = 0;
+
+  // If the first field of the first line is alphanumeric, there's a name and
+  // the value of the second field should be used as a name.
+  char *field1 = strtok(buffer, ",");
+  if (field1 != NULL && isalpha(field1[0]) != 0) {
+    have_name = 1;
+    char *field2 = strtok(NULL, ",");
+    if (field2 != NULL) {
+      strcpy(colorbar->menu_label, field2);
+      TrimBack(colorbar->menu_label);
+    }
+  }
+  rewind(stream);
+  if (have_name == 1) {
+    fgets(buffer, 255, stream);
+    TrimBack(buffer);
+  }
+  // Count the lines in the file TODO: rather than read the file twice (to count
+  // lines), just reallocate memory when needed.
+  for (;;) {
+    if (fgets(buffer, 255, stream) == NULL) break;
+    n++;
+  }
+  rewind(stream);
+  // TODO: we don't need to allocate rgbscopy has it only needs to be 3 chars
+  // long.
+  int *rgbs, *rgbscopy;
+  NewMemory((void **)&rgbs, 3 * n * sizeof(int));
+  rgbscopy = rgbs;
+
+  if (have_name == 1) {
+    fgets(buffer, 255, stream);
+    TrimBack(buffer);
+  }
+  for (int i = 0; i < n; i++) {
+    char *crgb;
+
+    if (fgets(buffer, 255, stream) == NULL) break;
+    TrimBack(buffer);
+    crgb = strtok(buffer, ",");
+    sscanf(crgb, "%i", rgbscopy);
+    crgb = strtok(NULL, ",");
+    sscanf(crgb, "%i", rgbscopy + 1);
+    crgb = strtok(NULL, ",");
+    sscanf(crgb, "%i", rgbscopy + 2);
+    colorbar->node_rgb[3 * i + 0] = (unsigned char)CLAMP(rgbscopy[0], 0, 255);
+    colorbar->node_rgb[3 * i + 1] = (unsigned char)CLAMP(rgbscopy[1], 0, 255);
+    colorbar->node_rgb[3 * i + 2] = (unsigned char)CLAMP(rgbscopy[2], 0, 255);
+    colorbar->node_index[i] = i;
+    strcpy(colorbar->colorbar_type, colorbar_type);
+    colorbar->type = type;
+    rgbscopy += 3;
+  }
+  colorbar->nnodes = n;
+  fclose(stream);
+  return 0;
+}
+
+colorbardata *CreateColorbar(void) {
+  colorbardata *colorbar;
+  NewMemory((void **)&colorbar, sizeof(colorbardata));
+  return colorbar;
+}
+
+void FreeColorbar(colorbardata *colorbar) { FreeMemory(colorbar); }
+
+colorbardata *CreateColorbarFromCsv(const char *filepath, char *colorbar_type,
+                                    int type) {
+  colorbardata *colorbar = CreateColorbar();
+  ReadCSVColorbar(colorbar, filepath, colorbar_type, type);
+  return colorbar;
+}
+
+/* ------------------ NextColorbar ------------------------ */
+
+colorbardata *NextColorbar(colorbar_collection *colorbars) {
+  if (colorbars->colorbarinfo == NULL) {
+    size_t new_capacity = 1;
+    NEWMEMORY(colorbars->colorbarinfo, new_capacity * sizeof(colorbardata));
+    colorbars->capacity = new_capacity;
+  }
+  else if (colorbars->ncolorbars >= colorbars->capacity) {
+    size_t new_capacity = MAX(colorbars->capacity * 2, 1);
+    CheckMemory;
+    RESIZEMEMORY(colorbars->colorbarinfo, new_capacity * sizeof(colorbardata));
+    colorbars->capacity = new_capacity;
+  }
+  return &colorbars->colorbarinfo[colorbars->ncolorbars];
+}
+
+colorbardata *NewColorbar(colorbar_collection *colorbars) {
+  colorbardata *cb = NextColorbar(colorbars);
+  memset(cb, 0, sizeof(colorbardata));
+  colorbars->ncolorbars++;
+  return cb;
+}
+
+/* ------------------ InitDefaultColorbars ------------------------ */
+
+void CreateColorbarRainbow(colorbardata *cbi);
+void CreateColorbarOriginalRainbow(colorbardata *cbi);
+void CreateColorbarRainbow2(colorbardata *cbi);
+void CreateColorbarYellowRed(colorbardata *cbi);
+void CreateColorbarBlueRedGreen(colorbardata *cbi);
+void CreateColorbarBlueYellowWhite(colorbardata *cbi);
+void CreateColorbarBlueRedSplit(colorbardata *cbi);
+void CreateColorbarAfacSplit(colorbardata *cbi);
+void CreateColorbarBlackWhite(colorbardata *cbi);
+void CreateColorbarFed(colorbardata *cbi);
+void CreateColorbarFireOriginal(colorbardata *cbi);
+void CreateColorbarFire2(colorbardata *cbi);
+void CreateColorbarFire3(colorbardata *cbi);
+void CreateColorbarCool(colorbardata *cbi);
+void CreateColorbarFireLineLevelSet(colorbardata *cbi);
+void CreateColorbarFireLineWallThickness(colorbardata *cbi);
+void CreateColorbarSplit(colorbardata *cbi);
+void CreateColorbarMethanol(colorbardata *cbi);
+void CreateColorbarPropane(colorbardata *cbi);
+void CreateColorbarCo2(colorbardata *cbi);
+
+/**
+ * @brief Get a path for a colorbar subdir. This is generally in the form
+ * ${SMV_ROOT_DIR}/colorbars/${subdir}.
+ *
+ * @param subdir The name of the subdir
+ * @return Path to directory (allocated via NEWMEMORY) or NULL if subidr is NULL
+ * or if GetSmvRootDir returns NULL.
+ */
+char *GetColorbarsSubDir(const char *subdir) {
+  char *return_path = NULL;
+  char *smv_bindir = GetSmvRootDir();
+  if (smv_bindir == NULL || subdir == NULL) return return_path;
+
+  NewMemory((void **)&return_path, strlen(smv_bindir) + strlen("colorbars") +
+                                       strlen(dirseparator) + strlen(subdir) +
+                                       2);
+  strcpy(return_path, smv_bindir);
+  strcat(return_path, "colorbars");
+  strcat(return_path, dirseparator);
+  if (strlen(subdir) > 0) strcat(return_path, subdir);
+  FREEMEMORY(smv_bindir);
+  return return_path;
+}
+
+char *GetHomeDir();
+
+void ReadColorbarDir(colorbar_collection *colorbars, const char *dir_path,
+                     const char *label, int type) {
+  filelistdata *filelist = NULL;
+  int n_files = GetFileListSize(dir_path, "*.csv", FILE_MODE);
+  MakeFileList(dir_path, "*.csv", n_files, NO, &filelist, FILE_MODE);
+  for (int i = 0; i < n_files; i++) {
+    colorbardata *cbi = NextColorbar(colorbars);
+
+    if (filelist[i].file == NULL || strlen(filelist[i].file) == 0) return;
+    if (dir_path == NULL || strlen(dir_path) == 0) return;
+    char *filepath = JoinPath(dir_path, filelist[i].file);
+    ReadCSVColorbar(cbi, filepath, label, type);
+    colorbars->ncolorbars++;
+    cbi->can_adjust = 1;
+    FREEMEMORY(filepath);
+  }
+}
+
+void ReadColorbarSubDir(colorbar_collection *colorbars, const char *subdir,
+                        int type) {
+  char *dir_path = GetColorbarsSubDir(subdir);
+  ReadColorbarDir(colorbars, dir_path, subdir, type);
+  FREEMEMORY(dir_path);
+}
+
+EXTERNCPP void InitDefaultColorbars(colorbar_collection *colorbars, int nini,
+                                    int show_extreme_mindata,
+                                    unsigned char rgb_below_min[3],
+                                    int show_extreme_maxdata,
+                                    unsigned char rgb_above_max[3],
+                                    colorbardata *colorbarcopyinfo) {
+
+  // Add colorbars as defined in the code.
+  CreateColorbarRainbow(NewColorbar(colorbars));
+  CreateColorbarRainbow(NewColorbar(colorbars));
+  CreateColorbarOriginalRainbow(NewColorbar(colorbars));
+  CreateColorbarRainbow2(NewColorbar(colorbars));
+  CreateColorbarYellowRed(NewColorbar(colorbars));
+  CreateColorbarBlueRedGreen(NewColorbar(colorbars));
+  CreateColorbarBlueYellowWhite(NewColorbar(colorbars));
+  CreateColorbarBlueRedSplit(NewColorbar(colorbars));
+  CreateColorbarAfacSplit(NewColorbar(colorbars));
+  CreateColorbarBlackWhite(NewColorbar(colorbars));
+  CreateColorbarFed(NewColorbar(colorbars));
+  CreateColorbarFireOriginal(NewColorbar(colorbars));
+  CreateColorbarFire2(NewColorbar(colorbars));
+  CreateColorbarFire3(NewColorbar(colorbars));
+  CreateColorbarCool(NewColorbar(colorbars));
+  CreateColorbarFireLineLevelSet(NewColorbar(colorbars));
+  CreateColorbarFireLineWallThickness(NewColorbar(colorbars));
+  CreateColorbarSplit(NewColorbar(colorbars));
+  CreateColorbarMethanol(NewColorbar(colorbars));
+  CreateColorbarPropane(NewColorbar(colorbars));
+  CreateColorbarCo2(NewColorbar(colorbars));
+
+  // Add colorbars as found in the root directory
+  ReadColorbarSubDir(colorbars, "linear", CB_LINEAR);
+  ReadColorbarSubDir(colorbars, "circular", CB_CIRCULAR);
+  ReadColorbarSubDir(colorbars, "rainbow", CB_RAINBOW);
+  ReadColorbarSubDir(colorbars, "divergent", CB_DIVERGENT);
+
+  // Add user colorbars as defined in the config directory.
+  char *colorbars_user_dir = GetUserColorbarDirPath();
+  ReadColorbarDir(colorbars, colorbars_user_dir, "user defined", CB_USER);
+  FREEMEMORY(colorbars_user_dir);
+
+  colorbars->ndefaultcolorbars = colorbars->ncolorbars;
+
+  for (int i = 0; i < colorbars->ncolorbars; i++) {
+    colorbardata *cbi = colorbars->colorbarinfo + i;
+    cbi->can_adjust = 1;
+    cbi->adjusted = 0;
+  }
+
+  // construct colormaps from color node info
+
+  for (int i = 0; i < colorbars->ndefaultcolorbars; i++) {
+    colorbardata *cbi = colorbars->colorbarinfo + i;
+
+    if (cbi->can_adjust == 1) {
+      cbi->interp = INTERP_LAB;
+    }
+    else {
+      cbi->interp = INTERP_RGB;
+    }
+    RemapColorbar(cbi, show_extreme_mindata, rgb_below_min,
+                  show_extreme_maxdata, rgb_above_max);
+    memcpy(cbi->node_rgb_orig, cbi->node_rgb,
+           3 * cbi->nnodes * sizeof(unsigned char));
+  }
+
+  for (int i = 0; i < colorbars->ncolorbars; i++) {
+    colorbardata *cbi = colorbars->colorbarinfo + i;
+    cbi->interp = INTERP_LAB;
+    if (cbi->can_adjust == 1) {
+      AdjustColorBar(cbi);
+    }
+  }
+  NEWMEMORY(colorbarcopyinfo, colorbars->ncolorbars * sizeof(colorbardata));
+  memcpy(colorbarcopyinfo, colorbars->colorbarinfo,
+         colorbars->ncolorbars * sizeof(colorbardata));
+}

--- a/Source/shared/colorbars.h
+++ b/Source/shared/colorbars.h
@@ -1,0 +1,126 @@
+
+#ifndef COLORBARS_H_DEFINED
+#define COLORBARS_H_DEFINED
+
+#include "options.h"
+
+#define FILE_UPDATE 6
+
+#define CB_RAINBOW 0
+#define CB_ORIGINAL 1
+#define CB_LINEAR 2
+#define CB_DIVERGENT 3
+#define CB_CIRCULAR 4
+#define CB_DEPRECATED 5
+#define CB_USER 6
+#define CB_OTHER 7
+#define INTERP_RGB 0
+#define INTERP_LAB 1
+
+typedef struct _colorbardata {
+  /// @brief The label used in GUI menus
+  char menu_label[1024];
+  /// @brief The category of colorbar: rainbow, linear, divergent, etc.
+  char colorbar_type[256];
+  int nnodes, nnodes_orig, node_index_orig[1024], nodehilight, type;
+  unsigned char node_rgb_orig[3 * 1024], node_rgb[3 * 1024],
+      colorbar_alpha[1024];
+  unsigned char node_index[1024]; // colorbar index
+  float node_dist[1024];
+  float colorbar_dist[256];
+  int dist_ind[256];
+  float colorbar_dist_delta[1024];
+  /// @brief Is the interpolation RGB (INTERP_RGB) or LAB (INTERP_LAB)?
+  int interp;
+  int can_adjust, adjusted;
+  float colorbar_rgb[3 * 1024], colorbar_lab[3 * 1024];
+} colorbardata;
+
+typedef struct {
+  /// @brief The capacity of the colorbarinfo array.
+  int capacity;
+  /// @brief The number of colorbars in the collection
+  int ncolorbars;
+  /// @brief An array of colorbars of length ncolorbars
+  colorbardata *colorbarinfo;
+  /// @brief How many of the colobars in colorbarinfo are defaults?
+  int ndefaultcolorbars;
+
+  int bw_colorbar_index;
+  int fire_colorbar_index;
+  colorbardata *fire_colorbar;
+
+  colorbardata *levelset_colorbar;
+
+  int split_colorbar_index;
+  colorbardata *split_colorbar;
+  int co2_colorbar_index;
+  int iso_colorbar_index;
+} colorbar_collection;
+
+/**
+ * @brief Get a colorbar given a label.
+ *
+ * @param[in] colorbars The colorbar collection to search through.
+ * @param[in] label The label of the colorbar.
+ * @return A pointer to the colorbar, or NULL if no matching colorbar was found.
+ */
+EXTERNCPP colorbardata *GetColorbar(colorbar_collection *colorbars,
+                                    const char *label);
+
+/**
+ * @brief Append a new (blank) colorbar to the colorbar collection.
+ *
+ * @param[inout] colorbars The colorbar collection.
+ * @return A pointer to the new colorbar.
+ */
+EXTERNCPP colorbardata *NewColorbar(colorbar_collection *colorbars);
+/**
+ * @brief Read a colorbar from a CSV file into a colorbar struct.
+ *
+ * @param[out] colorbar The colorbar to read the data into.
+ * @param[in] filepath The filepath of the CSV file.
+ * @param[in] colorbar_type The type of the colorbar (string label).
+ * @param[in] type The type of the colorbar (enum).
+ * @return 0 on success, non-zero on failure.
+ */
+EXTERNCPP int ReadCSVColorbar(colorbardata *colorbar, const char *filepath,
+                     const char *colorbar_type, int type);
+/**
+ * @brief Initialize the default colorbars. This includes:
+ *    - Initializing the colorbars which are hardcoded.
+ *    - Reading and initializing from the SMV_ROOT_DIR.
+ *    - Reading and initializing from the use config directory.
+ *
+ * @param colorbars The colorbar collection to read into.
+ * @param nini
+ * @param show_extreme_mindata Should this colorbar color data below it's
+ * bounds?
+ * @param rgb_below_min What color should data below the minimum bound be
+ * colored.
+ * @param show_extreme_maxdata Should this colorbar color data above it's
+ * bounds?
+ * @param rgb_above_max What color should data above the maximum bound be
+ * colored.
+ * @param colorbarcopyinfo
+ */
+EXTERNCPP void InitDefaultColorbars(colorbar_collection *colorbars, int nini,
+                                    int show_extreme_mindata,
+                                    unsigned char rgb_below_min[3],
+                                    int show_extreme_maxdata,
+                                    unsigned char rgb_above_max[3],
+                                    colorbardata *colorbarcopyinfo);
+
+
+
+EXTERNCPP void AdjustColorBar(colorbardata *cbi);
+EXTERNCPP void RemapColorbar(colorbardata *cbi, int show_extreme_mindata,
+                             unsigned char rgb_below_min[3],
+                             int show_extreme_maxdata,
+                             unsigned char rgb_above_max[3]);
+EXTERNCPP void Lab2XYZ(float *xyz, float *lab);
+EXTERNCPP void CheckLab(void);
+EXTERNCPP void FRgb2Lab(float *rgb_arg, float *lab);
+EXTERNCPP void GetColorDist(colorbardata *cbi, int option, float *min, float *max);
+
+#endif

--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -1324,6 +1324,10 @@ char *GetUserIniPath() {
   return GetUserConfigSubPath("smokeview.ini");
 }
 
+char *GetUserColorbarDirPath() {
+  return GetUserConfigSubPath("colorbars");
+}
+
 char *GetSmokeviewHtmlPath() {
   return GetSmvRootSubPath("smokeview.html");
 }

--- a/Source/shared/file_util.h
+++ b/Source/shared/file_util.h
@@ -261,6 +261,7 @@ EXTERNCPP char *GetSystemIniPath();
  * @return The path allocated with NEWMEMORY.
  */
 EXTERNCPP char *GetUserIniPath();
+EXTERNCPP char *GetUserColorbarDirPath();
 EXTERNCPP char *GetSmokeviewHtmlPath();
 EXTERNCPP void PrintTime(const char *tag, int line, float *timer,
                          const char *label, int stop_flag);
@@ -268,6 +269,8 @@ EXTERNCPP void PrintTime(const char *tag, int line, float *timer,
 EXTERNCPP int IsSootFile(char *shortlabel, char *longlabel);
 
 EXTERNCPP char *LastName(char *argi);
+
+EXTERNCPP char *JoinPath(const char *path, const char *segment);
 
 // vvvvvvvvvvvvvvvvvvvvvvvv variables vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 

--- a/Source/smokeview/IOscript.c
+++ b/Source/smokeview/IOscript.c
@@ -2966,9 +2966,9 @@ void ScriptSetCbar(scriptdata *scripti){
   int cb_index;
 
   if(scripti->cval!=NULL){
-    cb = GetColorbar(scripti->cval);
+    cb = GetColorbar(&colorbars, scripti->cval);
     if(cb != NULL){
-      cb_index = cb - colorbarinfo;
+      cb_index = cb - colorbars.colorbarinfo;
       ColorbarMenu(cb_index);
     }
   }

--- a/Source/smokeview/IOslice.c
+++ b/Source/smokeview/IOslice.c
@@ -4388,10 +4388,10 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
     if(strcmp(sd->label.shortlabel,"FED")==0){
       colorbardata *cb;
 
-      cb = GetColorbar("FED");
+      cb = GetColorbar(&colorbars, "FED");
       if(cb != NULL){
-        if(cb - colorbarinfo != colorbartype_save)colorbartype_save = colorbartype;
-        colorbartype = cb - colorbarinfo;
+        if(cb - colorbars.colorbarinfo != colorbartype_save)colorbartype_save = colorbartype;
+        colorbartype = cb - colorbars.colorbarinfo;
         ColorbarMenu(colorbartype);
       }
     }

--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -786,8 +786,8 @@ ERROR_CODE SetNamedColorbar(const char *name) {
 }
 
 ERROR_CODE GetNamedColorbar(const char *name, size_t *index) {
-  for(size_t i = 0; i < ncolorbars; i++) {
-    if(strcmp(colorbarinfo[i].menu_label, name) == 0) {
+  for (size_t i = 0; i < colorbars.ncolorbars; i++) {
+    if (strcmp(colorbars.colorbarinfo[i].menu_label, name) == 0) {
       *index = i;
       return 0;
     }
@@ -799,13 +799,13 @@ ERROR_CODE GetNamedColorbar(const char *name, size_t *index) {
 /// @param value
 void SetColorbar(size_t value) {
   colorbartype = value;
-  iso_colorbar_index = value;
-  iso_colorbar = colorbarinfo + iso_colorbar_index;
+  colorbars.iso_colorbar_index = value;
+  iso_colorbar = colorbars.colorbarinfo + colorbars.iso_colorbar_index;
   update_texturebar = 1;
   GLUIUpdateListIsoColorobar();
-  UpdateCurrentColorbar(colorbarinfo + colorbartype);
+  UpdateCurrentColorbar(colorbars.colorbarinfo + colorbartype);
   GLUIUpdateColorbarType();
-  if(colorbartype == bw_colorbar_index && bw_colorbar_index >= 0) {
+  if(colorbartype == colorbars.bw_colorbar_index && colorbars.bw_colorbar_index >= 0) {
     setbwdata = 1;
   }
   else {
@@ -3209,7 +3209,7 @@ int SetFirecolor(int r, int g, int b) {
 
 int SetFirecolormap(int type, int index) {
   fire_colormap_type = type;
-  fire_colorbar_index = index;
+  colorbars.fire_colorbar_index = index;
   return 0;
 } // FIRECOLORMAP
 

--- a/Source/smokeview/callbacks.c
+++ b/Source/smokeview/callbacks.c
@@ -2832,7 +2832,7 @@ void Keyboard(unsigned char key, int flag){
     case '<':
       if(keystate == GLUT_ACTIVE_ALT){
         colorbartype--;
-        if(colorbartype < 0)colorbartype=ncolorbars-1;
+        if(colorbartype < 0)colorbartype=colorbars.ncolorbars-1;
         ColorbarMenu(colorbartype);
         updatemenu = 1;
         break;
@@ -2845,7 +2845,7 @@ void Keyboard(unsigned char key, int flag){
     case '>':
       if(keystate == GLUT_ACTIVE_ALT){
         colorbartype++;
-        if(colorbartype >= ncolorbars)colorbartype = 0;
+        if(colorbartype >= colorbars.ncolorbars)colorbartype = 0;
         ColorbarMenu(colorbartype);
         updatemenu = 1;
         break;

--- a/Source/smokeview/getdatacolors.c
+++ b/Source/smokeview/getdatacolors.c
@@ -1043,7 +1043,7 @@ void UpdateCO2Colormap(void){
 
   if(use_transparency_data==1)transparent_level_local=transparent_level;
 
-  co2_cb = colorbarinfo[co2_colorbar_index].colorbar_rgb;
+  co2_cb = colorbars.colorbarinfo[colorbars.co2_colorbar_index].colorbar_rgb;
   rgb_colormap = rgb_sliceco2colormap_01;
 
   switch(co2_colormap_type){
@@ -1098,8 +1098,8 @@ void UpdateSmokeColormap(int option){
 
   if(use_transparency_data==1)transparent_level_local=transparent_level;
 
-  alpha_rgb = colorbarinfo[colorbartype].colorbar_alpha;
-  fire_cb = colorbarinfo[fire_colorbar_index].colorbar_rgb;
+  alpha_rgb = colorbars.colorbarinfo[colorbartype].colorbar_alpha;
+  fire_cb = colorbars.colorbarinfo[colorbars.fire_colorbar_index].colorbar_rgb;
 
   switch(fire_colormap_type){
     case FIRECOLORMAP_DIRECT:
@@ -1210,13 +1210,13 @@ void UpdateRGBColors(int colorbar_index){
     rgb_trans[4*n+2]=0.0;
     rgb_trans[4*n+3]=(float)n/(float)(nrgb_full-1);
   }
-  if(colorbarinfo!=NULL){
+  if(colorbars.colorbarinfo!=NULL){
     unsigned char *alpha_rgb;
     colorbardata *cbi;
 
-    cbi = colorbarinfo + colorbartype;
+    cbi = colorbars.colorbarinfo + colorbartype;
 
-    alpha_rgb = colorbarinfo[colorbartype].colorbar_alpha;
+    alpha_rgb = colorbars.colorbarinfo[colorbartype].colorbar_alpha;
     for(n=0;n<nrgb_full;n++){
       rgb_full[n][0]=cbi->colorbar_rgb[3*n];
       rgb_full[n][1]=cbi->colorbar_rgb[3*n+1];

--- a/Source/smokeview/glui_colorbar.cpp
+++ b/Source/smokeview/glui_colorbar.cpp
@@ -11,6 +11,8 @@
 #include "glui_bounds.h"
 #include "glui_motion.h"
 
+#include "colorbars.h"
+
 GLUI *glui_colorbar=NULL;
 
 GLUI_Rollout *ROLLOUT_cb_simple  = NULL;
@@ -376,10 +378,10 @@ void GetNewColorbarName(char *base, char *label){
     }
 
     int dup = 0;
-    for(j = 0;j < ncolorbars;j++){
+    for(j = 0;j < colorbars.ncolorbars;j++){
       colorbardata *cbj;
 
-      cbj = colorbarinfo + j;
+      cbj = colorbars.colorbarinfo + j;
       if(strcmp(label, cbj->menu_label) == 0){
         dup = 1;
         break;
@@ -392,13 +394,13 @@ void GetNewColorbarName(char *base, char *label){
 /* ------------------ ColorbarSimple ------------------------ */
 
 void ColorbarSimple(int node){
-  ColorbarSimple2General(colorbarinfo + colorbartype);
+  ColorbarSimple2General(colorbars.colorbarinfo + colorbartype);
   colorbarpoint = node;
   memcpy(cb_rgb, cb_simple_rgb + 3*colorbarpoint, 3*sizeof(int));
   SPINNER_cb_rgb[0]->set_int_val(cb_rgb[0]);
   SPINNER_cb_rgb[1]->set_int_val(cb_rgb[1]);
   SPINNER_cb_rgb[2]->set_int_val(cb_rgb[2]);
-  cb_colorindex = colorbarinfo[colorbartype].node_index[colorbarpoint];
+  cb_colorindex = colorbars.colorbarinfo[colorbartype].node_index[colorbarpoint];
   SPINNER_cb_colorindex->set_int_val(cb_colorindex);
   GLUIColorbarCB(COLORBAR_RGB);
 }
@@ -450,25 +452,26 @@ extern "C" void GLUIColorbarCB(int var){
   update_colorbar_dialog = 1;
   switch(var){
   case COLORBAR_COLORINDEX:
-    if(colorbartype < ncolorbars){
-      cbi = colorbarinfo + colorbartype;
+    if(colorbartype < colorbars.ncolorbars){
+      cbi = colorbars.colorbarinfo + colorbartype;
       UpdateCurrentColorbar(cbi);
 
       cbi->node_index[colorbarpoint] = cb_colorindex;
       cbi->can_adjust = 0;
 
       GLUIColorbarGlobal2Local();
-      RemapColorbar(cbi);
+      RemapColorbar(cbi, show_extreme_mindata, rgb_below_min,
+                  show_extreme_maxdata, rgb_above_max);
       UpdateRGBColors(colorbar_select_index);
       ColorbarGeneral2Simple(cbi);
       cbi->adjusted = 0;
     }
     break;
   case COLORBAR_LABEL:
-    if(colorbartype < ncolorbars){
+    if(colorbartype < colorbars.ncolorbars){
       char *clabel;
 
-      cbi = colorbarinfo + colorbartype;
+      cbi = colorbars.colorbarinfo + colorbartype;
       clabel = EDITTEXT_cb_label->get_text();
       strcpy(cbi->menu_label, clabel);
       LISTBOX_cb_edit->delete_item(colorbartype);
@@ -486,8 +489,8 @@ extern "C" void GLUIColorbarCB(int var){
     WriteIni(LOCAL_INI, NULL);
     break;
   case COLORBAR_ADDPOINT:
-    if(colorbartype >= ncolorbars)return;
-    cbi = colorbarinfo + colorbartype;
+    if(colorbartype >= colorbars.ncolorbars)return;
+    cbi = colorbars.colorbarinfo + colorbartype;
     if(colorbarpoint <= 0 || colorbarpoint > cbi->nnodes - 1)return;
 
     cbi->nnodes++;
@@ -519,16 +522,17 @@ extern "C" void GLUIColorbarCB(int var){
     }
 
     GLUIColorbarGlobal2Local();
-    RemapColorbar(cbi);
+    RemapColorbar(cbi, show_extreme_mindata, rgb_below_min,
+                  show_extreme_maxdata, rgb_above_max);
     UpdateRGBColors(colorbar_select_index);
 
     if(colorbarpoint == cbi->nnodes)colorbarpoint = cbi->nnodes - 1;
-    ColorbarGeneral2Simple(colorbarinfo + colorbartype);
+    ColorbarGeneral2Simple(colorbars.colorbarinfo + colorbartype);
     GLUIColorbarCB(COLORBAR_SIMPLE_ABLE);
     break;
   case COLORBAR_DELETEPOINT:
-    if(colorbartype >= ncolorbars)return;
-    cbi = colorbarinfo + colorbartype;
+    if(colorbartype >= colorbars.ncolorbars)return;
+    cbi = colorbars.colorbarinfo + colorbartype;
     if(colorbarpoint<0 || colorbarpoint>cbi->nnodes - 1)return;
     if(cbi->nnodes <= 2)return;
 
@@ -549,7 +553,8 @@ extern "C" void GLUIColorbarCB(int var){
       cbi->node_index[colorbarpoint] = 255;
     }
     if(colorbarpoint == 0)cbi->node_index[colorbarpoint] = 0;
-    RemapColorbar(cbi);
+    RemapColorbar(cbi, show_extreme_mindata, rgb_below_min,
+                  show_extreme_maxdata, rgb_above_max);
     UpdateRGBColors(colorbar_select_index);
     nodes_rgb = cbi->node_rgb + 3 * colorbarpoint;
     for(i = 0;i < 3;i++){
@@ -558,7 +563,7 @@ extern "C" void GLUIColorbarCB(int var){
     }
     SPINNER_cb_colorindex->set_int_val(cbi->node_index[colorbarpoint]);
     cb_colorindex = cbi->node_index[colorbarpoint];
-    ColorbarGeneral2Simple(colorbarinfo + colorbartype);
+    ColorbarGeneral2Simple(colorbars.colorbarinfo + colorbartype);
     GLUIColorbarCB(COLORBAR_SIMPLE_ABLE);
     break;
   case COLORBAR_RGB2:
@@ -588,7 +593,7 @@ extern "C" void GLUIColorbarCB(int var){
     toggle_on = 0;
     break;
   case COLORBAR_SIMPLE_ABLE:
-    if(colorbarinfo[colorbartype].nnodes > 5)break;
+    if(colorbars.colorbarinfo[colorbartype].nnodes > 5)break;
     switch(colorbar_simple_type){
       default:
       assert(FFALSE);
@@ -687,14 +692,14 @@ extern "C" void GLUIColorbarCB(int var){
     break;
   case COLORBAR_SIMPLE_TYPE:
     GLUIColorbarCB(COLORBAR_SIMPLE_ABLE);
-    ColorbarSimple2General(colorbarinfo + colorbartype);
+    ColorbarSimple2General(colorbars.colorbarinfo + colorbartype);
     GLUIColorbarCB(COLORBAR_LIST);
     ColorbarSimple(0);
     GLUTPOSTREDISPLAY;
     break;
   case COLORBAR_RGB:
-    if(colorbartype < 0 || colorbartype >= ncolorbars)return;
-    cbi = colorbarinfo + colorbartype;
+    if(colorbartype < 0 || colorbartype >= colorbars.ncolorbars)return;
+    cbi = colorbars.colorbarinfo + colorbartype;
     if(colorbarpoint<0 || colorbarpoint>cbi->nnodes - 1)return;
     if(colorbarpoint<=4){
       int index;
@@ -714,7 +719,8 @@ extern "C" void GLUIColorbarCB(int var){
     for(i = 0;i < 3;i++){
       nodes_rgb[i] = cb_rgb[i];
     }
-    RemapColorbar(cbi);
+    RemapColorbar(cbi, show_extreme_mindata, rgb_below_min,
+                  show_extreme_maxdata, rgb_above_max);
     UpdateRGBColors(colorbar_select_index);
     break;
   case COLORBAR_S0_RGB:
@@ -752,8 +758,8 @@ extern "C" void GLUIColorbarCB(int var){
     list_index = LISTBOX_cb_edit->get_int_val();
     if(list_index<0)break;
     colorbartype = list_index;
-    cbi = colorbarinfo + colorbartype;
-    if(show_firecolormap!=0)fire_colorbar_index= colorbartype;
+    cbi = colorbars.colorbarinfo + colorbartype;
+    if(show_firecolormap!=0)colorbars.fire_colorbar_index= colorbartype;
     GLUISetColorbarListBound(colorbartype);
     ColorbarMenu(colorbartype);
     GLUIColorbarGlobal2Local();
@@ -762,10 +768,10 @@ extern "C" void GLUIColorbarCB(int var){
 
     char button_label[sizeof(GLUI_String)];
     strcpy(button_label, "Copy to ");
-    strcat(button_label, colorbarinfo[colorbartype].menu_label);
+    strcat(button_label, colorbars.colorbarinfo[colorbartype].menu_label);
     strcat(button_label, "_copy");
     BUTTON_cb_save_as->set_name(button_label);
-    if(colorbartype < ndefaultcolorbars){
+    if(colorbartype < colorbars.ndefaultcolorbars){
       BUTTON_cb_delete ->disable();
     }
     else{
@@ -802,8 +808,8 @@ extern "C" void GLUIColorbarCB(int var){
   case COLORBAR_NODE_NEXT:
   case COLORBAR_NODE_PREV:
   case COLORBAR_SET:
-    if(colorbartype < 0 || colorbartype >= ncolorbars)return;
-    cbi = colorbarinfo + colorbartype;
+    if(colorbartype < 0 || colorbartype >= colorbars.ncolorbars)return;
+    cbi = colorbars.colorbarinfo + colorbartype;
     if(var == COLORBAR_NODE_NEXT){
       colorbarpoint++;
       if(colorbarpoint > cbi->nnodes - 1)colorbarpoint = 0;
@@ -816,13 +822,13 @@ extern "C" void GLUIColorbarCB(int var){
     GLUIColorbarGlobal2Local();
     break;
   case COLORBAR_COPY:
-    if(colorbartype < 0 || colorbartype >= ncolorbars)return;
+    if(colorbartype < 0 || colorbartype >= colorbars.ncolorbars)return;
     colorbartype = AddColorbar(colorbartype);
-    UpdateCurrentColorbar(colorbarinfo + colorbartype);
+    UpdateCurrentColorbar(colorbars.colorbarinfo + colorbartype);
     GLUIColorbarCB(COLORBAR_LIST);
     break;
   case COLORBAR_NEW:
-    colorbartype = bw_colorbar_index;
+    colorbartype = colorbars.bw_colorbar_index;
     GLUIColorbarCB(COLORBAR_COPY);
     char newlabel[sizeof(GLUI_String)], temp_label[sizeof(GLUI_String)];
     strcpy(temp_label, "new");
@@ -832,44 +838,47 @@ extern "C" void GLUIColorbarCB(int var){
     GLUIUpdateColorbarType();
     break;
   case COLORBAR_SAVE_AS:
-    if(colorbartype < ndefaultcolorbars){
+    if(colorbartype < colorbars.ndefaultcolorbars){
       int cb_save;
 
       cb_save = colorbartype;
       GLUIColorbarCB(COLORBAR_COPY);
-      memcpy(colorbarinfo + cb_save, colorbarcopyinfo + cb_save, sizeof(colorbardata));
+      memcpy(colorbars.colorbarinfo + cb_save, colorbarcopyinfo + cb_save, sizeof(colorbardata));
     }
     break;
   case COLORBAR_ADJUST_LAB:
-    AdjustColorBar(colorbarinfo + colorbartype);
+    AdjustColorBar(colorbars.colorbarinfo + colorbartype);
+    // As we have used AdjustColorBar we should set the flat to update the
+    // colorbar dialog.
+    update_colorbar_dialog = 1;
     GLUIColorbarCB(COLORBAR_RGB);
     break;
   case COLORBAR_REVERT:
-    RevertColorBar(colorbarinfo + colorbartype);
+    RevertColorBar(colorbars.colorbarinfo + colorbartype);
     GLUIColorbarCB(COLORBAR_LIST);
     break;
   case COLORBAR_SAVE_CSV:
-    cbi = colorbarinfo + colorbartype;
+    cbi = colorbars.colorbarinfo + colorbartype;
     Colorbar2File(cbi, colorbar_filename, colorbar_label);
     break;
   case COLORBAR_DELETE:
-    if(colorbartype >= ndefaultcolorbars&&colorbartype < ncolorbars){
+    if(colorbartype >= colorbars.ndefaultcolorbars&&colorbartype < colorbars.ncolorbars){
       colorbardata *cb_from, *cb_to;
 
-      for(i = colorbartype;i < ncolorbars - 1;i++){
-        cb_to = colorbarinfo + i;
+      for(i = colorbartype;i < colorbars.ncolorbars - 1;i++){
+        cb_to = colorbars.colorbarinfo + i;
         cb_from = cb_to + 1;
         memcpy(cb_to, cb_from, sizeof(colorbardata));
       }
-      for(i = colorbartype;i < ncolorbars;i++){
+      for(i = colorbartype;i < colorbars.ncolorbars;i++){
         LISTBOX_cb_edit->delete_item(i);
       }
-      ncolorbars--;
-      for(i = colorbartype;i < ncolorbars;i++){
-        cbi = colorbarinfo + i;
+      colorbars.ncolorbars--;
+      for(i = colorbartype;i < colorbars.ncolorbars;i++){
+        cbi = colorbars.colorbarinfo + i;
         LISTBOX_cb_edit->add_item(i, cbi->menu_label);
       }
-      if(colorbartype == ncolorbars)colorbartype--;
+      if(colorbartype == colorbars.ncolorbars)colorbartype--;
       LISTBOX_cb_edit->set_int_val(0);
       GLUIColorbarCB(COLORBAR_LIST);
       UpdateColorbarDialogs();
@@ -888,10 +897,10 @@ void AddColorbarListEdit(GLUI_Listbox *LIST_cbar, int index, char *label_arg, in
   int i, nitems=0;
 
 
-  for(i = 0; i < ncolorbars; i++){
+  for(i = 0; i < colorbars.ncolorbars; i++){
     colorbardata *cbi;
 
-    cbi = colorbarinfo + i;
+    cbi = colorbars.colorbarinfo + i;
     if(strcmp(cbi->colorbar_type, label_arg) != 0)continue;
     nitems++;
     break;
@@ -901,10 +910,10 @@ void AddColorbarListEdit(GLUI_Listbox *LIST_cbar, int index, char *label_arg, in
   strcat(cbar_type, label_arg);
   strcat(cbar_type, "----------");
   LIST_cbar->add_item(index, cbar_type);
-  for(i = 0; i < ncolorbars; i++){
+  for(i = 0; i < colorbars.ncolorbars; i++){
     colorbardata *cbi;
 
-    cbi = colorbarinfo + colorbar_list_sorted[i];
+    cbi = colorbars.colorbarinfo + colorbar_list_sorted[i];
     if(strcmp(cbi->colorbar_type, label_arg) != 0)continue;
     LIST_cbar->add_item(colorbar_list_sorted[i], cbi->menu_label);
     *max_index = MAX(colorbar_list_sorted[i], *max_index);
@@ -935,7 +944,7 @@ extern "C" void GLUIUpdateColorbarListEdit(int flag, int del){
   }
   if(LISTBOX_cb == NULL)return;
   if(del == CB_DELETE){
-    for(i = -7; i < ncolorbars; i++){
+    for(i = -7; i < colorbars.ncolorbars; i++){
       LISTBOX_cb->delete_item(i);
     }
   }
@@ -991,7 +1000,7 @@ extern "C" void GLUIColorbarSetup(int main_window){
   BUTTON_cb_save_as = glui_colorbar->add_button_to_panel(PANEL_cb_select1, _("Save"),      COLORBAR_SAVE_AS, GLUIColorbarCB);
   glui_colorbar->add_column_to_panel(PANEL_cb_select1, false);
   glui_colorbar->add_button_to_panel(PANEL_cb_select1,"New",COLORBAR_NEW,GLUIColorbarCB);
-  if(ncolorbars>0){
+  if(colorbars.ncolorbars>0){
     colorbartype=0;
 
     LISTBOX_cb_edit=glui_colorbar->add_listbox_to_panel(PANEL_cb_select,"",&colorbartype,COLORBAR_LIST,GLUIColorbarCB);
@@ -1154,7 +1163,7 @@ extern "C" void GLUIColorbarSetup(int main_window){
 #ifdef pp_CLOSEOFF
   BUTTON_colorbar_close->disable();
 #endif
-  if(ncolorbars > 0){
+  if(colorbars.ncolorbars > 0){
     GLUIColorbarCB(COLORBAR_LIST);
   }
 
@@ -1167,9 +1176,9 @@ extern "C" void GLUIColorbarGlobal2Local(void){
   colorbardata *cbi;
   unsigned char *rgb_local;
 
-  if(colorbartype<0||colorbartype>=ncolorbars)return;
+  if(colorbartype<0||colorbartype>=colorbars.ncolorbars)return;
 
-  cbi = colorbarinfo + colorbartype;
+  cbi = colorbars.colorbarinfo + colorbartype;
   colorbarpoint=cbi->nodehilight;
 
   if(SPINNER_cb_colorindex == NULL)return;

--- a/Source/smokeview/glui_display.cpp
+++ b/Source/smokeview/glui_display.cpp
@@ -1368,9 +1368,9 @@ extern "C" void GLUILabelsCB(int var){
     InitRGB();
     break;
   case LABELS_shadedata:
-    if(setbwdata==1 && bw_colorbar_index>=0){
+    if(setbwdata==1 && colorbars.bw_colorbar_index>=0){
       colorbartype_save=colorbartype;
-      ColorbarMenu(bw_colorbar_index);
+      ColorbarMenu(colorbars.bw_colorbar_index);
     }
     else{
       if(colorbartype_save>-1)ColorbarMenu(colorbartype_save);

--- a/Source/smokeview/glui_smoke.cpp
+++ b/Source/smokeview/glui_smoke.cpp
@@ -206,15 +206,15 @@ extern "C" void GLUIUpdateFireAlpha(void){
 /* ------------------ GLUIUpdateCO2ColorbarList ------------------------ */
 
 extern "C" void GLUIUpdateCO2ColorbarList(int value){
-  co2_colorbar_index = CLAMP(value, 0, ncolorbars-1);
-  if(LISTBOX_co2_colorbar!=NULL)LISTBOX_co2_colorbar->set_int_val(co2_colorbar_index);
+  colorbars.co2_colorbar_index = CLAMP(value, 0, colorbars.ncolorbars-1);
+  if(LISTBOX_co2_colorbar!=NULL)LISTBOX_co2_colorbar->set_int_val(colorbars.co2_colorbar_index);
   GLUISmoke3dCB(CO2_COLORBAR_LIST);
 }
 
 /* ------------------ GLUIUpdateFireColorbarList ------------------------ */
 
 extern "C" void GLUIUpdateFireColorbarList(void){
-  if(LISTBOX_smoke_colorbar!=NULL)LISTBOX_smoke_colorbar->set_int_val(fire_colorbar_index);
+  if(LISTBOX_smoke_colorbar!=NULL)LISTBOX_smoke_colorbar->set_int_val(colorbars.fire_colorbar_index);
 }
 
 /* ------------------ GLUIUpdateBackgroundFlip2 ------------------------ */
@@ -476,17 +476,17 @@ extern "C" void GLUI3dSmokeSetup(int main_window){
   SPINNER_smoke3d_fire_green->set_int_limits(0,255);
   SPINNER_smoke3d_fire_blue->set_int_limits(0,255);
 
-  if(ncolorbars > 0){
+  if(colorbars.ncolorbars > 0){
     CHECKBOX_use_fire_colormap = glui_3dsmoke->add_checkbox_to_panel(ROLLOUT_firecolor, "set smoke/fire color using colormap", &use_fire_colormap, USE_FIRE_COLORMAP, GLUISmoke3dCB);
     PANEL_colormap3 = glui_3dsmoke->add_panel_to_panel(ROLLOUT_firecolor, "colormap");
-    LISTBOX_smoke_colorbar = glui_3dsmoke->add_listbox_to_panel(PANEL_colormap3, "Select:", &fire_colorbar_index, SMOKE_COLORBAR_LIST, GLUISmoke3dCB);
-    for(i = 0;i < ncolorbars;i++){
+    LISTBOX_smoke_colorbar = glui_3dsmoke->add_listbox_to_panel(PANEL_colormap3, "Select:", &colorbars.fire_colorbar_index, SMOKE_COLORBAR_LIST, GLUISmoke3dCB);
+    for(i = 0;i < colorbars.ncolorbars;i++){
       colorbardata *cbi;
 
-      cbi = colorbarinfo + i;
+      cbi = colorbars.colorbarinfo + i;
       LISTBOX_smoke_colorbar->add_item(i, cbi->menu_label);
     }
-    LISTBOX_smoke_colorbar->set_int_val(fire_colorbar_index);
+    LISTBOX_smoke_colorbar->set_int_val(colorbars.fire_colorbar_index);
     glui_3dsmoke->add_column_to_panel(PANEL_colormap3,false);
     CHECKBOX_edit_colormap = glui_3dsmoke->add_checkbox_to_panel(PANEL_colormap3, "Edit", &show_firecolormap, SHOW_FIRECOLORMAP, GLUISmoke3dCB);
   }
@@ -577,16 +577,16 @@ extern "C" void GLUI3dSmokeSetup(int main_window){
     SPINNER_co2color[0]->set_int_limits(0, 255);
     SPINNER_co2color[1]->set_int_limits(0, 255);
     SPINNER_co2color[2]->set_int_limits(0, 255);
-    if(ncolorbars > 0){
+    if(colorbars.ncolorbars > 0){
       CHECKBOX_use_co2_colormap = glui_3dsmoke->add_checkbox_to_panel(ROLLOUT_co2color, "set colormap", &use_co2_colormap, USE_CO2_COLORMAP, GLUISmoke3dCB);
-      LISTBOX_co2_colorbar = glui_3dsmoke->add_listbox_to_panel(ROLLOUT_co2color, "colormap:", &co2_colorbar_index, CO2_COLORBAR_LIST, GLUISmoke3dCB);
-      for(i = 0; i < ncolorbars; i++){
+      LISTBOX_co2_colorbar = glui_3dsmoke->add_listbox_to_panel(ROLLOUT_co2color, "colormap:", &colorbars.co2_colorbar_index, CO2_COLORBAR_LIST, GLUISmoke3dCB);
+      for(i = 0; i < colorbars.ncolorbars; i++){
         colorbardata *cbi;
 
-        cbi = colorbarinfo+i;
+        cbi = colorbars.colorbarinfo+i;
         LISTBOX_co2_colorbar->add_item(i, cbi->menu_label);
       }
-      LISTBOX_co2_colorbar->set_int_val(co2_colorbar_index);
+      LISTBOX_co2_colorbar->set_int_val(colorbars.co2_colorbar_index);
     }
 
     if(nco2files > 0){
@@ -1073,12 +1073,12 @@ extern "C" void GLUISmoke3dCB(int var){
     }
     if(fire_temp_min<20.0){
       fire_temp_min = 20.0;
-      SPINNER_fire_temp_min->set_float_val(fire_temp_min);     
+      SPINNER_fire_temp_min->set_float_val(fire_temp_min);
     }
     if(fire_temp_min>fire_temp_max){
       fire_temp_max = fire_temp_min + 1500.0;
-      SPINNER_fire_temp_min->set_float_val(fire_temp_min);     
-      SPINNER_fire_temp_max->set_float_val(fire_temp_max);     
+      SPINNER_fire_temp_min->set_float_val(fire_temp_min);
+      SPINNER_fire_temp_max->set_float_val(fire_temp_max);
     }
     MakeFireColors(fire_temp_min, fire_temp_max, nfire_colors);
     break;
@@ -1177,11 +1177,11 @@ extern "C" void GLUISmoke3dCB(int var){
         SmokeColorbarMenu(fire_colorbar_index_save);
       }
       else{
-        SmokeColorbarMenu(fire_colorbar_index);
+        SmokeColorbarMenu(colorbars.fire_colorbar_index);
       }
       break;
     case FIRECOLORMAP_DIRECT:
-      fire_colorbar_index_save = fire_colorbar_index;
+      fire_colorbar_index_save = colorbars.fire_colorbar_index;
       UpdateRGBColors(colorbar_select_index);
       UpdateSmokeColormap(smoke_render_option);
       break;
@@ -1191,13 +1191,13 @@ extern "C" void GLUISmoke3dCB(int var){
 #endif
       break;
     }
-    if(LISTBOX_smoke_colorbar->get_int_val()!=fire_colorbar_index){
-      LISTBOX_smoke_colorbar->set_int_val(fire_colorbar_index);
+    if(LISTBOX_smoke_colorbar->get_int_val()!=colorbars.fire_colorbar_index){
+      LISTBOX_smoke_colorbar->set_int_val(colorbars.fire_colorbar_index);
     }
     UpdateSmokeColormap(smoke_render_option);
     break;
   case SMOKE_COLORBAR_LIST:
-    SmokeColorbarMenu(fire_colorbar_index);
+    SmokeColorbarMenu(colorbars.fire_colorbar_index);
     UpdateSmokeColormap(smoke_render_option);
     updatemenu=1;
     break;

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -21,6 +21,7 @@
 #include "IOobjects.h"
 #include "IOscript.h"
 #include "viewports.h"
+#include "colorbars.h"
 
 void LoadHVACMenu(int value);
 void LoadPlot2DMenu(int value);
@@ -948,9 +949,9 @@ void SmokeColorbarMenu(int value){
   if(value==MENU_DUMMY)return;
   updatemenu=1;
 
-  value = CLAMP(value, 0, ncolorbars - 1);
-  fire_colorbar_index=value;
-  fire_colorbar = colorbarinfo + value;
+  value = CLAMP(value, 0, colorbars.ncolorbars - 1);
+  colorbars.fire_colorbar_index=value;
+  fire_colorbar = colorbars.colorbarinfo + value;
   UpdateRGBColors(colorbar_select_index);
   if(FlowDir>0){
     Keyboard('-',FROM_SMOKEVIEW);
@@ -1010,9 +1011,9 @@ void ColorbarMenu(int value){
       break;
     case COLORBAR_TOGGLE_BW_DATA:
       setbwdata = 1 - setbwdata;
-      if(setbwdata==1&&bw_colorbar_index>=0){
+      if(setbwdata==1&&colorbars.bw_colorbar_index>=0){
         colorbartype_save=colorbartype;
-        ColorbarMenu(bw_colorbar_index);
+        ColorbarMenu(colorbars.bw_colorbar_index);
       }
       else{
         if(colorbartype_save>-1)ColorbarMenu(colorbartype_save);
@@ -1069,14 +1070,14 @@ void ColorbarMenu(int value){
   }
   if(value>=0){
     colorbartype=value;
-    iso_colorbar_index=value;
-    iso_colorbar = colorbarinfo + iso_colorbar_index;
+    colorbars.iso_colorbar_index=value;
+    iso_colorbar = colorbars.colorbarinfo + colorbars.iso_colorbar_index;
     update_texturebar=1;
     GLUIUpdateListIsoColorobar();
-    UpdateCurrentColorbar(colorbarinfo+colorbartype);
+    UpdateCurrentColorbar(colorbars.colorbarinfo+colorbartype);
     GLUIUpdateColorbarType();
     GLUISetColorbarListBound(colorbartype);
-    if(colorbartype == bw_colorbar_index&&bw_colorbar_index>=0){
+    if(colorbartype == colorbars.bw_colorbar_index&&colorbars.bw_colorbar_index>=0){
       setbwdata = 1;
     }
     else{
@@ -1085,7 +1086,7 @@ void ColorbarMenu(int value){
     GLUIIsoBoundCB(ISO_COLORS);
     GLUISetLabelControls();
     char *ext, cblabel[1024];
-    strcpy(cblabel,colorbarinfo[colorbartype].menu_label);
+    strcpy(cblabel,colorbars.colorbarinfo[colorbartype].menu_label);
     ext = strrchr(cblabel,'.');
     if(ext!=NULL)*ext=0;
   }
@@ -8899,10 +8900,10 @@ void InitPatchSubMenus(int **loadsubpatchmenu_sptr, int **nsubpatchmenus_sptr){
 int MakeSubColorbarMenu(int *submenuptr, int *nmenusptr, char *ctype, void (*CBMenu)(int)){
   int i, nitems=0, submenu;
 
-  for(i = 0; i < ncolorbars; i++){
+  for(i = 0; i < colorbars.ncolorbars; i++){
     colorbardata *cbi;
 
-    cbi = colorbarinfo + i;
+    cbi = colorbars.colorbarinfo + i;
     if(strcmp(cbi->colorbar_type, ctype) != 0)continue;
     nitems++;
     break;
@@ -8913,10 +8914,10 @@ int MakeSubColorbarMenu(int *submenuptr, int *nmenusptr, char *ctype, void (*CBM
   *submenuptr = submenu;
   char ccolorbarmenu[256];
 
-  for(i = 0; i < ncolorbars; i++){
+  for(i = 0; i < colorbars.ncolorbars; i++){
     colorbardata *cbi;
 
-    cbi = colorbarinfo + colorbar_list_sorted[i];
+    cbi = colorbars.colorbarinfo + colorbar_list_sorted[i];
     if(strcmp(cbi->colorbar_type, ctype) != 0)continue;
     strcpy(ccolorbarmenu, "");
     if(colorbartype == colorbar_list_sorted[i]){

--- a/Source/smokeview/renderhtml.c
+++ b/Source/smokeview/renderhtml.c
@@ -2194,6 +2194,7 @@ int Smv2Html(char *html_file, int option, int from_where){
     printf("***error: smokeview html template file %s failed to open\n", template_file);
     return 1;
   }
+  FREEMEMORY(template_file);
 
   if(from_where==FROM_SCRIPT){
     strcpy(html_fullfile, html_file);

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -9,6 +9,8 @@
 #define TERRAIN_FIRE_LINE_UPDATE 39
 #endif
 
+#include "colorbars.h"
+
 //*** glui_clip.cpp headers
 
 EXTERNCPP void GLUIClipSetup(int main_window);
@@ -220,11 +222,8 @@ EXTERNCPP void DrawVerticalColorbarRegLabels(void);
 EXTERNCPP void DrawSelectColorbar(void);
 EXTERNCPP void DrawTimebar(float xleft, float xright, float ybot, float ytop);
 EXTERNCPP void FRgb2Lab(float *rgb_arg, float *lab);
-EXTERNCPP colorbardata *GetColorbar(char *label);
-EXTERNCPP void InitDefaultColorbars(int nini);
 EXTERNCPP int  IsColorbarSplit(colorbardata *cbi);
 EXTERNCPP void Lab2Rgb(unsigned char *rgb255, float *frgb, float *lab);
-EXTERNCPP void RemapColorbar(colorbardata *cbi);
 EXTERNCPP void RevertColorBar(colorbardata *cbi);
 EXTERNCPP void Rgb2Lab(unsigned char *rgb, float *lab);
 EXTERNCPP void SortColorBars(void);

--- a/Source/smokeview/smokeview.c
+++ b/Source/smokeview/smokeview.c
@@ -211,6 +211,7 @@ void DisplayVersionInfo(char *progname){
   }
   char *smv_progname = GetBinPath();
   PRINTF("Smokeview path   : %s\n",smv_progname);
+  FREEMEMORY(smv_progname);
 #ifdef pp_COMPRESS
   if(smokezippath!=NULL){
     if(verbose_output==1)PRINTF("Smokezip         : %s\n",smokezippath);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -449,7 +449,6 @@ SVEXTERN int SVDECL(update_texturebar, 0);
 SVEXTERN float SVDECL(iso_valmin, 20.0), SVDECL(iso_valmax, 1020.0);
 SVEXTERN float SVDECL(glui_iso_valmin, 20.0), SVDECL(glui_iso_valmax, 1020.0);
 SVEXTERN float SVDECL(iso_global_min,0.0), SVDECL(iso_global_max,1.0);
-SVEXTERN int SVDECL(iso_colorbar_index, 0);
 SVEXTERN colorbardata SVDECL(*iso_colorbar, NULL);
 SVEXTERN int SVDECL(show_iso_color, 1);
 SVEXTERN int SVDECL(update_iso_ini, 0);
@@ -678,7 +677,6 @@ SVEXTERN unsigned int SVDECL(*screenmap360, NULL);
 SVEXTERN float SVDECL(*screenmap360IX, NULL), SVDECL(*screenmap360IY, NULL);
 
 SVEXTERN colorbardata SVDECL(*split_colorbar, NULL);
-SVEXTERN int SVDECL(split_colorbar_index, -1);
 #ifdef INMAIN
 SVEXTERN float splitvals[3]={-1.0,0.0,1.0};
 #else
@@ -1257,11 +1255,11 @@ SVEXTERN int showiso_colorbar;
 SVEXTERN int SVDECL(visgridloc,0);
 SVEXTERN int SVDECL(valindex,0);
 
-SVEXTERN int co2_colorbar_index, SVDECL(co2_colorbar_index_save, -1);
+SVEXTERN int SVDECL(co2_colorbar_index_save, -1);
 SVEXTERN int SVDECL(update_co2_colorbar_index, 0);
 SVEXTERN int SVDECL(co2_colorbar_index_ini, 0);
 
-SVEXTERN int fire_colorbar_index,SVDECL(fire_colorbar_index_save,-1);
+SVEXTERN int SVDECL(fire_colorbar_index_save,-1);
 SVEXTERN int SVDECL(update_fire_colorbar_index,0);
 SVEXTERN int SVDECL(fire_colorbar_index_ini,0);
 SVEXTERN float SVDECL(*rgb2_ini,NULL);
@@ -1788,8 +1786,6 @@ SVEXTERN char SVDECL(*colorbars_linear_dir,  NULL);
 SVEXTERN char SVDECL(*colorbars_rainbow_dir, NULL);
 SVEXTERN char SVDECL(*colorbars_divergent_dir, NULL);
 SVEXTERN char SVDECL(*colorbars_circular_dir, NULL);
-SVEXTERN char SVDECL(*colorbars_user_dir, NULL);
-SVEXTERN int SVDECL(nlinear_filelist,0), SVDECL(ncircular_filelist,0), SVDECL(nrainbow_filelist,0), SVDECL(ndivergent_filelist,0);
 SVEXTERN int SVDECL(ndeprecated_filelist, 0);
 SVEXTERN int SVDECL(nuser_filelist, 0);
 SVEXTERN char release_title[1024];
@@ -2073,9 +2069,12 @@ SVEXTERN int smoke_alpha;
 SVEXTERN int SVDECL(showall_textures,0);
 SVEXTERN int SVDECL(enable_texture_lighting,0);
 
-SVEXTERN int SVDECL(ncolorbars,0);
-SVEXTERN int ndefaultcolorbars;
-SVEXTERN colorbardata SVDECL(*colorbarinfo,NULL),SVDECL(*current_colorbar,NULL);
+#ifdef INMAIN
+SVEXTERN colorbar_collection colorbars = {.split_colorbar_index = -1, 0};
+#else
+SVEXTERN colorbar_collection colorbars;
+#endif
+SVEXTERN colorbardata SVDECL(*current_colorbar,NULL);
 SVEXTERN colorbardata SVDECL(*colorbarcopyinfo, NULL);
 
 SVEXTERN int SVDECL(ncolortableinfo, 0);
@@ -2139,7 +2138,6 @@ SVEXTERN int glui_tick_inside, glui_tick_outside;
 SVEXTERN int user_tick_nxyz[3], user_tick_sub, user_tick_option, SVDECL(visUSERticks,0), SVDECL(auto_user_tick_placement,1);
 SVEXTERN int SVDECL(user_tick_show_x,1), SVDECL(user_tick_show_y,1), SVDECL(user_tick_show_z,1);
 SVEXTERN int SVDECL(visCadTextures,1), SVDECL(visTerrainTexture,1);
-SVEXTERN int bw_colorbar_index;
 SVEXTERN int SVDECL(viscolorbarpath,0);
 SVEXTERN int SVDECL(*sortedblocklist,NULL),SVDECL(*changed_idlist,NULL),SVDECL(nchanged_idlist,0);
 SVEXTERN int SVDECL(nselectblocks,0);

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -401,10 +401,11 @@ void InitStartupDirs(void){
   }
 
   // Create the colorbar directory if it doesn't already exist.
-  colorbars_user_dir = GetUserConfigSubPath("colorbars");
+  char *colorbars_user_dir = GetUserColorbarDirPath();
   if(FileExistsOrig(colorbars_user_dir)==NO){
     MKDIR(colorbars_user_dir);
   }
+  FREEMEMORY(colorbars_user_dir);
 
   if(verbose_output==1)PRINTF("Scratch directory: %s\n", smokeview_scratchdir);
   char *smokeviewini_filename = GetSystemIniPath();
@@ -1206,32 +1207,6 @@ void InitOpenGL(int option){
     TrainerViewMenu(trainerview);
   }
 
-  /* ------------------ InitColorbarsSubDir ------------------------ */
-
-  char *InitColorbarsSubDir(char *subdir){
-    char *return_path = NULL;
-    char *smv_bindir = GetSmvRootDir();
-    if(subdir==NULL)return return_path;
-
-    NewMemory((void **)&return_path,
-              strlen(smv_bindir) + strlen("colorbars") + strlen(dirseparator) + strlen(subdir) + 2);
-    strcpy(return_path, smv_bindir);
-    strcat(return_path, "colorbars");
-    strcat(return_path, dirseparator);
-    if(strlen(subdir)>0)strcat(return_path, subdir);
-    FREEMEMORY(smv_bindir);
-    return return_path;
-  }
-
-  /* ------------------ InitColorbarsDir ------------------------ */
-
-  void InitColorbarsDir(void){
-    colorbars_dir           = InitColorbarsSubDir("");
-    colorbars_linear_dir    = InitColorbarsSubDir("linear");
-    colorbars_divergent_dir = InitColorbarsSubDir("divergent");
-    colorbars_rainbow_dir   = InitColorbarsSubDir("rainbow");
-    colorbars_circular_dir  = InitColorbarsSubDir("circular");
-  }
   /* ------------------ InitTextureDir ------------------------ */
 
 void InitTextureDir(void){
@@ -1527,7 +1502,7 @@ void InitVars(void){
   strcpy(script_renderfile,"");
   setpartmin_old=setpartmin;
   setpartmax_old=setpartmax;
-  UpdateCurrentColorbar(colorbarinfo);
+  UpdateCurrentColorbar(colorbars.colorbarinfo);
   visBlocks=visBLOCKAsInput;
   blocklocation=BLOCKlocation_grid;
   render_window_size=RenderWindow;

--- a/Source/smokeview/structures.h
+++ b/Source/smokeview/structures.h
@@ -191,33 +191,6 @@ typedef struct _treedata {
   int state;
 } treedata;
 
-/* --------------------------  colorbardata ------------------------------------ */
-
-#define CB_RAINBOW    0
-#define CB_ORIGINAL   1
-#define CB_LINEAR     2
-#define CB_DIVERGENT  3
-#define CB_CIRCULAR   4
-#define CB_DEPRECATED 5
-#define CB_USER       6
-#define CB_OTHER      7
-#define INTERP_RGB    0
-#define INTERP_LAB    1
-typedef struct _colorbardata {
-  char menu_label[1024];        // menu label
-  char colorbar_type[256];      // rainbow, linear, divergent, etc
-  int nnodes, nnodes_orig, node_index_orig[1024], nodehilight, type;
-  unsigned char node_rgb_orig[3*1024], node_rgb[3*1024], colorbar_alpha[1024];
-  unsigned char node_index[1024];  // colorbar index
-  float node_dist[1024];
-  float colorbar_dist[256];
-  int dist_ind[256];
-  float colorbar_dist_delta[1024];
-  int interp;   // (LAB or RGB)
-  int can_adjust, adjusted;
-  float colorbar_rgb[3*1024], colorbar_lab[3*1024];
-} colorbardata;
-
 /* --------------------------  colortabledata ------------------------------------ */
 
 typedef struct _colortabledata {

--- a/Source/smokeview/update.c
+++ b/Source/smokeview/update.c
@@ -3111,18 +3111,18 @@ void UpdateDisplay(void){
   }
   if(update_smokecolorbar == 1){
     update_smokecolorbar = 0;
-    SmokeColorbarMenu(fire_colorbar_index);
+    SmokeColorbarMenu(colorbars.fire_colorbar_index);
   }
   if(update_colorbar_dialog == 1){
-    GLUIUpdateNodeLabel(colorbarinfo + colorbartype);
+    GLUIUpdateNodeLabel(colorbars.colorbarinfo + colorbartype);
     update_colorbar_dialog = 0;
   }
   if(update_colorbartype == 1){
     colorbardata *cb;
 
-    cb = GetColorbar(colorbarname);
+    cb = GetColorbar(&colorbars, colorbarname);
     if(cb != NULL){
-      colorbartype = cb - colorbarinfo;
+      colorbartype = cb - colorbars.colorbarinfo;
       colorbartype_default = colorbartype;
       if(cb->can_adjust == 1){
         cb->interp = INTERP_LAB;
@@ -3130,13 +3130,14 @@ void UpdateDisplay(void){
       else{
         cb->interp = INTERP_RGB;
       }
-      RemapColorbar(cb);
+      RemapColorbar(cb, show_extreme_mindata, rgb_below_min,
+                    show_extreme_maxdata, rgb_above_max);
       memcpy(cb->node_rgb_orig, cb->node_rgb, 3*cb->nnodes*sizeof(unsigned char));
       UpdateCurrentColorbar(cb);
       if(colorbartype != colorbartype_default){
         colorbartype_ini = colorbartype;
       }
-      if(colorbarinfo != NULL){
+      if(colorbars.colorbarinfo != NULL){
         colorbartype = colorbartype_default;
         UpdateColorbarDialogs();
       }

--- a/Source/smokeview/viewports.c
+++ b/Source/smokeview/viewports.c
@@ -12,6 +12,7 @@
 #include "glui_bounds.h"
 #include "IOvolsmoke.h"
 #include "infoheader.h"
+#include "colorbars.h"
 #include "readtour.h"
 #include "readsmoke.h"
 
@@ -1115,7 +1116,7 @@ void ViewportSlicePlot(int quad, GLint screen_left, GLint screen_down){
 
     position = 0;
 
-    cbi = colorbarinfo + colorbartype;
+    cbi = colorbars.colorbarinfo + colorbartype;
     strcpy(label, cbi->menu_label);
     strcat(label, "/CIELab delta");
 
@@ -1123,8 +1124,7 @@ void ViewportSlicePlot(int quad, GLint screen_left, GLint screen_down){
       xvals[i] = (float)i;
     }
 
-    void GetColorDist(colorbardata *cbi, int option, float *min, float *max);
-    GetColorDist(colorbarinfo + colorbartype, 1, &valmin, &valmax);
+    GetColorDist(colorbars.colorbarinfo + colorbartype, 1, &valmin, &valmax);
     DrawPlot2D(PLOT_ALL, xvals, cbi->colorbar_dist_delta, NULL, 254,
       0.0, cbi->colorbar_dist_delta[0], 0.0, 1, position, valmin, valmax,
       label, NULL, "",

--- a/Tests/.gitignore
+++ b/Tests/.gitignore
@@ -1,3 +1,4 @@
 fig/
+bot/
 test_model_small/
 test_model_large/

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -189,6 +189,56 @@ if ((NOT MACOSX) AND UNIX)
 endif()
 
 
+# parse_objects
+add_executable(parse_objects parse_objects.c
+    ../Source/shared/dmalloc.c
+    ../Source/shared/readobject.c
+    ../Source/shared/string_util.c
+    ../Source/shared/file_util.c
+    ../Source/shared/stdio_buffer.c
+    ../Source/shared/sha256.c
+    ../Source/shared/sha1.c
+    ../Source/shared/md5.c
+)
+
+target_include_directories(parse_objects PRIVATE
+    ../Tests
+    ../Source/shared
+)
+if (WIN32)
+    target_include_directories(parse_objects PRIVATE ../Source/pthreads)
+endif()
+if ((NOT MACOSX) AND UNIX)
+    target_link_libraries(parse_objects m)
+endif()
+
+
+# parse_colorbar
+add_executable(parse_colorbar parse_colorbar.c
+    ../Source/shared/getdata.c
+    ../Source/shared/dmalloc.c
+    ../Source/shared/colorbars.c
+    ../Source/shared/colorbar_defs.c
+    ../Source/shared/file_util.c
+    ../Source/shared/string_util.c
+    ../Source/shared/stdio_buffer.c
+    ../Source/shared/sha256.c
+    ../Source/shared/sha1.c
+    ../Source/shared/md5.c
+)
+
+target_include_directories(parse_colorbar PRIVATE
+    ../Tests
+    ../Source/shared
+)
+if (WIN32)
+    target_include_directories(parse_colorbar PRIVATE ../Source/pthreads)
+endif()
+if ((NOT MACOSX) AND UNIX)
+    target_link_libraries(parse_colorbar m)
+endif()
+
+
 # mem_test
 add_executable(mem_test mem_test.c
     ../Source/shared/dmalloc.c
@@ -251,7 +301,19 @@ add_test(NAME "Parse CAD"
     COMMAND parse_cad)
 
 add_test(NAME "Test Object API"
+    COMMAND test_objects)
+
+# This test will still pass as it will simply try to parse as many objects as
+# possible.
+add_test(NAME "Test Object API (bad objects)"
     COMMAND test_objects ${CMAKE_SOURCE_DIR}/Tests/bad_objects.svo)
+# set_property(TEST "Test Object API (bad objects)" PROPERTY WILL_FAIL true)
+
+add_test(NAME "Test Object API (for bundle)"
+    COMMAND parse_objects ${CMAKE_SOURCE_DIR}/Build/for_bundle/objects.svo)
+
+add_test(NAME "Parse Colorbar"
+    COMMAND parse_colorbar ${CMAKE_SOURCE_DIR}/Build/for_bundle/colorbars/divergent/CET-D01.csv)
 
 add_test(NAME "Simple HVAC Vals - Complete"
     COMMAND parse_hvac_vals ${FIG_DIR}/smv/Tests/simple_hvac.hvac)

--- a/Tests/parse_colorbar.c
+++ b/Tests/parse_colorbar.c
@@ -1,0 +1,31 @@
+#include "options.h"
+
+#include "dmalloc.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "colorbars.h"
+
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
+int main(int argc, char **argv) {
+  initMALLOC();
+  if (argc < 2) return 2;
+  int error = 0;
+  const char *filename = argv[1];
+  colorbardata *cb;
+  NEWMEMORY(cb, sizeof(colorbardata));
+
+  int result = ReadCSVColorbar(cb, filename, "divergent", CB_DIVERGENT);
+  assert(!result);
+  assert(strcmp(cb->colorbar_type, "divergent") == 0);
+  assert(strcmp(cb->menu_label, "light blue->white->light red") == 0);
+  assert(cb->nnodes == 256);
+  return error;
+}

--- a/Tests/parse_objects.c
+++ b/Tests/parse_objects.c
@@ -1,0 +1,33 @@
+#include "options.h"
+
+#include "getdata.h"
+
+#include "dmalloc.h"
+
+#include "string_util.h"
+#include <stdlib.h>
+
+#include "readobject.h"
+
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
+int main(int argc, char **argv) {
+  initMALLOC();
+  if (argc > 1) {
+    const char *file_path = argv[1];
+    // Create an object collection, read in object definitions, then free it.
+    object_collection *objectscoll = CreateObjectCollection();
+    int result = ReadObjectDefs(objectscoll, file_path, 0);
+    // Two of the objects in this bad file are still parsable so we should
+    // parse 2 object definitions.
+    assert(result > 0);
+    FreeObjectCollection(objectscoll);
+    return 0;
+  }
+  else {
+    return 1;
+  }
+}

--- a/Tests/test_objects.c
+++ b/Tests/test_objects.c
@@ -29,30 +29,12 @@ int main(int argc, char **argv) {
     // There should be no objects to begin with
     assert(objectscoll->nobject_defs == 0);
     ReadDefaultObjectCollection(objectscoll, NULL, 0, 0);
-    // for (int i = 0; i < objectscoll->nobject_defs; i++) {
-    //   sv_object *objecti = objectscoll->object_defs[i];
-    //   printf("label[%d]: %s\n", i, objecti->label);
-    // }
     FreeObjectCollection(objectscoll);
   }
   {
     // Create an object collection, read in object definitions, then free it.
     object_collection *objectscoll = CreateObjectCollection();
     ReadDefaultObjectCollection(objectscoll, NULL, 0, 0);
-    // for (int i = 0; i < objectscoll->nobject_defs; i++) {
-    //   sv_object *objecti = objectscoll->object_defs[i];
-    //   printf("label[%d]: %s\n", i, objecti->label);
-    // }
-    FreeObjectCollection(objectscoll);
-  }
-  if (argc > 1) {
-    const char *bad_file_path = argv[1];
-    // Create an object collection, read in object definitions, then free it.
-    object_collection *objectscoll = CreateObjectCollection();
-    int result = ReadObjectDefs(objectscoll, bad_file_path, 0);
-    // Two of the objects in this bad file are still parsable so we should
-    // parse 2 object definitions.
-    assert(result == 2);
     FreeObjectCollection(objectscoll);
   }
   return 0;


### PR DESCRIPTION
There is a lot of useful code that is currently intertwined with GLUT and GLUI. This splits that code out and put it into shared.

This does include some refactoring in that colorbar data is collected into a struct of type `colorbar_collection` which can be used without reference to global variables (including tests as shown in `Tests/parse_colorbar.c`).