### PR TITLE
remove pp_FED code from {c,lua}_api.h

### DIFF
--- a/Source/smokeview/c_api.h
+++ b/Source/smokeview/c_api.h
@@ -1,3 +1,5 @@
+#ifndef C_API_H_DEFINED
+#define C_API_H_DEFINED
 #include "options_common.h"
 
 #include "gd.h"
@@ -336,16 +338,9 @@ int SetWindowheight(int v);                   // WINDOWHEIGHT
 // --  *** DATA LOADING ***
 
 int SetBoundzipstep(int v); // BOUNDZIPSTEP
-#ifdef pp_FED
-int SetFed(int v);                    // FED
-int SetFedcolorbar(const char *name); // FEDCOLORBAR
-#endif
 int SetIsozipstep(int v); // ISOZIPSTEP
 int SetNopart(int v);     // NOPART
 // int set_partpointstep(int v); // PARTPOINTSTEP
-#ifdef pp_FED
-int SetShowfedarea(int v); // SHOWFEDAREA
-#endif
 int SetSliceaverage(int flag, float interval, int vis); // SLICEAVERAGE
 int SetSlicedataout(int v);                             // SLICEDATAOUT
 int SetSlicezipstep(int v);                             // SLICEZIPSTEP
@@ -595,3 +590,4 @@ int ShowSlicesHideall();
 int RenderFrameLuaVar(int view_mode, gdImagePtr *RENDERimage);
 
 #define PROPINDEX_STRIDE 2
+#endif

--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -3376,21 +3376,6 @@ int LuaSetBoundzipstep(lua_State *L) {
   return 1;
 }
 
-#ifdef pp_FED
-int LuaSetFed(lua_State *L) {
-  int v = lua_tonumber(L, 1);
-  int return_code = SetFed(v);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-
-int LuaSetFedcolorbar(lua_State *L) {
-  const char *name = lua_tostring(L, 1);
-  int return_code = SetFedcolorbar(name);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-#endif
 int LuaSetIsozipstep(lua_State *L) {
   int v = lua_tonumber(L, 1);
   int return_code = SetIsozipstep(v);
@@ -3404,15 +3389,6 @@ int LuaSetNopart(lua_State *L) {
   lua_pushnumber(L, return_code);
   return 1;
 }
-
-#ifdef pp_FED
-int LuaSetShowfedarea(lua_State *L) {
-  int v = lua_tonumber(L, 1);
-  int return_code = SetShowfedarea(v);
-  lua_pushnumber(L, return_code);
-  return 1;
-}
-#endif
 
 int LuaSetSliceaverage(lua_State *L) {
   int flag = lua_tonumber(L, 1);
@@ -5351,15 +5327,8 @@ static luaL_Reg const SMVLIB[] = {
     {"set_windowheight", LuaSetWindowheight},
 
     {"set_boundzipstep", LuaSetBoundzipstep},
-#ifdef pp_FED
-    {"set_fed", LuaSetFed},
-    {"set_fedcolorbar", LuaSetFedcolorbar},
-#endif
     {"set_isozipstep", LuaSetIsozipstep},
     {"set_nopart", LuaSetNopart},
-#ifdef pp_FED
-    {"set_showfedarea", LuaSetShowfedarea},
-#endif
     {"set_sliceaverage", LuaSetSliceaverage},
     {"set_slicedataout", LuaSetSlicedataout},
     {"set_slicezipstep", LuaSetSlicezipstep},

--- a/Source/smvq/smvq.c
+++ b/Source/smvq/smvq.c
@@ -124,14 +124,6 @@ int SetGlobalFilenames(const char *fdsprefix_arg) {
     STRCAT(ffmpeg_command_filename, ".sh");
 #endif
   }
-#ifdef pp_FED
-  if (fed_filename == NULL) {
-    STRCPY(fed_filename_base, fdsprefix);
-    STRCAT(fed_filename_base, ".fed_smv");
-    fed_filename =
-        GetFileName(smokeview_scratchdir, fed_filename_base, NOT_FORCE_IN_DIR);
-  }
-#endif
   if (stop_filename == NULL) {
     NewMemory((void **)&stop_filename,
               (unsigned int)(len_casename + strlen(".stop") + 1));


### PR DESCRIPTION
These are leftovers that weren't fully removed previously. No longer in use.