### PR TITLE
tweak object_collection and cadgeom_collection APIs to be more flexible

### DIFF
--- a/Source/shared/readcad.c
+++ b/Source/shared/readcad.c
@@ -415,14 +415,28 @@ int ReadCADGeomToCollection(cadgeom_collection *coll, const char *file,
   return 0;
 }
 
+int InitCADGeomCollection(cadgeom_collection *coll, int capacity) {
+  // Set everything to NULL
+  memset(coll, 0, sizeof(cadgeom_collection));
+  // Allocate capacity
+  if(NEWMEMORY(coll->cadgeominfo, capacity * sizeof(cadgeomdata)) == 0)
+    return 1;
+  coll->capacity = capacity;
+  return 0;
+}
+
 cadgeom_collection *CreateCADGeomCollection(int capacity) {
   cadgeom_collection *coll;
   if(NewMemory((void **)&coll, capacity * sizeof(cadgeom_collection)) == 0)
     return NULL;
-  // Set everything to NULL
-  memset(coll, 0, capacity * sizeof(cadgeom_collection));
-  coll->capacity = capacity;
-  return coll;
+  int ret = InitCADGeomCollection(coll, capacity);
+  if(ret != 0) {
+    FREEMEMORY(coll);
+    return NULL;
+  }
+  else {
+    return coll;
+  }
 }
 
 void FreeCADGeom(cadgeomdata *cd) {
@@ -431,10 +445,15 @@ void FreeCADGeom(cadgeomdata *cd) {
 }
 
 void FreeCADGeomCollection(cadgeom_collection *coll) {
+  ClearCADGeomCollection(coll);
+  FREEMEMORY(coll);
+}
+
+void ClearCADGeomCollection(cadgeom_collection *coll) {
   for(int i = 0; i < coll->ncadgeom; i++) {
     FreeCADGeom(&(coll->cadgeominfo[i]));
   }
-  FreeMemory(coll);
+  if(coll->cadgeominfo != NULL) FreeMemory(coll->cadgeominfo);
 }
 
 int NCADGeom(cadgeom_collection *coll) {

--- a/Source/shared/readcad.h
+++ b/Source/shared/readcad.h
@@ -49,7 +49,7 @@ typedef struct {
 } cadgeom_collection;
 
 /**
- * @brief Initialise an @ref cadgeom_collection.
+ * @brief Create and initialise an @ref cadgeom_collection.
  *
  * @param capacity The maximum capacity of this collection.
  *
@@ -58,8 +58,26 @@ typedef struct {
 cadgeom_collection *CreateCADGeomCollection(int capacity);
 
 /**
- * @brief Free an @ref cadgeom_collection previously created by @ref
- * CreateCADGeomCollection.
+ * @brief Initialise an already allocated cadgeom_collection. This is useful
+ * when the collection is allocated as part of a larger data structure.
+ *
+ * @param coll
+ * @param capacity
+ * @return int
+ */
+int InitCADGeomCollection(cadgeom_collection *coll, int capacity);
+
+/**
+ * @brief Clear an @ref cadgeom_collection. This does not free the data
+ * structure itself, but simply empties it.
+ *
+ * @param[inout] coll The @ref cadgeom_collection to clear.
+ */
+void ClearCADGeomCollection(cadgeom_collection *coll);
+
+/**
+ * @brief Free a @ref cadgeom_collection that was previously allocated with
+ * NewMemory or created by @ref CreateCADGeomCollection.
  *
  * @param[inout] coll The @ref cadgeom_collection to free.
  */

--- a/Source/shared/readobject.c
+++ b/Source/shared/readobject.c
@@ -1456,20 +1456,32 @@ void InitStdObjectDefs(object_collection *objectscoll, int setbw,
   }
 }
 
-object_collection *CreateObjectCollection(void){
-  object_collection *objectscoll;
-  NewMemory((void **)&objectscoll, sizeof(object_collection));
-  // Set everything to NULL
-  memset(objectscoll, 0, sizeof(object_collection));
-  strcpy(objectscoll->object_def_first.label, "first");
-  objectscoll->object_def_first.next = &objectscoll->object_def_last;
-  objectscoll->object_def_first.prev = NULL;
 
-  strcpy(objectscoll->object_def_last.label, "last");
-  objectscoll->object_def_last.next = NULL;
-  objectscoll->object_def_last.prev = &objectscoll->object_def_first;
-  objectscoll->object_defs = NULL;
-  return objectscoll;
+int InitObjectCollection(object_collection *coll) {
+  // Set everything to NULL
+  memset(coll, 0, sizeof(object_collection));
+  strcpy(coll->object_def_first.label, "first");
+  coll->object_def_first.next = &coll->object_def_last;
+  coll->object_def_first.prev = NULL;
+
+  strcpy(coll->object_def_last.label, "last");
+  coll->object_def_last.next = NULL;
+  coll->object_def_last.prev = &coll->object_def_first;
+  coll->object_defs = NULL;
+  return 0;
+}
+
+object_collection *CreateObjectCollection(void) {
+  object_collection *coll;
+  if(NEWMEMORY(coll, sizeof(object_collection)) == 0) return NULL;
+  int ret = InitObjectCollection(coll);
+  if(ret != 0) {
+    FREEMEMORY(coll);
+    return NULL;
+  }
+  else {
+    return coll;
+  }
 }
 
 void LoadDefaultObjectDefs(object_collection *objectscoll){

--- a/Source/shared/readobject.c
+++ b/Source/shared/readobject.c
@@ -1154,9 +1154,7 @@ sv_object *InitSmvObject1(object_collection *objectscoll, const char *label,
   return object;
 }
 
-/* ----------------------- FreeObjectCollection ----------------------------- */
-
-void FreeObjectCollection(object_collection *objectscoll){
+void ClearObjectCollection(object_collection *objectscoll){
   sv_object *object;
 
   for(;;){
@@ -1164,6 +1162,10 @@ void FreeObjectCollection(object_collection *objectscoll){
     if(object->prev == NULL) break;
     FreeObject(object);
   }
+}
+
+void FreeObjectCollection(object_collection *objectscoll){
+  ClearObjectCollection(objectscoll);
   FreeMemory(objectscoll);
 }
 

--- a/Source/shared/readobject.h
+++ b/Source/shared/readobject.h
@@ -358,13 +358,23 @@ object_collection *CreateObjectCollection(void);
 void ReadDefaultObjectCollection(object_collection *objectscoll,
                                  const char *fdsprefix, int setbw,
                                  int isZoneFireModel);
+
 /**
- * @brief Free an @ref object_collection previously created by @ref
- * CreateObjectCollection.
+ * @brief Clear a @ref object_collection. This does not free the data structure
+ * itself but simply empties it.
+ *
+ * @param[inout] objectscoll The @ref object_collection to clear.
+ */
+void ClearObjectCollection(object_collection *objectscoll);
+
+/**
+ * @brief Free an @ref object_collection previously allocated with NewMemory or
+ * created by @ref CreateObjectCollection.
  *
  * @param[inout] objectscoll The @ref object_collection to free.
  */
 void FreeObjectCollection(object_collection *objectscoll);
+
 /**
  * @brief Given a label, find the @ref sv_object in the given @ref
  * object_collection.
@@ -375,6 +385,7 @@ void FreeObjectCollection(object_collection *objectscoll);
  * @return A pointer to the object if found, NULL if not found.
  */
 sv_object *GetSmvObject(object_collection *objectscoll, char *label);
+
 /**
  * @brief Given a label, find the @ref sv_object in the given @ref
  * object_collection.
@@ -387,6 +398,7 @@ sv_object *GetSmvObject(object_collection *objectscoll, char *label);
  */
 sv_object *GetSmvObjectType(object_collection *objectscoll, char *olabel,
                             sv_object *default_object);
+
 /**
  * @brief Read in object definitions from an object file and add them to an
  * object collection.

--- a/Source/shared/readobject.h
+++ b/Source/shared/readobject.h
@@ -344,6 +344,15 @@ typedef struct {
 object_collection *CreateObjectCollection(void);
 
 /**
+ * @brief Initialise an already allocated object_collection. This is useful
+ * when the collection is allocated as part of a larger data structure.
+ *
+ * @param[inout] coll
+ * @return int
+ */
+int InitObjectCollection(object_collection *coll);
+
+/**
  * @brief Read objects from the standard file locations, using fallback objects
  * if object definitions are not found.
  *


### PR DESCRIPTION
This adds `Clear*` functions that allow data structures to be emptied without freeing them. This is useful when allocated as part of larger data structures.