### PR TITLE
switch from separate globals to global struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if (LUA)
         add_subdirectory(Source/lfs)
     endif()
     if (VENDOR_LPEG)
-        add_subdirectory(Source/lpeg)
+        # add_subdirectory(Source/lpeg)
     endif()
 endif()
 

--- a/Source/shared/datadefs.h
+++ b/Source/shared/datadefs.h
@@ -19,12 +19,12 @@
 #define USEMESH_DRAW -1
 #define IF_NOT_USEMESH_RETURN0(loaded,blocknum)\
   if(loaded==1)return 0;\
-  if((blocknum)>=0 && meshinfo[(blocknum)].use == 0){\
+  if((blocknum)>=0 && global_scase.meshescoll.meshinfo[(blocknum)].use == 0){\
     return 0;\
    }
 #define IF_NOT_USEMESH_CONTINUE(loaded,blocknum)\
   if(loaded==1)continue;\
-  if((blocknum)>=0 && meshinfo[(blocknum)].use == 0){\
+  if((blocknum)>=0 && global_scase.meshescoll.meshinfo[(blocknum)].use == 0){\
     continue;\
    }
 
@@ -41,13 +41,13 @@
 #define REL_VAL(val, valmin, valmax) ((float)((val)-(valmin))/(float)((valmax)-(valmin)))
 #define SHIFT_VAL(val, valmin, valmax, shift_val) ((valmin) + ((valmax)-(valmin))*pow(REL_VAL((val),(valmin),(valmax)),(shift_val)))
 
-#define FDS2SMV_X(x) (((x)-xbar0)/xyzmaxdiff)
-#define FDS2SMV_Y(y) (((y)-ybar0)/xyzmaxdiff)
-#define FDS2SMV_Z(z) (((z)-zbar0)/xyzmaxdiff)
+#define FDS2SMV_X(x) (((x)-global_scase.xbar0)/xyzmaxdiff)
+#define FDS2SMV_Y(y) (((y)-global_scase.ybar0)/xyzmaxdiff)
+#define FDS2SMV_Z(z) (((z)-global_scase.zbar0)/xyzmaxdiff)
 
-#define SMV2FDS_X(x) (xbar0+(x)*xyzmaxdiff)
-#define SMV2FDS_Y(y) (ybar0+(y)*xyzmaxdiff)
-#define SMV2FDS_Z(z) (zbar0+(z)*xyzmaxdiff)
+#define SMV2FDS_X(x) (global_scase.xbar0+(x)*xyzmaxdiff)
+#define SMV2FDS_Y(y) (global_scase.ybar0+(y)*xyzmaxdiff)
+#define SMV2FDS_Z(z) (global_scase.zbar0+(z)*xyzmaxdiff)
 
 #define DONOT_SET_MINMAX_FLAG 0
 #define SET_MINMAX_FLAG       1

--- a/Source/shared/file_util.h
+++ b/Source/shared/file_util.h
@@ -104,8 +104,8 @@ typedef struct {
 
 #define FILE_EXISTS(a) FileExists(a, NULL, 0, NULL, 0)
 #define FILE_EXISTS_CASEDIR(a)                                                 \
-  FileExists(a, filelist_casename, nfilelist_casename, filelist_casedir,       \
-             nfilelist_casedir)
+  FileExists(a, global_scase.filelist_coll.filelist_casename, global_scase.filelist_coll.nfilelist_casename, global_scase.filelist_coll.filelist_casedir,       \
+             global_scase.filelist_coll.nfilelist_casedir)
 int FileExistsOrig(char *filename);
 
 #ifdef WIN32

--- a/Source/shared/readgeom.c
+++ b/Source/shared/readgeom.c
@@ -617,24 +617,24 @@ void DecimateAllTerrains(void){
     meshi = meshinfo + i;
     meshi->decimated = 0;
   }
-  for(i = 0; i < npatchinfo; i++){
+  for(i = 0; i < global_scase.npatchinfo; i++){
     meshdata *meshi;
     patchdata *patchi;
     geomlistdata *geomlisti;
     int nx, ny;
     float *boxmin, *boxmax;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->loaded == 0 || patchi->display == 0 || patchi->blocknumber < 0)
       continue;
     meshi = meshinfo + patchi->blocknumber;
     if(meshi->decimated == 1) continue;
-    if(patchi->geominfo == NULL || patchi->geominfo->display == 0 ||
-        patchi->geominfo->loaded == 0)
+    if(patchi->global_scase.geominfo == NULL || patchi->global_scase.geominfo->display == 0 ||
+        patchi->global_scase.geominfo->loaded == 0)
       continue;
 
     meshi->decimated = 1;
-    geomlisti = patchi->geominfo->geomlistinfo - 1;
+    geomlisti = patchi->global_scase.geominfo->geomlistinfo - 1;
     boxmin = meshi->boxmin;
     boxmax = meshi->boxmax;
     nx = MAX((boxmax[0] - boxmin[0]) / terrain_decimate_delta + 1, 2);

--- a/Source/smokeview/IOboundary.c
+++ b/Source/smokeview/IOboundary.c
@@ -40,7 +40,7 @@ void OutputBoundaryData(patchdata *patchi){
   meshdata *meshi;
 
   patchfile = patchi->file;
-  meshi = meshinfo + patchi->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + patchi->blocknumber;
 
   if(patchout_tmin > patchout_tmax)return;
   strcpy(csvfile, patchi->file);
@@ -194,11 +194,11 @@ void OutputBoundaryData(patchdata *patchi){
 int GetBoundaryIndex(const patchdata *patchi){
   int j;
 
-  for(j = 0; j < nboundarytypes; j++){
+  for(j = 0; j < global_scase.nboundarytypes; j++){
     patchdata *patchi2;
 
-    patchi2 = patchinfo + boundarytypes[j];
-    if(strcmp(patchi->label.shortlabel, patchi2->label.shortlabel) == 0)return boundarytypes[j];
+    patchi2 = global_scase.patchinfo + global_scase.boundarytypes[j];
+    if(strcmp(patchi->label.shortlabel, patchi2->label.shortlabel) == 0)return global_scase.boundarytypes[j];
   }
   return -1;
 }
@@ -209,11 +209,11 @@ void InitVentColors(void){
   int i;
 
   nventcolors = 0;
-  for(i = 0; i < nmeshes; i++){
+  for(i = 0; i < global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     int j;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j = 0; j<meshi->nvents; j++){
       ventdata *venti;
 
@@ -226,12 +226,12 @@ void InitVentColors(void){
   for(i = 0; i < nventcolors; i++){
     ventcolors[i] = NULL;
   }
-  ventcolors[0] = surfinfo->color;
-  for(i = 0; i < nmeshes; i++){
+  ventcolors[0] = global_scase.surfcoll.surfinfo->color;
+  for(i = 0; i < global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     int j;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j = 0; j < meshi->nvents; j++){
       ventdata *venti;
       int vent_id;
@@ -274,7 +274,7 @@ int NodeInBlockage(const meshdata *meshnode, int i, int j, int k, int *imesh, in
 
   *imesh = -1;
 
-  for(ii = 0; ii < nmeshes; ii++){
+  for(ii = 0; ii < global_scase.meshescoll.nmeshes; ii++){
     int jj;
     meshdata *meshii;
     blockagedata *bc;
@@ -286,7 +286,7 @@ int NodeInBlockage(const meshdata *meshnode, int i, int j, int k, int *imesh, in
     float zb_min, zb_max;
     float *xplt, *yplt, *zplt;
 
-    meshii = meshinfo + ii;
+    meshii = global_scase.meshescoll.meshinfo + ii;
     if(meshnode == meshii)continue;
 
     xplt = meshii->xplt;
@@ -546,7 +546,7 @@ void DrawOnlyThreshold(const meshdata *meshi){
   patch_times = meshi->patch_times;
   xyzpatch = meshi->xyzpatch_threshold;
   patchblank = meshi->patchblank;
-  patchi = patchinfo+meshi->patchfilenum;
+  patchi = global_scase.patchinfo+meshi->patchfilenum;
   switch(patchi->compression_type){
   case UNCOMPRESSED:
     assert(meshi->cpatchval_iframe!=NULL);
@@ -557,7 +557,7 @@ void DrawOnlyThreshold(const meshdata *meshi){
   default:
     assert(FFALSE);
   }
-  patchi = patchinfo+meshi->patchfilenum;
+  patchi = global_scase.patchinfo+meshi->patchfilenum;
 
   if(patch_times[0]>global_times[itimes]||patchi->display==0)return;
   if(cullfaces==1)glDisable(GL_CULL_FACE);
@@ -997,7 +997,7 @@ void GetBoundaryHeader2(char *file, patchfacedata *patchfaceinfo, int nmeshes_ar
     patchfaceinfo->mesh_index = mesh_index;
     patchfaceinfo->meshinfo = NULL;
     patchfaceinfo->obst     = NULL;
-    if(mesh_index >= 0 && mesh_index < nmeshes_arg)patchfaceinfo->meshinfo = meshinfo + mesh_index;
+    if(mesh_index >= 0 && mesh_index < nmeshes_arg)patchfaceinfo->meshinfo = global_scase.meshescoll.meshinfo + mesh_index;
     if(patchfaceinfo->meshinfo != NULL && obst_index>=0 && obst_index<patchfaceinfo->meshinfo->nbptrs)patchfaceinfo->obst = patchfaceinfo->meshinfo->blockageinfoptrs[obst_index];
   }
   fclose(stream);
@@ -1125,10 +1125,10 @@ void ComputeLoadedPatchHist(char *label, histogramdata **histptr, float *global_
   int i, have_data=0;
 
 
-  for(i = 0; i<npatchinfo; i++){
+  for(i = 0; i<global_scase.npatchinfo; i++){
     patchdata *patchi;
 
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==0||strcmp(patchi->label.shortlabel, label)!=0)continue;
     if(patchi->blocknumber>=0){
       if(patchi->patch_filetype==PATCH_STRUCTURED_NODE_CENTER||patchi->patch_filetype==PATCH_STRUCTURED_CELL_CENTER){
@@ -1149,10 +1149,10 @@ void ComputeLoadedPatchHist(char *label, histogramdata **histptr, float *global_
   *histptr = hist;
 
   InitHistogram(hist, NHIST_BUCKETS, global_min, global_max);
-  for(i = 0; i<npatchinfo; i++){
+  for(i = 0; i<global_scase.npatchinfo; i++){
     patchdata *patchi;
 
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==0||strcmp(patchi->label.shortlabel, label)!=0)continue;
     switch(patchi->patch_filetype){
       case PATCH_STRUCTURED_NODE_CENTER:
@@ -1161,7 +1161,7 @@ void ComputeLoadedPatchHist(char *label, histogramdata **histptr, float *global_
           int npatchvals;
           meshdata *meshi;
 
-          meshi = meshinfo+patchi->blocknumber;
+          meshi = global_scase.meshescoll.meshinfo+patchi->blocknumber;
           npatchvals = patchi->ntimes*meshi->npatchsize;
           MergeVals2Histogram(meshi->patchval, NULL, NULL, npatchvals, hist);
         }
@@ -1252,7 +1252,7 @@ void GetPatchSizes2(FILE_m *stream, int npatch, int nmeshes_arg, int *npatchsize
     mesh_index = ijkp[8] - 1;
     pfi->meshinfo = NULL;
     pfi->obst     = NULL;
-    if(mesh_index >= 0 && mesh_index < nmeshes_arg)pfi->meshinfo = meshinfo + ijkp[8] - 1;
+    if(mesh_index >= 0 && mesh_index < nmeshes_arg)pfi->meshinfo = global_scase.meshescoll.meshinfo + ijkp[8] - 1;
     if(pfi->meshinfo != NULL && obst_index >= 0 && obst_index < pfi->meshinfo->nbptrs)pfi->obst = pfi->meshinfo->blockageinfoptrs[obst_index];
     pfi->obst_index = obst_index;
     pfi->mesh_index = mesh_index;
@@ -1387,7 +1387,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
   FILE_SIZE return_filesize = 0;
 
   CheckMemory;
-  patchi = patchinfo + ifile;
+  patchi = global_scase.patchinfo + ifile;
   if(patchi->loaded==0&&load_flag==UNLOAD)return 0;
   if(strcmp(patchi->label.shortlabel,"wc")==0)wallcenter=1;
 
@@ -1403,12 +1403,12 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
   file = patchi->file;
   blocknumber = patchi->blocknumber;
   highlight_mesh = blocknumber;
-  meshi = meshinfo+blocknumber;
+  meshi = global_scase.meshescoll.meshinfo+blocknumber;
   UpdateCurrentMesh(meshi);
-  if(load_flag!=RELOAD&&load_flag!=UNLOAD&&meshi->patchfilenum >= 0 && meshi->patchfilenum < npatchinfo){
+  if(load_flag!=RELOAD&&load_flag!=UNLOAD&&meshi->patchfilenum >= 0 && meshi->patchfilenum < global_scase.npatchinfo){
     patchdata *patchold;
 
-    patchold = patchinfo + meshi->patchfilenum;
+    patchold = global_scase.patchinfo + meshi->patchfilenum;
     if(patchold->loaded == 1){
       int errorcode2;
 
@@ -1424,7 +1424,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
 #endif
 #endif
 
-  if(load_flag!=RELOAD&&filenum>=0&&filenum<npatchinfo){
+  if(load_flag!=RELOAD&&filenum>=0&&filenum<global_scase.npatchinfo){
     patchi->loaded=0;
   }
 
@@ -1433,7 +1433,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
 
   nbb = meshi->nbptrs;
   if(nbb==0)nbb=1;
-  updatefaces=1;
+  global_scase.updatefaces=1;
   *errorcode=0;
   if(load_flag != RELOAD){
     FREEMEMORY(meshi->xyzpatch_offset);
@@ -1458,7 +1458,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
 
   if(load_flag==UNLOAD){
     boundary_loaded = 0;
-    if(boundary_interface_unhide == 1 && have_removable_obsts == 1 && nmeshes>1){
+    if(boundary_interface_unhide == 1 && have_removable_obsts == 1 && global_scase.meshescoll.nmeshes>1){
       BlockageMenu(visBLOCKAsInput);
     }
     UpdateBoundaryType();
@@ -1481,7 +1481,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
   update_frame = 1;
 #endif
 
-  if(ifile>=0&&ifile<npatchinfo){
+  if(ifile>=0&&ifile<global_scase.npatchinfo){
     Global2GLUIBoundaryBounds(patchi->label.shortlabel);
   }
 
@@ -1544,7 +1544,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
   }
 
   if(patchi->compression_type==UNCOMPRESSED){
-    GetPatchSizes2(stream, patchi->npatches, nmeshes, &meshi->npatchsize, patchi->patchfaceinfo, &headersize, &framesize);
+    GetPatchSizes2(stream, patchi->npatches, global_scase.meshescoll.nmeshes, &meshi->npatchsize, patchi->patchfaceinfo, &headersize, &framesize);
 
     // loadpatchbysteps
     //  0 - load entire uncompressed data set
@@ -1563,7 +1563,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
     int nnsize=0;
     int i;
 
-    GetBoundaryHeader2(file, patchi->patchfaceinfo, nmeshes);
+    GetBoundaryHeader2(file, patchi->patchfaceinfo, global_scase.meshescoll.nmeshes);
     for(i=0;i<patchi->npatches;i++){
       int ii1, ii2, jj1, jj2, kk1, kk2;
       patchfacedata *pfi;
@@ -1627,7 +1627,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
     k1 = pfi->ib[4];
     k2 = pfi->ib[5];
 
-    // determine if a patch is on an external wall 
+    // determine if a patch is on an external wall
     if(i1 == i2){
       if(j1 == 0 && j2 == meshi->jbar && k1 == 0 && k2 == meshi->kbar){
         if(i1 == 0)patchi->meshfaceinfo[0]           = pfi;
@@ -2034,7 +2034,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
     return 0;
   }
   if(loadpatchbysteps==COMPRESSED_ALLFRAMES){
-    GetBoundaryDataZlib(patchi,meshi->cpatchval_zlib,ncompressed_buffer, 
+    GetBoundaryDataZlib(patchi,meshi->cpatchval_zlib,ncompressed_buffer,
       meshi->patch_times,meshi->zipoffset,meshi->zipsize,patchi->ntimes);
     framestart = 0;
     return_filesize += ncompressed_buffer;
@@ -2080,7 +2080,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
           int filesize;
           int imesh;
 
-          imesh = (int)(meshi - meshinfo);
+          imesh = (int)(meshi - global_scase.meshescoll.meshinfo);
 
           GetPatchData(imesh,stream,patchi->npatches,patchi->patchfaceinfo,
           meshi->patch_timesi,meshi->patchval_iframe,&npatchval_iframe,&filesize, &error);
@@ -2156,7 +2156,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
     }
     CheckMemory;
     if(error!=0)break;
-    if(use_tload_end!=0&&*meshi->patch_timesi>tload_end)break;
+    if(use_tload_end!=0&&*meshi->patch_timesi>global_scase.tload_end)break;
 
     switch(loadpatchbysteps){
       case UNCOMPRESSED_ALLFRAMES:
@@ -2191,7 +2191,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
   for(n=0;n<MAXRGB;n++){
     colorlabelpatch[n]=NULL;
   }
-  for(n=0;n<nrgb;n++){
+  for(n=0;n<global_scase.nrgb;n++){
     if(NewResizeMemory(colorlabelpatch[n],11)==0){
       *errorcode=1;
       if(loadpatchbysteps!=COMPRESSED_ALLFRAMES){
@@ -2238,13 +2238,13 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
     }
     GetBoundaryColors3(patchi, meshi->patchval, patchstart, npatchvals, meshi->cpatchval,
                        &glui_patchmin, &glui_patchmax,
-                       nrgb, colorlabelpatch, colorvaluespatch, boundarylevels256,
+                       global_scase.nrgb, colorlabelpatch, colorvaluespatch, boundarylevels256,
                        &patchi->extreme_min, &patchi->extreme_max, 0);
     break;
   case COMPRESSED_ALLFRAMES:
     GetBoundaryLabels(
       glui_patchmin, glui_patchmax,
-      colorlabelpatch,colorvaluespatch,boundarylevels256,nrgb);
+      colorlabelpatch,colorvaluespatch,boundarylevels256,global_scase.nrgb);
     break;
   default:
     assert(FFALSE);
@@ -2271,10 +2271,10 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
     if(loadpatchbysteps==UNCOMPRESSED_ALLFRAMES && output_patchdata==1){
       int j;
 
-      for(j=0; j<npatchinfo; j++){
+      for(j=0; j<global_scase.npatchinfo; j++){
         patchdata *patchj;
 
-        patchj = patchinfo + j;
+        patchj = global_scase.patchinfo + j;
         if(patchj->loaded == 0)continue;
         OutputBoundaryData(patchj);
       }
@@ -2334,10 +2334,10 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
       meshi->patchventcolors[i]=ventcolors[vent_index];
     }
     int mintimes = -1;
-    for(i = 0;i < npatchinfo;i++){
+    for(i = 0;i < global_scase.npatchinfo;i++){
       patchdata *pi;
 
-      pi = patchinfo + i;
+      pi = global_scase.patchinfo + i;
       if(pi->loaded == 0)continue;
       if(mintimes < 0){
         mintimes = pi->ntimes;
@@ -2346,13 +2346,13 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
         mintimes = MIN(mintimes, pi->ntimes);
       }
     }
-    for(i = 0;i < npatchinfo;i++){
+    for(i = 0;i < global_scase.npatchinfo;i++){
       patchdata *pi;
       meshdata *mi;
 
-      pi = patchinfo + i;
+      pi = global_scase.patchinfo + i;
       if(pi->loaded == 0)continue;
-      mi = meshinfo + pi->blocknumber;
+      mi = global_scase.meshescoll.meshinfo + pi->blocknumber;
       mi->maxtimes_boundary = mintimes;
     }
   }
@@ -2465,12 +2465,12 @@ FILE_SIZE ReadBoundary(int ifile, int load_flag, int *errorcode){
 
 
   SetTimeState();
-  patchi = patchinfo + ifile;
+  patchi = global_scase.patchinfo + ifile;
   if(patchi->structured == NO){
     return_filesize=ReadGeomData(patchi,NULL, load_flag,ALL_FRAMES, NULL, 1, errorcode);
   }
   else{
-    assert(ifile>=0&&ifile<npatchinfo);
+    assert(ifile>=0&&ifile<global_scase.npatchinfo);
     return_filesize=ReadBoundaryBndf(ifile,load_flag,errorcode);
   }
   return return_filesize;
@@ -2481,10 +2481,10 @@ FILE_SIZE ReadBoundary(int ifile, int load_flag, int *errorcode){
 void GLUI2GlobalBoundaryBounds(const char *key){
   int i;
 
-  for(i=0;i<npatchinfo;i++){
+  for(i=0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(strcmp(key,"")==0||strcmp(patchi->label.shortlabel,key)==0){
       patchi->valmin_glui = glui_patchmin;
       patchi->valmax_glui = glui_patchmax;
@@ -2502,10 +2502,10 @@ void GLUI2GlobalBoundaryBounds(const char *key){
 void Global2GLUIBoundaryBounds(const char *key){
   int i;
 
-  for(i=0;i<npatchinfo;i++){
+  for(i=0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(strcmp(patchi->label.shortlabel,key)==0){
       glui_patchmin = patchi->valmin_glui;
       glui_patchmax = patchi->valmax_glui;
@@ -2536,7 +2536,7 @@ int SkipPatchTriangle(int is_time_arrival, float *cb, float *parm, int *iparm){
   if(skip == 0 && cb[4*iparm[0]+3] == 0.0 && cb[4*iparm[1]+3] == 0.0 && cb[4*iparm[3]+3] == 0.0)skip = 1;
   if(skip == 0 && cb[4*iparm[0]+3] == 0.0 && cb[4*iparm[2]+3] == 0.0 && cb[4*iparm[3]+3] == 0.0)skip = 1;
   return skip;
-}            
+}
 
 /* ------------------ DrawBoundaryTexture ------------------------ */
 
@@ -2559,8 +2559,8 @@ void DrawBoundaryTexture(const meshdata *meshi){
   patch_times=meshi->patch_times;
   xyzpatch = GetPatchXYZ(meshi);
   patchblank=meshi->patchblank;
-  patchi=patchinfo+meshi->patchfilenum;
-  patchi = patchinfo + meshi->patchfilenum;
+  patchi=global_scase.patchinfo+meshi->patchfilenum;
+  patchi = global_scase.patchinfo + meshi->patchfilenum;
 
   int set_valmin, set_valmax;
   char *label;
@@ -2584,7 +2584,7 @@ void DrawBoundaryTexture(const meshdata *meshi){
   if(is_time_arrival == 1){
     float delta_z=0.0;
 
-    delta_z = (meshinfo->zplt[1] - meshinfo->zplt[0])/10.0;
+    delta_z = (global_scase.meshescoll.meshinfo->zplt[1] - global_scase.meshescoll.meshinfo->zplt[0])/10.0;
     glPushMatrix();
     glTranslatef(0.0, 0.0, delta_z);
   }
@@ -2879,7 +2879,7 @@ void DrawBoundaryTextureThreshold(const meshdata *meshi){
   patch_times=meshi->patch_times;
   xyzpatch = GetPatchXYZ(meshi);
   patchblank=meshi->patchblank;
-  patchi=patchinfo+meshi->patchfilenum;
+  patchi=global_scase.patchinfo+meshi->patchfilenum;
   switch(patchi->compression_type){
   case UNCOMPRESSED:
 #ifndef pp_BOUNDFRAME
@@ -2892,7 +2892,7 @@ void DrawBoundaryTextureThreshold(const meshdata *meshi){
   default:
     assert(FFALSE);
   }
-  patchi = patchinfo + meshi->patchfilenum;
+  patchi = global_scase.patchinfo + meshi->patchfilenum;
 
   if(patch_times[0]>global_times[itimes]||patchi->display==0)return;
 
@@ -3208,7 +3208,7 @@ void DrawBoundaryThresholdCellcenter(const meshdata *meshi){
   patch_times=meshi->patch_times;
   xyzpatch = GetPatchXYZ(meshi);
   patchblank=meshi->patchblank;
-  patchi=patchinfo+meshi->patchfilenum;
+  patchi=global_scase.patchinfo+meshi->patchfilenum;
   switch(patchi->compression_type){
   case UNCOMPRESSED:
     assert(meshi->cpatchval_iframe!=NULL);
@@ -3219,7 +3219,7 @@ void DrawBoundaryThresholdCellcenter(const meshdata *meshi){
   default:
     assert(FFALSE);
   }
-  patchi = patchinfo + meshi->patchfilenum;
+  patchi = global_scase.patchinfo + meshi->patchfilenum;
 
   if(patch_times[0]>global_times[itimes]||patchi->display==0)return;
   if(cullfaces==1)glDisable(GL_CULL_FACE);
@@ -3404,7 +3404,7 @@ void MakeBoundaryMask(patchdata *patchi){
   int n;
 
   if(patchi->blocknumber < 0)return;
-  meshi = meshinfo + patchi->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + patchi->blocknumber;
   if(meshi->boundary_mask != NULL|| meshi->npatchsize <= 0)return;
   NewMemory((void **)&meshi->boundary_mask, meshi->npatchsize);
   memset(meshi->boundary_mask, 0, meshi->npatchsize);
@@ -3448,7 +3448,7 @@ void DrawBoundaryCellCenter(const meshdata *meshi){
 
   patch_times = meshi->patch_times;
   patchventcolors = meshi->patchventcolors;
-  patchi = patchinfo+meshi->patchfilenum;
+  patchi = global_scase.patchinfo+meshi->patchfilenum;
   xyzpatch = GetPatchXYZ(meshi);
 
   label = patchi->label.shortlabel;
@@ -3470,7 +3470,7 @@ void DrawBoundaryCellCenter(const meshdata *meshi){
   default:
     assert(FFALSE);
   }
-  patchi = patchinfo+meshi->patchfilenum;
+  patchi = global_scase.patchinfo+meshi->patchfilenum;
 
   if(patch_times[0]>global_times[itimes]||patchi->display==0)return;
   if(cullfaces==1)glDisable(GL_CULL_FACE);
@@ -3765,13 +3765,13 @@ meshdata *GetPatchMeshNabor(meshdata *meshi, int *ib){
 void DrawBoundaryFrame(int flag){
   int i;
 
-  if(use_tload_begin==1 && global_times[itimes]<tload_begin)return;
-  if(use_tload_end==1   && global_times[itimes]>tload_end)return;
+  if(use_tload_begin==1 && global_times[itimes]<global_scase.tload_begin)return;
+  if(use_tload_end==1   && global_times[itimes]>global_scase.tload_end)return;
 
-  for(i=0;i<npatchinfo;i++){
+  for(i=0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     IF_NOT_USEMESH_CONTINUE(USEMESH_DRAW,patchi->blocknumber);
     if(patchi->structured == NO && patchi->loaded == 1 && patchi->display == 1){
       if(flag == DRAW_OPAQUE){
@@ -3789,14 +3789,14 @@ void DrawBoundaryFrame(int flag){
     }
   }
   if(flag == DRAW_TRANSPARENT)return;
-  for(i = 0; i < npatchinfo; i++){
+  for(i = 0; i < global_scase.npatchinfo; i++){
     patchdata *patchi;
     meshdata *meshi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     IF_NOT_USEMESH_CONTINUE(USEMESH_DRAW, patchi->blocknumber);
     if(patchi->structured == NO)continue;
-    meshi = meshinfo + patchi->blocknumber;
+    meshi = global_scase.meshescoll.meshinfo + patchi->blocknumber;
     if(meshi->use == 0)continue;
     if(patchi->loaded == 0 || patchi->display == 0 || patchi->shortlabel_index != iboundarytype)continue;
     if(patchi->npatches < 0)continue;
@@ -3827,13 +3827,13 @@ void UpdateBoundaryTypes(void){
   int i;
   patchdata *patchi;
 
-  nboundarytypes = 0;
-  for(i=0;i<npatchinfo;i++){
-    patchi = patchinfo+i;
-    if(GetBoundaryIndex(patchi)==-1)boundarytypes[nboundarytypes++]=i;
+  global_scase.nboundarytypes = 0;
+  for(i=0;i<global_scase.npatchinfo;i++){
+    patchi = global_scase.patchinfo+i;
+    if(GetBoundaryIndex(patchi)==-1)global_scase.boundarytypes[global_scase.nboundarytypes++]=i;
   }
-  for(i=0;i<npatchinfo;i++){
-    patchi = patchinfo+i;
+  for(i=0;i<global_scase.npatchinfo;i++){
+    patchi = global_scase.patchinfo+i;
     patchi->shortlabel_index =GetBoundaryType(patchi);
   }
 }
@@ -3843,10 +3843,10 @@ void UpdateBoundaryTypes(void){
 int GetBoundaryType(const patchdata *patchi){
   int j;
 
-  for(j=0;j<nboundarytypes;j++){
+  for(j=0;j<global_scase.nboundarytypes;j++){
     patchdata *patchi2;
 
-    patchi2 = patchinfo+boundarytypes[j];
+    patchi2 = global_scase.patchinfo+global_scase.boundarytypes[j];
     if(strcmp(patchi->label.shortlabel,patchi2->label.shortlabel)==0)return j;
   }
   return -1;
@@ -3857,17 +3857,17 @@ int GetBoundaryType(const patchdata *patchi){
 void UpdateBoundaryType(void){
   int i;
 
-  for(i=0;i<npatchinfo;i++){
+  for(i=0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->boundary==1&&patchi->loaded==1&&patchi->display==1&&patchi->shortlabel_index==iboundarytype)return;
   }
 
-  for(i=0;i<npatchinfo;i++){
+  for(i=0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->boundary==1&&patchi->loaded==1&&patchi->display==1){
       iboundarytype = GetBoundaryIndex(patchi);
       return;
@@ -3881,8 +3881,8 @@ void UpdateBoundaryType(void){
 int BoundaryCompare(const void *arg1, const void *arg2){
   patchdata *patchi, *patchj;
 
-  patchi = patchinfo + *(int *)arg1;
-  patchj = patchinfo + *(int *)arg2;
+  patchi = global_scase.patchinfo + *(int *)arg1;
+  patchj = global_scase.patchinfo + *(int *)arg2;
 
   if(strcmp(patchi->menulabel_base,patchj->menulabel_base)<0)return -1;
   if(strcmp(patchi->menulabel_base,patchj->menulabel_base)>0)return 1;
@@ -3900,18 +3900,18 @@ void UpdateBoundaryMenuLabels(void){
   patchdata *patchi;
   char label[128];
 
-  if(npatchinfo>0){
-    for(i=0;i<npatchinfo;i++){
-      patchi = patchinfo + i;
+  if(global_scase.npatchinfo>0){
+    for(i=0;i<global_scase.npatchinfo;i++){
+      patchi = global_scase.patchinfo + i;
       STRCPY(patchi->menulabel, "");
       STRCPY(patchi->menulabel_suffix, "");
-      if(nmeshes == 1){
+      if(global_scase.meshescoll.nmeshes == 1){
         STRCAT(patchi->menulabel, patchi->label.longlabel);
       }
       else{
         meshdata *patchmesh;
 
-        patchmesh = meshinfo + patchi->blocknumber;
+        patchmesh = global_scase.meshescoll.meshinfo + patchi->blocknumber;
         sprintf(label,"%s",patchmesh->label);
         STRCAT(patchi->menulabel,label);
       }
@@ -3953,11 +3953,11 @@ void UpdateBoundaryMenuLabels(void){
       }
     }
     FREEMEMORY(patchorderindex);
-    NewMemory((void **)&patchorderindex, sizeof(int)*npatchinfo);
-    for(i = 0;i < npatchinfo;i++){
+    NewMemory((void **)&patchorderindex, sizeof(int)*global_scase.npatchinfo);
+    for(i = 0;i < global_scase.npatchinfo;i++){
       patchorderindex[i] = i;
     }
-    qsort((int *)patchorderindex, (size_t)npatchinfo, sizeof(int), BoundaryCompare);
+    qsort((int *)patchorderindex, (size_t)global_scase.npatchinfo, sizeof(int), BoundaryCompare);
   }
 }
 
@@ -3994,17 +3994,17 @@ int IsBoundaryDuplicate(patchdata *patchi, int flag){
   if(patchi->dir == 0)return 0;
   xyzmini = patchi->xyz_min;
   xyzmaxi = patchi->xyz_max;
-  meshi = meshinfo + patchi->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + patchi->blocknumber;
   labeli = &(patchi->label);
-  for(j=0;j<npatchinfo;j++){ // identify duplicate slices
+  for(j=0;j<global_scase.npatchinfo;j++){ // identify duplicate slices
     patchdata *patchj;
     float *xyzminj, *xyzmaxj, grid_eps;
     meshdata *meshj;
     flowlabels *labelj;
 
-    patchj = patchinfo + j;
+    patchj = global_scase.patchinfo + j;
     labelj = &(patchj->label);
-    meshj = meshinfo + patchj->blocknumber;
+    meshj = global_scase.meshescoll.meshinfo + patchj->blocknumber;
 
     if(patchj==patchi||patchj->skip==1)continue;
     if(patchj->structured == YES||patchj->patch_filetype!=PATCH_GEOMETRY_SLICE)continue;
@@ -4030,10 +4030,10 @@ int CountBoundarySliceDups(void){
   int i, count;
 
   count = 0;
-  for(i = 0; i < npatchinfo; i++){
+  for(i = 0; i < global_scase.npatchinfo; i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     count += IsBoundaryDuplicate(patchi, COUNT_DUPLICATES);
   }
   return count;
@@ -4044,17 +4044,17 @@ int CountBoundarySliceDups(void){
 void UpdateBoundarySliceDups(void){
   int i;
 
-  for(i = 0;i < npatchinfo;i++){
+  for(i = 0;i < global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     patchi->skip = 0;
   }
   // look for duplicate patches
-  for(i = 0;i < npatchinfo;i++){
+  for(i = 0;i < global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->structured == YES||patchi->patch_filetype!=PATCH_GEOMETRY_SLICE)continue;
     patchi->skip = IsBoundaryDuplicate(patchi, FIND_DUPLICATES);
   }
@@ -4065,7 +4065,7 @@ void UpdateBoundarySliceDups(void){
 void GetBoundaryParams(void){
   int i;
 
-  for(i = 0;i < npatchinfo;i++){
+  for(i = 0;i < global_scase.npatchinfo;i++){
     patchdata *patchi;
     float *xyz_min, *xyz_max;
     int *ijk;
@@ -4073,7 +4073,7 @@ void GetBoundaryParams(void){
     float *xplt, *yplt, *zplt;
     float dxyz[3];
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     patchi->dir = 0;
 
     xyz_min = patchi->xyz_min;
@@ -4088,7 +4088,7 @@ void GetBoundaryParams(void){
     if(patchi->structured == YES || patchi->patch_filetype != PATCH_GEOMETRY_SLICE)continue;
 
     ijk = patchi->ijk;
-    meshi = meshinfo + patchi->blocknumber;
+    meshi = global_scase.meshescoll.meshinfo + patchi->blocknumber;
 
     xplt = meshi->xplt;
     yplt = meshi->yplt;

--- a/Source/smokeview/IOgeometry.c
+++ b/Source/smokeview/IOgeometry.c
@@ -316,10 +316,10 @@ void ClassifyGeom(geomdata *geomi, int *geom_frame_index){
 void *ClassifyAllGeom(void *arg){
   int i;
 
-  for(i = 0; i < ngeominfo; i++){
+  for(i = 0; i < global_scase.ngeominfo; i++){
     geomdata *geomi;
 
-    geomi = geominfo + i;
+    geomi = global_scase.geominfo + i;
     THREADcontrol(readallgeom_threads, THREAD_LOCK);
     if(geomi->read_status != 0){
       THREADcontrol(readallgeom_threads, THREAD_UNLOCK);
@@ -335,10 +335,10 @@ void *ClassifyAllGeom(void *arg){
     geomi->read_status = 2;
     THREADcontrol(readallgeom_threads, THREAD_UNLOCK);
   }
-  for(i = 0; i < ncgeominfo; i++){
+  for(i = 0; i < global_scase.ncgeominfo; i++){
     geomdata *geomi;
 
-    geomi = cgeominfo + i;
+    geomi = global_scase.cgeominfo + i;
     THREADcontrol(readallgeom_threads, THREAD_LOCK);
     if(geomi->read_status != 0){
       THREADcontrol(readallgeom_threads, THREAD_UNLOCK);
@@ -465,10 +465,10 @@ void UpdateGeomAreas(void){
 
     // initialize surf values
 
-    for(i = 0; i<nsurfinfo; i++){
+    for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
       surfdata *surfi;
 
-      surfi = surfinfo+i;
+      surfi = global_scase.surfcoll.surfinfo+i;
       surfi->geom_area = 0.0;
       surfi->axis[0] = 0.0;
       surfi->axis[1] = 0.0;
@@ -506,10 +506,10 @@ void UpdateGeomAreas(void){
 
     // normalize median
 
-    for(i = 0; i<nsurfinfo; i++){
+    for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
       surfdata *surfi;
 
-      surfi = surfinfo+i;
+      surfi = global_scase.surfcoll.surfinfo+i;
       if(surfi->ntris>0){
         surfi->axis[0] /= surfi->ntris;
         surfi->axis[1] /= surfi->ntris;
@@ -538,7 +538,7 @@ void DrawSelectGeom(void){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       glPointSize(20);
       color_index = 1;
       glBegin(GL_POINTS);
@@ -565,7 +565,7 @@ void DrawSelectGeom(void){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       color_index = 0;
       glBegin(GL_TRIANGLES);
       for(i = 0; i<geomlisti->ntriangles; i++){
@@ -832,7 +832,7 @@ void DrawObstBoundingBox(void){
   if(obst_bounding_box[4]>obst_bounding_box[5])return;
   glPushMatrix();
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
   DrawBoxOutline(obst_bounding_box, foregroundcolor);
   glPopMatrix();
 }
@@ -844,12 +844,12 @@ void DrawGeomBoundingBox(float *boundingbox_color){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),vertical_factor*SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
-  for(i = 0; i<ngeominfo; i++){
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
+  for(i = 0; i<global_scase.ngeominfo; i++){
     geomdata *geomi;
     int j, have_box;
 
-    geomi = geominfo + i;
+    geomi = global_scase.geominfo + i;
     if(geomi->geomtype!=GEOM_GEOM)continue;
     have_box = 0;
     for(j = 0; j<geomi->ngeomobjinfo; j++){
@@ -887,7 +887,7 @@ void DrawGeom(int flag, int timestate){
   tridata **tris;
   int texture_state = OFF, texture_first=1;
 
-  if(auto_terrain==1)return;
+  if(global_scase.auto_terrain==1)return;
   if(show_geom_boundingbox==SHOW_BOUNDING_BOX_ALWAYS||geom_bounding_box_mousedown==1){
     if(flag==DRAW_OPAQUE&&timestate==GEOM_STATIC&&have_geom_triangles==1){
       DrawGeomBoundingBox(NULL);
@@ -939,7 +939,7 @@ void DrawGeom(int flag, int timestate){
 
     glPushMatrix();
     glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),vertical_factor*SCALE2SMV(1.0));
-    glTranslatef(-xbar0,-ybar0,-zbar0);
+    glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
     glBegin(GL_TRIANGLES);
     if(have_non_textures==1){
       for(i = 0; i<ntris; i++){
@@ -1250,16 +1250,16 @@ void DrawGeom(int flag, int timestate){
     if(show_surf_axis==1){
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       glLineWidth(glui_surf_axis_width);
       glBegin(GL_LINES);
-      for(i = 0; i<nsurfinfo;  i++){
+      for(i = 0; i<global_scase.surfcoll.nsurfinfo;  i++){
         surfdata *surfi;
         float *axis;
         float x0, y0, z0;
         float x1, y1, z1;
 
-        surfi = surfinfo+i;
+        surfi = global_scase.surfcoll.surfinfo+i;
         if(surfi->ntris==0)continue;
         axis = surfi->axis;
 
@@ -1286,13 +1286,13 @@ void DrawGeom(int flag, int timestate){
         Output3Text(foregroundcolor, x0, y0, z1, "Z");
       }
       glEnd();
-      for(i = 0; i<nsurfinfo; i++){
+      for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
         surfdata *surfi;
         float *axis;
         float x0, y0, z0;
         float x1, y1, z1;
 
-        surfi = surfinfo+i;
+        surfi = global_scase.surfcoll.surfinfo+i;
         if(surfi->ntris==0)continue;
         axis = surfi->axis;
 
@@ -1318,7 +1318,7 @@ void DrawGeom(int flag, int timestate){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-      glTranslatef(-xbar0,-ybar0,-zbar0);
+      glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
       glTranslatef(0.0, 0.0, geom_dz_offset);
       if(geomi->geomtype==GEOM_ISO){
         glLineWidth(isolinewidth);
@@ -1420,7 +1420,7 @@ void DrawGeom(int flag, int timestate){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-      glTranslatef(-xbar0,-ybar0,-zbar0);
+      glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
       glTranslatef(0.0, 0.0, geom_dz_offset);
       glPointSize(geom_pointsize);
       glBegin(GL_POINTS);
@@ -1496,7 +1496,7 @@ void DrawGeom(int flag, int timestate){
     if(doit==1){  // draw faceted normals
       glPushMatrix();
       glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-      glTranslatef(-xbar0,-ybar0,-zbar0);
+      glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
       glLineWidth(geom_linewidth);
       glBegin(GL_LINES);
       glColor3fv(blue);
@@ -1574,7 +1574,7 @@ void DrawGeom(int flag, int timestate){
     if(doit==1){  // draw smooth normals
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       glLineWidth(geom_linewidth);
       glBegin(GL_LINES);
       glColor3fv(blue);
@@ -2677,7 +2677,7 @@ FILE_SIZE ReadGeomData(patchdata *patchi, slicedata *slicei, int load_flag, int 
     for(n = 0; n < MAXRGB; n++){
       colorlabelpatch[n] = NULL;
     }
-    for(n = 0; n < nrgb; n++){
+    for(n = 0; n < global_scase.nrgb; n++){
       if(NewMemory((void **)&colorlabelpatch[n], 11) == 0){
         ReadGeomData(patchi, NULL, UNLOAD, time_frame, time_value, 0, &error);
         return 0;
@@ -2694,7 +2694,7 @@ FILE_SIZE ReadGeomData(patchdata *patchi, slicedata *slicei, int load_flag, int 
     if(patchi->patch_filetype != PATCH_GEOMETRY_BOUNDARY && patchi->patch_filetype != PATCH_GEOMETRY_SLICE)convert = 0;
     GetBoundaryColors3(patchi, patchi->geom_vals, 0, patchi->geom_nvals, patchi->geom_ivals,
       &valmin, &valmax,
-      nrgb, colorlabelpatch, colorvaluespatch, boundarylevels256,
+      global_scase.nrgb, colorlabelpatch, colorvaluespatch, boundarylevels256,
       &patchi->extreme_min, &patchi->extreme_max, convert);
     if(cache_boundary_data==0){
       FREEMEMORY(patchi->geom_vals);
@@ -2756,7 +2756,7 @@ FILE_SIZE ReadGeomData(patchdata *patchi, slicedata *slicei, int load_flag, int 
     SliceBounds2Glui(slicefile_labelindex);
 
     GetSliceColors(patchi->geom_vals, patchi->geom_nvals, patchi->geom_ivals,
-      glui_slicemin, glui_slicemax, nrgb_full, nrgb,
+      glui_slicemin, glui_slicemax, nrgb_full, global_scase.nrgb,
       sb->colorlabels, sb->colorvalues, sb->levels256,
       &slicei->extreme_min, &slicei->extreme_max, 1
     );
@@ -2856,16 +2856,16 @@ FILE_SIZE ReadGeomData(patchdata *patchi, slicedata *slicei, int load_flag, int 
 void SetupReadAllGeom(void){
   int i;
 
-  for(i = 0; i<ngeominfo; i++){
+  for(i = 0; i<global_scase.ngeominfo; i++){
     geomdata *geomi;
 
-    geomi = geominfo+i;
+    geomi = global_scase.geominfo+i;
     geomi->read_status = 0;
   }
-  for(i = 0; i<ncgeominfo; i++){
+  for(i = 0; i<global_scase.ncgeominfo; i++){
     geomdata *geomi;
 
-    geomi = cgeominfo+i;
+    geomi = global_scase.cgeominfo+i;
     geomi->read_status = 0;
   }
 }
@@ -2979,10 +2979,10 @@ void UpdateGeomTriangles(geomdata *geomi, int geom_type){
 void *ReadAllGeom(void *arg){
   int i;
 
-  for(i=0;i<ngeominfo;i++){
+  for(i=0;i<global_scase.ngeominfo;i++){
     geomdata *geomi;
 
-    geomi = geominfo + i;
+    geomi = global_scase.geominfo + i;
     THREADcontrol(readallgeom_threads, THREAD_LOCK);
     if(geomi->read_status!=0){
       THREADcontrol(readallgeom_threads, THREAD_UNLOCK);
@@ -2996,10 +2996,10 @@ void *ReadAllGeom(void *arg){
     geomi->read_status = 2;
     THREADcontrol(readallgeom_threads, THREAD_UNLOCK);
   }
-  for(i = 0; i<ncgeominfo; i++){
+  for(i = 0; i<global_scase.ncgeominfo; i++){
     geomdata *geomi;
 
-    geomi = cgeominfo+i;
+    geomi = global_scase.cgeominfo+i;
     THREADcontrol(readallgeom_threads, THREAD_LOCK);
     if(geomi->read_status!=0){
       THREADcontrol(readallgeom_threads, THREAD_UNLOCK);
@@ -3022,10 +3022,10 @@ void *ReadAllGeom(void *arg){
 void UpdateAllGeomTriangles(void){
   int i;
 
-  for(i = 0; i<ngeominfo; i++){
+  for(i = 0; i<global_scase.ngeominfo; i++){
     geomdata *geomi;
 
-    geomi = geominfo+i;
+    geomi = global_scase.geominfo+i;
     UpdateGeomTriangles(geomi, GEOM_STATIC);
   }
 }
@@ -3132,8 +3132,8 @@ FILE_SIZE ReadGeom0(geomdata *geomi, int load_flag, int type, int *geom_frame_in
 
       icount++;
       if(geom_frame_index == NULL){
-        if(use_tload_begin == 1 && times_local[0]     < tload_begin)skipframe = 1;
-        if(use_tload_end   == 1 && times_local[0]     > tload_end)skipframe = 1;
+        if(use_tload_begin == 1 && times_local[0]     < global_scase.tload_begin)skipframe = 1;
+        if(use_tload_end   == 1 && times_local[0]     > global_scase.tload_end)skipframe = 1;
         if(tload_step      >  1 && icount%tload_step != 0)skipframe = 1;
         if(skipframe == 0)geomi->times[iframe] = times_local[0];
       }
@@ -3215,7 +3215,7 @@ FILE_SIZE ReadGeom0(geomdata *geomi, int load_flag, int type, int *geom_frame_in
       if(count_read != ntris)break;
       return_filesize += 4+ntris*4+4;
 
-      if(type==GEOM_ISO)offset=nsurfinfo;
+      if(type==GEOM_ISO)offset=global_scase.surfcoll.nsurfinfo;
       for(ii=0;ii<ntris;ii++){
         surfdata *surfi;
 
@@ -3223,7 +3223,7 @@ FILE_SIZE ReadGeom0(geomdata *geomi, int load_flag, int type, int *geom_frame_in
         triangles[ii].verts[1]=verts+ijk[3*ii+1]-1;
         triangles[ii].verts[2]=verts+ijk[3*ii+2]-1;
 
-        surfi = surfinfo+CLAMP(surf_ind[ii]+offset, nsurfinfo+1, nsurfinfo+MAX_ISO_COLORS);
+        surfi = global_scase.surfcoll.surfinfo+CLAMP(surf_ind[ii]+offset, global_scase.surfcoll.nsurfinfo+1, global_scase.surfcoll.nsurfinfo+MAX_ISO_COLORS);
         triangles[ii].geomsurf=surfi;
         if(geomi->file2_tris!=NULL){
           triangles[ii].geomobj = geomi->geomobjinfo + geomi->file2_tris[ii] - 1;
@@ -3244,7 +3244,7 @@ FILE_SIZE ReadGeom0(geomdata *geomi, int load_flag, int type, int *geom_frame_in
       // add decimation code here
       iframe++;
     }
-    if(geom_frame_index==NULL&&use_tload_end == 1 && times_local[0] > tload_end)break;
+    if(geom_frame_index==NULL&&use_tload_end == 1 && times_local[0] > global_scase.tload_end)break;
   }
   geomi->loaded = 1;
   geomi->display=1;
@@ -3257,11 +3257,11 @@ FILE_SIZE ReadGeom0(geomdata *geomi, int load_flag, int type, int *geom_frame_in
 int InMesh(float *xyz){
   int i;
 
-  for(i = 0;i < nmeshes;i++){
+  for(i = 0;i < global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     float *boxmin, *boxmax;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     boxmin = meshi->boxmin;
     boxmax = meshi->boxmax;
     if(xyz[0]<boxmin[0] || xyz[0]>boxmax[0])continue;
@@ -3512,7 +3512,7 @@ FILE_SIZE ReadGeom2(geomdata *geomi, int load_flag, int type){
           have_geom_factors = 1;
         }
 
-        if(terrain_textures!=NULL){
+        if(global_scase.terrain_texture_coll.terrain_textures!=NULL){
           float xfactor, yfactor;
 
           xfactor = 1.0;
@@ -3622,18 +3622,17 @@ FILE_SIZE ReadGeom2(geomdata *geomi, int load_flag, int type){
                           triangles[ii].tri_norm, NULL);
 
         CheckMemory;
-        surfi = surfinfo;
         triangles[ii].geomtype = type;
         switch(type){
         case GEOM_CGEOM:
-          surfi=surfinfo + CLAMP(surf_ind[ii],0,nsurfinfo-1);
+          surfi=global_scase.surfcoll.surfinfo + CLAMP(surf_ind[ii],0,global_scase.surfcoll.nsurfinfo-1);
           triangles[ii].insolid = locations[ii];
-          triangles[ii].geomobj = geominfo->geomobjinfo+geom_ind[ii]-1;
+          triangles[ii].geomobj = global_scase.geominfo->geomobjinfo+geom_ind[ii]-1;
           break;
         case GEOM_GEOM:
         case GEOM_ISO:
-          surfi=surfinfo + CLAMP(surf_ind[ii],0,nsurfinfo-1);
-          if(type==GEOM_ISO)surfi+=nsurfinfo;
+          surfi=global_scase.surfcoll.surfinfo + CLAMP(surf_ind[ii],0,global_scase.surfcoll.nsurfinfo-1);
+          if(type==GEOM_ISO)surfi+=global_scase.surfcoll.nsurfinfo;
           triangles[ii].insolid = surf_ind[ii];
           if(geomi->file2_tris!=NULL){
             triangles[ii].geomobj = geomi->geomobjinfo+geomi->file2_tris[ii]-1;
@@ -3649,7 +3648,7 @@ FILE_SIZE ReadGeom2(geomdata *geomi, int load_flag, int type){
           break;
         case GEOM_SLICE:
         case GEOM_BOUNDARY:
-          surfi=surfinfo;
+          surfi=global_scase.surfcoll.surfinfo;
           triangles[ii].insolid = 0;
           break;
 	    default:
@@ -3839,8 +3838,8 @@ void DrawGeomVData(vslicedata *vd){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
-      if(auto_terrain==1)glTranslatef(0.0, 0.0, SCALE2FDS(0.01));
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
+      if(global_scase.auto_terrain==1)glTranslatef(0.0, 0.0, SCALE2FDS(0.01));
 
       glLineWidth(vectorlinewidth);
       glBegin(GL_LINES);
@@ -4094,8 +4093,8 @@ void DrawGeomData(int flag, slicedata *sd, patchdata *patchi, int geom_type){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0+boundaryoffset);
-      if(auto_terrain==1)glTranslatef(0.0, 0.0, slice_dz);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0+boundaryoffset);
+      if(global_scase.auto_terrain==1)glTranslatef(0.0, 0.0, slice_dz);
       glBegin(GL_TRIANGLES);
       if((patchi->patch_filetype!=PATCH_GEOMETRY_BOUNDARY&&smooth_iso_normal == 0)
        ||patchi->patch_filetype==PATCH_GEOMETRY_BOUNDARY){
@@ -4270,7 +4269,7 @@ void DrawGeomData(int flag, slicedata *sd, patchdata *patchi, int geom_type){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       if(patchi->patch_filetype == PATCH_GEOMETRY_BOUNDARY){
         glLineWidth(geomboundary_linewidth);
       }
@@ -4418,7 +4417,7 @@ void DrawGeomData(int flag, slicedata *sd, patchdata *patchi, int geom_type){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       if(patchi->patch_filetype == PATCH_GEOMETRY_BOUNDARY){
         glPointSize(geomboundary_pointsize);
       }
@@ -4543,7 +4542,7 @@ void DrawGeomValues(slicedata *sd, patchdata *patchi, int geom_type){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       for(j = 0; j<nvals; j++){
         tridata *trianglei;
         vertdata *verti;
@@ -4653,7 +4652,7 @@ void DrawCGeom(int flag, geomdata *cgeom){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       glBegin(GL_TRIANGLES);
       for(j = 0; j<ntris; j++){
         float *color, *xyzptr[3];
@@ -4726,7 +4725,7 @@ void DrawCGeom(int flag, geomdata *cgeom){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       glTranslatef(0.0, 0.0, geom_dz_offset);
       glLineWidth(geom_linewidth);
       glBegin(GL_LINES);
@@ -4804,7 +4803,7 @@ void DrawCGeom(int flag, geomdata *cgeom){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       glLineWidth(geom_linewidth);
       glBegin(GL_LINES);
       for(j = 0; j<geomi->ncface_normals; j++){
@@ -4836,7 +4835,7 @@ void DrawCGeom(int flag, geomdata *cgeom){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       glTranslatef(0.0, 0.0, geom_dz_offset);
       glPointSize(geom_pointsize);
       glBegin(GL_POINTS);
@@ -4871,7 +4870,7 @@ void GetGeomInfoPtrs(int flag){
   if(flag==1){
     int count;
 
-    count = nisoinfo+ngeominfo;
+    count = global_scase.nisoinfo+global_scase.ngeominfo;
     if(count>0){
       NewMemory((void **)&gptr, count*sizeof(geomdata *));
     }
@@ -4883,10 +4882,10 @@ void GetGeomInfoPtrs(int flag){
 
   gptr = geominfoptrs;
   hide_geom = 0;
-  for(i = 0;i < npatchinfo;i++){
+  for(i = 0;i < global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->patch_filetype == PATCH_GEOMETRY_BOUNDARY && patchi->loaded == 1 && patchi->display == 1){
       hide_geom = 1;
       break;
@@ -4897,18 +4896,18 @@ void GetGeomInfoPtrs(int flag){
   // count size of geominfoptrs array
 
   ngeominfoptrs=0;
-  for(i=0;i<ngeominfo;i++){
+  for(i=0;i<global_scase.ngeominfo;i++){
     geomdata *geomi;
 
-    geomi = geominfo + i;
+    geomi = global_scase.geominfo + i;
     // hide geometry if we are displaying a boundary file over top of it
     if(geomi->loaded==1&&geomi->display==1&&geomi->geomtype==GEOM_GEOM&&hide_geom==0)ngeominfoptrs++;
   }
-  for(i=0;i<nisoinfo;i++){
+  for(i=0;i<global_scase.nisoinfo;i++){
     isodata *isoi;
     geomdata *geomi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     if(isoi->loaded==0||isoi->display==0)continue;
     geomi = isoi->geominfo;
     if(geomi==NULL)continue;
@@ -4918,17 +4917,17 @@ void GetGeomInfoPtrs(int flag){
 
   // put pointers into geominfoptrs array
 
-  for(i=0;i<ngeominfo;i++){
+  for(i=0;i<global_scase.ngeominfo;i++){
     geomdata *geomi;
 
-    geomi = geominfo + i;
+    geomi = global_scase.geominfo + i;
     if(geomi->loaded==1&&geomi->display==1&&geomi->geomtype==GEOM_GEOM&&hide_geom == 0)*gptr++=geomi;
   }
-  for(i=0;i<nisoinfo;i++){
+  for(i=0;i<global_scase.nisoinfo;i++){
     isodata *isoi;
     geomdata *geomi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     if(isoi->loaded==0||isoi->display==0)continue;
     geomi = isoi->geominfo;
     if(geomi==NULL||geomi->loaded==0||geomi->display==0)continue;
@@ -4961,7 +4960,7 @@ void ShowHideSortGeometry(int sort_geom, float *mm){
 
       // reject unwanted geometry
 
-      if(auto_terrain==1&&i==0)continue;
+      if(global_scase.auto_terrain==1&&i==0)continue;
       if(geomi->is_terrain==1)continue;
       have_geom_triangles = 1;
       if( (geomi->fdsblock == NOT_FDSBLOCK && geomi->geomtype!=GEOM_ISO)|| geomi->patchactive == 1)continue;
@@ -4978,8 +4977,8 @@ void ShowHideSortGeometry(int sort_geom, float *mm){
           if(geomi->currentframe != NULL)geomlisti = geomi->currentframe;
         }
         if(itime==1&&geomi->geomtype==GEOM_ISO){
-          if(use_tload_begin==1&&global_times[itimes]<tload_begin)continue;
-          if(use_tload_end==1&&global_times[itimes]>tload_end)continue;
+          if(use_tload_begin==1&&global_times[itimes]<global_scase.tload_begin)continue;
+          if(use_tload_end==1&&global_times[itimes]>global_scase.tload_end)continue;
         }
 
         for(j = 0; j < geomlisti->ntriangles; j++){
@@ -5000,7 +4999,7 @@ void ShowHideSortGeometry(int sort_geom, float *mm){
             if(tri->geomsurf!=NULL&&tri->geomsurf->transparent_level>=1.0)is_opaque = 1;
           }
           if(geom_force_transparent == 1)is_opaque = 0;
-          isurf = tri->geomsurf - surfinfo - nsurfinfo - 1;
+          isurf = tri->geomsurf - global_scase.surfcoll.surfinfo - global_scase.surfcoll.nsurfinfo - 1;
           tri->geomlisti = geomlisti;
           if((geomi->geomtype==GEOM_ISO&&showlevels != NULL&&showlevels[isurf] == 0) || tri->geomsurf->transparent_level <= 0.0){
             continue;

--- a/Source/smokeview/IOhvac.c
+++ b/Source/smokeview/IOhvac.c
@@ -29,9 +29,9 @@ void UpdateHVACDuctColorLabels(int index){
   int set_valmin, set_valmax;
   float valmin, valmax;
 
-  hi = hvaccoll.hvacductvalsinfo->duct_vars + index;
+  hi = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + index;
   GLUIGetMinMax(BOUND_HVACDUCT, hi->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
-  GetColorbarLabels(valmin, valmax, nrgb, hi->colorlabels, hi->levels256);
+  GetColorbarLabels(valmin, valmax, global_scase.nrgb, hi->colorlabels, hi->levels256);
 }
 
 /* ------------------ UpdateHVACColorNodeLabels ------------------------ */
@@ -41,9 +41,9 @@ void UpdateHVACNodeColorLabels(int index){
   int set_valmin, set_valmax;
   float valmin, valmax;
 
-  hi = hvaccoll.hvacnodevalsinfo->node_vars + index;
+  hi = global_scase.hvaccoll.hvacnodevalsinfo->node_vars + index;
   GLUIGetMinMax(BOUND_HVACNODE, hi->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
-  GetColorbarLabels(valmin, valmax, nrgb, hi->colorlabels, hi->levels256);
+  GetColorbarLabels(valmin, valmax, global_scase.nrgb, hi->colorlabels, hi->levels256);
 }
 
 /* ------------------ UpdateAllHVACColorLabels ------------------------ */
@@ -51,23 +51,23 @@ void UpdateHVACNodeColorLabels(int index){
 void UpdateAllHVACColorLabels(void){
   int i;
 
-  for(i = 0; i < hvaccoll.hvacductvalsinfo->n_duct_vars; i++){
+  for(i = 0; i < global_scase.hvaccoll.hvacductvalsinfo->n_duct_vars; i++){
     hvacvaldata *hi;
     int set_valmin, set_valmax;
     float valmin, valmax;
 
-    hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
+    hi = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + i;
     GLUIGetMinMax(BOUND_HVACDUCT, hi->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
-    GetColorbarLabels(hi->valmin, hi->valmax, nrgb, hi->colorlabels, hi->levels256);
+    GetColorbarLabels(hi->valmin, hi->valmax, global_scase.nrgb, hi->colorlabels, hi->levels256);
   }
-  for(i = 0; i < hvaccoll.hvacnodevalsinfo->n_node_vars; i++){
+  for(i = 0; i < global_scase.hvaccoll.hvacnodevalsinfo->n_node_vars; i++){
     hvacvaldata *hi;
     int set_valmin, set_valmax;
     float valmin, valmax;
 
-    hi = hvaccoll.hvacnodevalsinfo->node_vars + i;
+    hi = global_scase.hvaccoll.hvacnodevalsinfo->node_vars + i;
     GLUIGetMinMax(BOUND_HVACNODE, hi->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
-    GetColorbarLabels(valmin, valmax, nrgb, hi->colorlabels, hi->levels256);
+    GetColorbarLabels(valmin, valmax, global_scase.nrgb, hi->colorlabels, hi->levels256);
   }
 }
 
@@ -80,7 +80,7 @@ void ReadHVACData(int flag){
   if(flag == LOAD){
     START_TIMER(total_time);
   }
-  ReadHVACData0(&hvaccoll,flag, &file_size);
+  ReadHVACData0(&global_scase.hvaccoll,flag, &file_size);
   if(flag == LOAD){
     UpdateAllHVACColorLabels();
     GetGlobalHVACNodeBounds(1);
@@ -89,7 +89,7 @@ void ReadHVACData(int flag){
     GLUISetValTypeIndex(BOUND_HVACDUCT, 0);
 
     STOP_TIMER(total_time);
-    PRINTF("Loading %s", hvaccoll.hvacductvalsinfo->file);
+    PRINTF("Loading %s", global_scase.hvaccoll.hvacductvalsinfo->file);
     if(file_size > 1000000000){
       PRINTF(" - %.1f GB/%.1f s\n", (float)file_size / 1000000000., total_time);
     }
@@ -99,7 +99,7 @@ void ReadHVACData(int flag){
     else{
       PRINTF(" - %.0f KB/%.1f s\n", (float)file_size / 1000., total_time);
     }
-    hvaccoll.hvacductvalsinfo->loaded = 1;
+    global_scase.hvaccoll.hvacductvalsinfo->loaded = 1;
   }
   if(flag == BOUNDS_ONLY){
     ReadHVACData(UNLOAD);
@@ -354,42 +354,42 @@ void DrawHVAC(hvacdata *hvaci){
   unsigned char hvac_cell_color[3] = {128, 128, 128};
   float *last_color = NULL;
 
-  if((hvaccoll.hvacductvar_index >= 0||hvaccoll.hvacnodevar_index>=0)&&global_times!=NULL){
-    frame_index = GetTimeInterval(GetTime(), hvaccoll.hvacductvalsinfo->times, hvaccoll.hvacductvalsinfo->ntimes);
+  if((global_scase.hvaccoll.hvacductvar_index >= 0||global_scase.hvaccoll.hvacnodevar_index>=0)&&global_times!=NULL){
+    frame_index = GetTimeInterval(GetTime(), global_scase.hvaccoll.hvacductvalsinfo->times, global_scase.hvaccoll.hvacductvalsinfo->ntimes);
   }
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
 
   // draw ducts
 
   float valmin, valmax;
   int set_valmin, set_valmax;
   hvacvaldata *ductvar;
-  if(global_times != NULL && hvaccoll.hvacductvar_index>=0){
-    ductvar = hvaccoll.hvacductvalsinfo->duct_vars + hvaccoll.hvacductvar_index;
+  if(global_times != NULL && global_scase.hvaccoll.hvacductvar_index>=0){
+    ductvar = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + global_scase.hvaccoll.hvacductvar_index;
     GLUIGetOnlyMinMax(BOUND_HVACDUCT, ductvar->label.shortlabel, &set_valmin, &valmin, &set_valmax, &valmax);
   }
 
   glLineWidth(hvaci->duct_width);
   glBegin(GL_LINES);
-  if(hvaccoll.hvacductvar_index < 0||global_times==NULL){
+  if(global_scase.hvaccoll.hvacductvar_index < 0||global_times==NULL){
     uc_color[0] = CLAMP(hvaci->duct_color[0], 0, 255);
     uc_color[1] = CLAMP(hvaci->duct_color[1], 0, 255);
     uc_color[2] = CLAMP(hvaci->duct_color[2], 0, 255);
     glColor3ubv(uc_color);
   }
-  for(i = 0; i < hvaccoll.nhvacductinfo; i++){
+  for(i = 0; i < global_scase.hvaccoll.nhvacductinfo; i++){
     hvacductdata *ducti;
     hvacnodedata *node_from, *node_to;
 
-    ducti = hvaccoll.hvacductinfo + i;
+    ducti = global_scase.hvaccoll.hvacductinfo + i;
     if(hvac_show_networks==1&&strcmp(hvaci->network_name, ducti->network_name) != 0)continue;
     if(hvac_show_connections==1&&ducti->connect != NULL && ducti->connect->display == 0)continue;
 
-    node_from = hvaccoll.hvacnodeinfo + ducti->node_id_from;
-    node_to = hvaccoll.hvacnodeinfo + ducti->node_id_to;
+    node_from = global_scase.hvaccoll.hvacnodeinfo + ducti->node_id_from;
+    node_to = global_scase.hvaccoll.hvacnodeinfo + ducti->node_id_to;
     if(node_from == NULL || node_to == NULL)continue;
     float *xyzs;
     int nxyzs, j, *cell_index;
@@ -404,7 +404,7 @@ void DrawHVAC(hvacdata *hvaci){
       cell_index = ducti->cell_reg;
       nxyzs      = ducti->nxyz_reg_cell-1;
     }
-    if(global_times != NULL && hvaccoll.hvacductvar_index >= 0){
+    if(global_times != NULL && global_scase.hvaccoll.hvacductvar_index >= 0){
       for(j = 0;j < nxyzs;j++){
         float *xyz, *this_color;
         int cell;
@@ -442,12 +442,12 @@ void DrawHVAC(hvacdata *hvaci){
     glColor3ubv(hvac_cell_color);
     glPointSize(hvaci->cell_node_size);
     glBegin(GL_POINTS);
-    for(i = 0; i < hvaccoll.nhvacductinfo; i++){
+    for(i = 0; i < global_scase.hvaccoll.nhvacductinfo; i++){
       hvacductdata *ducti;
       float *xyzs;
       int nxyzs, j;
 
-      ducti = hvaccoll.hvacductinfo + i;
+      ducti = global_scase.hvaccoll.hvacductinfo + i;
       if(ducti->nduct_cells <= 1)continue;
 
       if(hvac_metro_view == 1){
@@ -469,20 +469,20 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac duct points");
   }
   if(hvaci->show_duct_labels == 1){
-    for(i = 0; i < hvaccoll.nhvacductinfo; i++){
+    for(i = 0; i < global_scase.hvaccoll.nhvacductinfo; i++){
       hvacductdata *ducti;
       hvacnodedata *node_from, *node_to;
       float xyz[3];
       char label[256];
       float offset;
 
-      ducti = hvaccoll.hvacductinfo + i;
+      ducti = global_scase.hvaccoll.hvacductinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, ducti->network_name) != 0)continue;
       if(hvac_show_connections == 1 && ducti->connect != NULL && ducti->connect->display == 0)continue;
 
       strcpy(label, ducti->duct_name);
-      node_from = hvaccoll.hvacnodeinfo + ducti->node_id_from;
-      node_to   = hvaccoll.hvacnodeinfo + ducti->node_id_to;
+      node_from = global_scase.hvaccoll.hvacnodeinfo + ducti->node_id_from;
+      node_to   = global_scase.hvaccoll.hvacnodeinfo + ducti->node_id_to;
       if(node_from == NULL || node_to == NULL)continue;
       if(hvac_metro_view==1){
         memcpy(xyz, ducti->xyz_label_metro, 3*sizeof(float));
@@ -496,20 +496,20 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac duct labels");
   }
   if(hvaci->show_component == DUCT_COMPONENT_TEXT){
-    for(i = 0; i < hvaccoll.nhvacductinfo; i++){
+    for(i = 0; i < global_scase.hvaccoll.nhvacductinfo; i++){
       hvacductdata *ducti;
       hvacnodedata *node_from, *node_to;
       float xyz[3];
       char label[256];
 
-      ducti = hvaccoll.hvacductinfo + i;
+      ducti = global_scase.hvaccoll.hvacductinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, ducti->network_name) != 0)continue;
       if(hvac_show_connections == 1 && ducti->connect != NULL && ducti->connect->display == 0)continue;
 
       strcpy(label, "");
       strcat(label, ducti->c_component);
-      node_from = hvaccoll.hvacnodeinfo + ducti->node_id_from;
-      node_to   = hvaccoll.hvacnodeinfo + ducti->node_id_to;
+      node_from = global_scase.hvaccoll.hvacnodeinfo + ducti->node_id_from;
+      node_to   = global_scase.hvaccoll.hvacnodeinfo + ducti->node_id_to;
       if(node_from == NULL || node_to == NULL)continue;
       if(hvac_metro_view == 1){
         memcpy(xyz, ducti->xyz_symbol_metro, 3*sizeof(float));
@@ -523,16 +523,16 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac duct component text");
   }
   if(hvaci->show_component == DUCT_COMPONENT_SYMBOLS){
-    for(i = 0; i < hvaccoll.nhvacductinfo; i++){
+    for(i = 0; i < global_scase.hvaccoll.nhvacductinfo; i++){
       hvacductdata *ducti;
       hvacnodedata *node_from, *node_to;
       float *xyz;
 
-      ducti = hvaccoll.hvacductinfo + i;
+      ducti = global_scase.hvaccoll.hvacductinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, ducti->network_name) != 0)continue;
       if(hvac_show_connections == 1 && ducti->connect != NULL && ducti->connect->display == 0)continue;
-      node_from = hvaccoll.hvacnodeinfo + ducti->node_id_from;
-      node_to   = hvaccoll.hvacnodeinfo + ducti->node_id_to;
+      node_from = global_scase.hvaccoll.hvacnodeinfo + ducti->node_id_from;
+      node_to   = global_scase.hvaccoll.hvacnodeinfo + ducti->node_id_to;
       if(node_from == NULL || node_to == NULL)continue;
       float size;
       int state;
@@ -569,27 +569,27 @@ void DrawHVAC(hvacdata *hvaci){
   // draw nodes
   glPointSize(hvaci->node_size);
   glBegin(GL_POINTS);
-  if(hvaccoll.hvacnodevar_index < 0 || global_times == NULL){
+  if(global_scase.hvaccoll.hvacnodevar_index < 0 || global_times == NULL){
     uc_color[0] = CLAMP(hvaci->node_color[0], 0, 255);
     uc_color[1] = CLAMP(hvaci->node_color[1], 0, 255);
     uc_color[2] = CLAMP(hvaci->node_color[2], 0, 255);
     glColor3ubv(uc_color);
   }
-  for(i = 0; i < hvaccoll.nhvacnodeinfo; i++){
+  for(i = 0; i < global_scase.hvaccoll.nhvacnodeinfo; i++){
     hvacnodedata *nodei;
 
-    nodei = hvaccoll.hvacnodeinfo + i;
+    nodei = global_scase.hvaccoll.hvacnodeinfo + i;
     if(hvac_show_networks == 1 && strcmp(hvaci->network_name, nodei->network_name) != 0)continue;
     if(hvac_show_connections == 1 && nodei->connect != NULL && nodei->connect->display == 0)continue;
-    if(global_times != NULL && hvaccoll.hvacnodevar_index >= 0){
+    if(global_times != NULL && global_scase.hvaccoll.hvacnodevar_index >= 0){
       hvacvaldata *nodevar;
       unsigned char ival;
 
       //        duct: i
       //        time: itime
       //   var index: hvacductvar_index
-      nodevar = hvaccoll.hvacnodevalsinfo->node_vars + hvaccoll.hvacnodevar_index;
-      ival = HVACCOLORCONV(nodevar->vals[frame_index + i * hvaccoll.hvacnodevalsinfo->ntimes], nodevar->valmin, nodevar->valmax);
+      nodevar = global_scase.hvaccoll.hvacnodevalsinfo->node_vars + global_scase.hvaccoll.hvacnodevar_index;
+      ival = HVACCOLORCONV(nodevar->vals[frame_index + i * global_scase.hvaccoll.hvacnodevalsinfo->ntimes], nodevar->valmin, nodevar->valmax);
       glColor3fv(rgb_full[ival]);
     }
     glVertex3fv(nodei->xyz);
@@ -602,12 +602,12 @@ void DrawHVAC(hvacdata *hvaci){
   uc_color[2] = CLAMP(hvaci->node_color[2], 0, 255);
   glColor3ubv(uc_color);
   if(hvaci->show_node_labels == 1){
-    for(i = 0; i < hvaccoll.nhvacnodeinfo; i++){
+    for(i = 0; i < global_scase.hvaccoll.nhvacnodeinfo; i++){
       hvacnodedata* nodei;
       char label[256];
       float offset;
 
-      nodei = hvaccoll.hvacnodeinfo + i;
+      nodei = global_scase.hvaccoll.hvacnodeinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, nodei->network_name) != 0)continue;
       if(hvac_show_connections == 1 && nodei->connect != NULL && nodei->connect->display == 0)continue;
       offset = 0.01/xyzmaxdiff;
@@ -617,12 +617,12 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac node labels");
   }
   if(hvaci->show_filters == NODE_FILTERS_LABELS){
-    for(i = 0; i < hvaccoll.nhvacnodeinfo; i++){
+    for(i = 0; i < global_scase.hvaccoll.nhvacnodeinfo; i++){
       hvacnodedata *nodei;
       char label[256];
       float offset;
 
-      nodei = hvaccoll.hvacnodeinfo + i;
+      nodei = global_scase.hvaccoll.hvacnodeinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, nodei->network_name) != 0)continue;
       if(hvac_show_connections == 1 && nodei->connect != NULL && nodei->connect->display == 0)continue;
       strcpy(label, nodei->c_filter);
@@ -632,13 +632,13 @@ void DrawHVAC(hvacdata *hvaci){
     SNIFF_ERRORS("after hvac node filter labels");
   }
   if(hvaci->show_filters == NODE_FILTERS_SYMBOLS){
-    for(i = 0; i < hvaccoll.nhvacnodeinfo; i++){
+    for(i = 0; i < global_scase.hvaccoll.nhvacnodeinfo; i++){
       hvacnodedata *nodei;
       float size;
 
       size  = xyzmaxdiff / 25.0;
       size *= hvaci->filter_size;
-      nodei = hvaccoll.hvacnodeinfo + i;
+      nodei = global_scase.hvaccoll.hvacnodeinfo + i;
       if(hvac_show_networks == 1 && strcmp(hvaci->network_name, nodei->network_name) != 0)continue;
       if(hvac_show_connections == 1 && nodei->connect != NULL && nodei->connect->display == 0)continue;
       if(nodei->filter == HVAC_FILTER_NO)continue;
@@ -654,10 +654,10 @@ void DrawHVAC(hvacdata *hvaci){
 void DrawHVACS(void){
   int i;
 
-  for(i=0; i<hvaccoll.nhvacinfo; i++){
+  for(i=0; i<global_scase.hvaccoll.nhvacinfo; i++){
     hvacdata *hvaci;
 
-    hvaci = hvaccoll.hvacinfo + i;
+    hvaci = global_scase.hvaccoll.hvacinfo + i;
     if(hvac_show_networks==1&&hvaci->display==0)continue;
     DrawHVAC(hvaci);
   }

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -50,11 +50,11 @@ void GetSmokeSensors(void){
   height = screenHeight;
 
   doit=0;
-  for(i=0;i<ndeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
     devicedata *devicei;
     char *label;
 
-    devicei = deviceinfo + i;
+    devicei = global_scase.devicecoll.deviceinfo + i;
     label = devicei->object->label;
     if(STRCMP(label,"smokesensor")!=0)continue;
     doit=1;
@@ -72,13 +72,13 @@ void GetSmokeSensors(void){
   glPixelStorei(GL_PACK_ALIGNMENT, 1);
   glReadPixels(0,0,width,height, GL_RGB, GL_UNSIGNED_BYTE, rgbimage);
 
-  for(i=0;i<ndeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
     devicedata *devicei;
     char *label;
     int row, col;
     int index,val;
 
-    devicei = deviceinfo + i;
+    devicei = global_scase.devicecoll.deviceinfo + i;
     label = devicei->object->label;
 
 
@@ -169,10 +169,10 @@ void RGBTest(void){
 int HaveSmokeSensor(void){
   int i;
 
-  for(i = 0; i<ndeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
     devicedata *devicei;
 
-    devicei = deviceinfo+i;
+    devicei = global_scase.devicecoll.deviceinfo+i;
     if(STRCMP(devicei->object->label, "smokesensor")==0)return 1;
   }
   return 0;
@@ -322,11 +322,11 @@ void GetDeviceScreenCoords(void){
   int doit;
 
   doit=0;
-  for(i=0;i<ndeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
     devicedata *devicei;
     char *label;
 
-    devicei = deviceinfo + i;
+    devicei = global_scase.devicecoll.deviceinfo + i;
     label = devicei->object->label;
     if(STRCMP(label,"smokesensor")==0){
       doit=1;
@@ -338,7 +338,7 @@ void GetDeviceScreenCoords(void){
   glGetDoublev(GL_MODELVIEW_MATRIX,mv_setup);
   glGetDoublev(GL_PROJECTION_MATRIX,projection_setup);
   glGetIntegerv(GL_VIEWPORT, viewport_setup);
-  for(i=0;i<ndeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
     float *xyz;
     double d_ijk[3];
     devicedata *devicei;
@@ -346,7 +346,7 @@ void GetDeviceScreenCoords(void){
     char *label;
     meshdata *device_mesh;
 
-    devicei = deviceinfo + i;
+    devicei = global_scase.devicecoll.deviceinfo + i;
     label = devicei->object->label;
 
     if(STRCMP(label,"smokesensor")!=0)continue;
@@ -374,12 +374,12 @@ void DrawDevicesVal(void){
   if(fontindex==SCALED_FONT)ScaleFont3D();
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
   if(active_smokesensors==1&&show_smokesensors!=SMOKESENSORS_HIDDEN){
     GetDeviceScreenCoords();
   }
-  for(i=0;i<ndeviceinfo;i++){
-    devicei = deviceinfo + i;
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
+    devicei = global_scase.devicecoll.deviceinfo + i;
 
     if(devicei->object->visible==0||devicei->show == 0)continue;
     xyz = devicei->xyz;
@@ -772,13 +772,13 @@ void DrawWindRosesDevices(void){
   int i;
 
   if(windrose_xy_vis==0&&windrose_xz_vis==0&&windrose_yz_vis==0)return;
-  for(i = 0;i<nvdeviceinfo;i++){
+  for(i = 0;i<global_scase.devicecoll.nvdeviceinfo;i++){
     vdevicedata *vdevi;
     windrosedata *wr;
     int itime;
 
 
-    vdevi = vdeviceinfo + i;
+    vdevi = global_scase.devicecoll.vdeviceinfo + i;
     if(vdevi->display==0||vdevi->unique==0)continue;
     itime = 0;
     if(global_times!=NULL)itime = CLAMP(itimes, 0, vdevi->nwindroseinfo-1);
@@ -806,20 +806,20 @@ void DrawTargetNorm(void){
   devicedata *devicei;
   float *xyz, *xyznorm;
 
-  if(isZoneFireModel==1&&hasSensorNorm==1&&visSensor==1&&visSensorNorm==1){
+  if(global_scase.isZoneFireModel==1&&hasSensorNorm==1&&visSensor==1&&visSensorNorm==1){
     glPushMatrix();
     glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
     glBegin(GL_LINES);
     glColor4fv(sensornormcolor);
 
-    for(i=0;i<ndeviceinfo;i++){
+    for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
       float xyz2[3];
 
-      devicei = deviceinfo + i;
+      devicei = global_scase.devicecoll.deviceinfo + i;
 
       if(devicei->object->visible == 0 || devicei->show == 0)continue;
       if(STRCMP(devicei->object->label,"sensor")==0&&visSensor==0)continue;
-      if(isZoneFireModel==1&&STRCMP(devicei->object->label,"target")==0&&visSensor==0)continue;
+      if(global_scase.isZoneFireModel==1&&STRCMP(devicei->object->label,"target")==0&&visSensor==0)continue;
       xyz = devicei->xyz;
       xyznorm = devicei->xyznorm;
       glVertex3fv(xyz);
@@ -1086,11 +1086,11 @@ void DrawCDisk(float diameter, float height, unsigned char *rgbcolor){
 void DrawTSphere(int texture_index,float diameter, unsigned char *rgbcolor){
   texturedata *texti;
 
-  if(texture_index<0||texture_index>ntextureinfo-1){
+  if(texture_index<0||texture_index>global_scase.texture_coll.ntextureinfo-1){
     texti=NULL;
   }
   else{
-    texti = textureinfo + texture_index;
+    texti = global_scase.texture_coll.textureinfo + texture_index;
     if(texti->loaded==0||texti->display==0)texti=NULL;
   }
   if(texti!=NULL&&object_outlines==0){
@@ -1599,7 +1599,7 @@ void DrawHalfSphere(void){
     for(i = 0; i < nlong_hsphere; i++){
       float x[4], y[4], z[4];
       int ip1;
-      
+
       ip1 = i + 1;
 
       x[0] = c_long[i]*c_lat[j];
@@ -3365,7 +3365,7 @@ float *InitSphere2(int nlat, int nlong){
   }
   c_long[nlong] = 1.0;
   s_long[nlong] = 0.0;
-  
+
   return sphere;
 }
 #endif
@@ -3378,9 +3378,9 @@ void GetGlobalDeviceBounds(int type){
 
   valmin = 1.0;
   valmax = 0.0;
-  for(i = 0; i<ndeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
     devicedata *devicei;
-    devicei = deviceinfo+i;
+    devicei = global_scase.devicecoll.deviceinfo+i;
     if(devicei->type2==type){
       int j;
       float *vals;
@@ -3398,9 +3398,9 @@ void GetGlobalDeviceBounds(int type){
       }
     }
   }
-  for(i = 0; i<ndeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
     devicedata *devicei;
-    devicei = deviceinfo+i;
+    devicei = global_scase.devicecoll.deviceinfo+i;
     if(devicei->type2==type){
       devicei->global_valmin = valmin;
       devicei->global_valmax = valmax;
@@ -3428,12 +3428,12 @@ void DrawDevices(int mode){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
-      for(i = 0; i<ndeviceinfo; i++){
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
+      for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
         devicedata *devicei;
         float *xyz1, *xyz2, dxyz[3];
 
-        devicei = deviceinfo+i;
+        devicei = global_scase.devicecoll.deviceinfo+i;
         if(devicei->object->visible == 0 || devicei->show == 0)continue;
         xyz1 = devicei->xyz1;
         xyz2 = devicei->xyz2;
@@ -3448,16 +3448,16 @@ void DrawDevices(int mode){
       }
     }
 
-    for(i = 0;i < ndeviceinfo;i++){
+    for(i = 0;i < global_scase.devicecoll.ndeviceinfo;i++){
       devicedata *devicei;
 
-      devicei = deviceinfo + i;
+      devicei = global_scase.devicecoll.deviceinfo + i;
       if(devicei->object->visible == 0 || devicei->show == 0)continue;
       if(devicei->in_zone_csv == 1)continue;
       if(devicei->plane_surface != NULL){
         int j;
 
-        for(j = 0;j < nmeshes;j++){
+        for(j = 0;j < global_scase.meshescoll.nmeshes;j++){
           DrawStaticIso(devicei->plane_surface[j], -1, 0, 2, 0, devicei->line_width);
           DrawStaticIso(devicei->plane_surface[j], 2, 0, 2, 0, devicei->line_width);
         }
@@ -3466,7 +3466,7 @@ void DrawDevices(int mode){
     }
   }
   drawobjects_as_vectors = 0;
-  if(showtime == 1 && itimes >= 0 && itimes < nglobal_times&&showvdevice_val == 1 && nvdeviceinfo>0){
+  if(showtime == 1 && itimes >= 0 && itimes < nglobal_times&&showvdevice_val == 1 && global_scase.devicecoll.nvdeviceinfo>0){
     unsigned char arrow_color[4];
     float arrow_color_float[4];
     int j;
@@ -3479,7 +3479,7 @@ void DrawDevices(int mode){
 
     glPushMatrix();
     glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-    glTranslatef(-xbar0, -ybar0, -zbar0);
+    glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
     glPointSize(vectorpointsize);
     arrow_color[0] = 255 * foregroundcolor[0];
     arrow_color[1] = 255 * foregroundcolor[1];
@@ -3501,7 +3501,7 @@ void DrawDevices(int mode){
         int velocity_type;
         vdevicesortdata *vdevsorti;
 
-        vdevsorti = vdevices_sorted + i;
+        vdevsorti = global_scase.devicecoll.vdevices_sorted + i;
         if(vectortype == VECTOR_PROFILE){
           if(vdevsorti->dir == XDIR && vis_xtree == 0)continue;
           if(vdevsorti->dir == YDIR && vis_ytree == 0)continue;
@@ -3816,8 +3816,8 @@ void DrawDevices(int mode){
   glPushMatrix();
   glPushAttrib(GL_POINT_BIT | GL_LINE_BIT);
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
-  for(ii = 0;ii < ndeviceinfo;ii++){
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
+  for(ii = 0;ii < global_scase.devicecoll.ndeviceinfo;ii++){
     devicedata *devicei;
     int tagval;
     int save_use_displaylist;
@@ -3826,15 +3826,15 @@ void DrawDevices(int mode){
     float dpsi;
     float *xyz;
 
-    devicei = deviceinfo + ii;
+    devicei = global_scase.devicecoll.deviceinfo + ii;
     prop = devicei->prop;
 
     if(devicei->object->visible == 0 || (devicei->prop != NULL&&devicei->prop->smv_object->visible == 0))continue;
     if(devicei->plane_surface != NULL)continue;
     if(devicei->show == 0)continue;
-    if(isZoneFireModel == 1 && STRCMP(devicei->object->label, "target") == 0 && visSensor == 0)continue;
+    if(global_scase.isZoneFireModel == 1 && STRCMP(devicei->object->label, "target") == 0 && visSensor == 0)continue;
     if(devicei->in_zone_csv == 1&&strcmp(devicei->deviceID,"TARGET")!=0)continue;
-    if(isZoneFireModel == 1 && STRCMP(devicei->deviceID, "TIME") == 0)continue;
+    if(global_scase.isZoneFireModel == 1 && STRCMP(devicei->deviceID, "TIME") == 0)continue;
     save_use_displaylist = devicei->object->use_displaylist;
     tagval = ii + 1;
     if(select_device == 1 && show_mode == SELECTOBJECT){
@@ -4023,15 +4023,15 @@ void DrawSmvObject(sv_object *object_dev, int iframe_local, propdata *prop, int 
     object = object_dev;
   }
   if(object->visible == 0 && vis_override == 0)return;
-  if(object == objectscoll->std_object_defs.missing_device&&show_missing_objects == 0)return;
+  if(object == global_scase.objectscoll.std_object_defs.missing_device&&show_missing_objects == 0)return;
   if(iframe_local > object->nframes - 1 || iframe_local < 0)iframe_local = 0;
   framei = object->obj_frames[iframe_local];
 
   assert(framei->error == 0 || framei->error == 1);
 
   if(framei->error == 1){
-    object = objectscoll->std_object_defs.error_device;
-    framei = objectscoll->std_object_defs.error_device->obj_frames[0];
+    object = global_scase.objectscoll.std_object_defs.error_device;
+    framei = global_scase.objectscoll.std_object_defs.error_device->obj_frames[0];
     prop = NULL;
   }
 
@@ -4259,7 +4259,7 @@ void DrawSmvObject(sv_object *object_dev, int iframe_local, propdata *prop, int 
           iframe_local2 = 0;
         }
         object_name = (toki - 1)->string;
-        included_object = GetSmvObjectType(objectscoll, object_name, objectscoll->std_object_defs.missing_device);
+        included_object = GetSmvObjectType(&global_scase.objectscoll, object_name, global_scase.objectscoll.std_object_defs.missing_device);
         toki->included_frame = iframe_local2;
         toki->included_object = included_object;
       }
@@ -4684,8 +4684,8 @@ void DrawSmvObject(sv_object *object_dev, int iframe_local, propdata *prop, int 
 
       texturefile = (toki - 2)->stringptr;
 
-      for(i = 0;i < ndevice_texture_list;i++){
-        if(strcmp(device_texture_list[i], texturefile) == 0){
+      for(i = 0;i < global_scase.device_texture_list_coll.ndevice_texture_list;i++){
+        if(strcmp(global_scase.device_texture_list_coll.device_texture_list[i], texturefile) == 0){
           textureindex = i;
           break;
         }
@@ -4813,14 +4813,14 @@ tokendata *GetTokenPtr(char *var,sv_object_frame *frame){
 devicedata *GetCSVDeviceFromLabel(char *label, int index){
   int i;
 
-  if(strlen(label)>=4&&strncmp(label, "null", 4)==0&&index>=0&&index<ndeviceinfo){
-    return deviceinfo+index;
+  if(strlen(label)>=4&&strncmp(label, "null", 4)==0&&index>=0&&index<global_scase.devicecoll.ndeviceinfo){
+    return global_scase.devicecoll.deviceinfo+index;
   }
-  for(i = 0; i<ndeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
     devicedata *devicei;
 
-    devicei = deviceinfo+i;
-    if(nzoneinfo==0){
+    devicei = global_scase.devicecoll.deviceinfo+i;
+    if(global_scase.nzoneinfo==0){
       if(STRCMP(devicei->labelptr, label)==0)return devicei;
     }
     else{
@@ -4835,10 +4835,10 @@ devicedata *GetCSVDeviceFromLabel(char *label, int index){
 int GetDeviceIndexFromLabel(char *label){
   int i;
 
-  for(i = 0;i < ndeviceinfo;i++){
+  for(i = 0;i < global_scase.devicecoll.ndeviceinfo;i++){
     devicedata *devicei;
 
-    devicei = deviceinfo + i;
+    devicei = global_scase.devicecoll.deviceinfo + i;
     if(STRCMP(devicei->deviceID, label) == 0)return i;
   }
   return -1;
@@ -4849,13 +4849,13 @@ int GetDeviceIndexFromLabel(char *label){
 devicedata *GetDeviceFromLabel(char *label,int index){
   int i;
 
-  if(strlen(label)>=4&&strncmp(label,"null",4)==0&&index>=0&&index<ndeviceinfo){
-    return deviceinfo + index;
+  if(strlen(label)>=4&&strncmp(label,"null",4)==0&&index>=0&&index<global_scase.devicecoll.ndeviceinfo){
+    return global_scase.devicecoll.deviceinfo + index;
   }
-  for(i=0;i<ndeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
     devicedata *devicei;
 
-    devicei = deviceinfo + i;
+    devicei = global_scase.devicecoll.deviceinfo + i;
     if(STRCMP(devicei->deviceID,label)==0)return devicei;
   }
   return NULL;
@@ -5013,16 +5013,16 @@ void SetupZTreeDevices(void){
     FREEMEMORY(deviceinfo_sortedz);
     nztreedeviceinfo=0;
   }
-  NewMemory((void **)&ztreedeviceinfo, ndeviceinfo*sizeof(ztreedevicedata));
-  NewMemory((void **)&deviceinfo_sortedz, ndeviceinfo*sizeof(devicedata *));
-  for(i = 0; i<ndeviceinfo; i++){
-    deviceinfo_sortedz[i] = deviceinfo+i;
+  NewMemory((void **)&ztreedeviceinfo, global_scase.devicecoll.ndeviceinfo*sizeof(ztreedevicedata));
+  NewMemory((void **)&deviceinfo_sortedz, global_scase.devicecoll.ndeviceinfo*sizeof(devicedata *));
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
+    deviceinfo_sortedz[i] = global_scase.devicecoll.deviceinfo+i;
   }
-  qsort((devicedata **)deviceinfo_sortedz, (size_t)ndeviceinfo, sizeof(devicedata *), CompareZ3Devices);
+  qsort((devicedata **)deviceinfo_sortedz, (size_t)global_scase.devicecoll.ndeviceinfo, sizeof(devicedata *), CompareZ3Devices);
 
   nztreedeviceinfo = 1;
   ztreedeviceinfo->first = 0;
-  for(i = 1; i<ndeviceinfo; i++){
+  for(i = 1; i<global_scase.devicecoll.ndeviceinfo; i++){
     if(CompareZ2Devices(deviceinfo_sortedz+i, deviceinfo_sortedz+i-1)!=0){
       ztreedevicedata *ztreei;
 
@@ -5040,9 +5040,9 @@ void SetupZTreeDevices(void){
     ztreedevicedata *ztreei;
 
     ztreei           = ztreedeviceinfo+nztreedeviceinfo-1;
-    ztreei->quantity = deviceinfo_sortedz[ndeviceinfo-1]->quantity;
-    ztreei->unit     = deviceinfo_sortedz[ndeviceinfo-1]->unit;
-    ztreei->n        = ndeviceinfo-ztreei->first;
+    ztreei->quantity = deviceinfo_sortedz[global_scase.devicecoll.ndeviceinfo-1]->quantity;
+    ztreei->unit     = deviceinfo_sortedz[global_scase.devicecoll.ndeviceinfo-1]->unit;
+    ztreei->n        = global_scase.devicecoll.ndeviceinfo-ztreei->first;
   }
   ResizeMemory((void **)&ztreedeviceinfo, nztreedeviceinfo*sizeof(ztreedevicedata));
 }
@@ -5053,7 +5053,7 @@ void SetupWindTreeDevices(void){
   int i;
   treedevicedata *treei;
 
-  if(nvdeviceinfo==0)return;
+  if(global_scase.devicecoll.nvdeviceinfo==0)return;
   if(ntreedeviceinfo>0){
     FREEMEMORY(treedeviceinfo);
     ntreedeviceinfo=0;
@@ -5064,11 +5064,11 @@ void SetupWindTreeDevices(void){
     nzwindtreeinfo = 0;
   }
 
-  qsort((vdevicedata **)vdevices_sorted,3*(size_t)nvdeviceinfo,sizeof(vdevicesortdata), CompareV3Devices);
+  qsort((vdevicedata **)global_scase.devicecoll.vdevices_sorted,3*(size_t)global_scase.devicecoll.nvdeviceinfo,sizeof(vdevicesortdata), CompareV3Devices);
 
   ntreedeviceinfo = 1;
-  for(i = 1; i < 3*nvdeviceinfo; i++){
-    if(CompareV2Devices(vdevices_sorted+i, vdevices_sorted+i-1) != 0)ntreedeviceinfo++;
+  for(i = 1; i < 3*global_scase.devicecoll.nvdeviceinfo; i++){
+    if(CompareV2Devices(global_scase.devicecoll.vdevices_sorted+i, global_scase.devicecoll.vdevices_sorted+i-1) != 0)ntreedeviceinfo++;
   }
 
   NewMemory((void **)&treedeviceinfo,ntreedeviceinfo*sizeof(treedevicedata));
@@ -5076,15 +5076,15 @@ void SetupWindTreeDevices(void){
   ntreedeviceinfo = 1;
   treei = treedeviceinfo;
   treei->first = 0;
-  for(i = 1; i < 3*nvdeviceinfo; i++){
-    if(CompareV2Devices(vdevices_sorted + i, vdevices_sorted + i - 1) != 0){
+  for(i = 1; i < 3*global_scase.devicecoll.nvdeviceinfo; i++){
+    if(CompareV2Devices(global_scase.devicecoll.vdevices_sorted + i, global_scase.devicecoll.vdevices_sorted + i - 1) != 0){
       treei->last = i-1;
       treei = treedeviceinfo + ntreedeviceinfo;
       treei->first = i;
       ntreedeviceinfo++;
     }
   }
-  treei->last = 3*nvdeviceinfo - 1;
+  treei->last = 3*global_scase.devicecoll.nvdeviceinfo - 1;
 
   max_device_tree=0;
   for(i = 0; i < ntreedeviceinfo; i++){
@@ -5096,7 +5096,7 @@ void SetupWindTreeDevices(void){
       vdevicedata *vdevi;
       vdevicesortdata *vdevsorti;
 
-      vdevsorti = vdevices_sorted + j;
+      vdevsorti = global_scase.devicecoll.vdevices_sorted + j;
       vdevi = vdevsorti->vdeviceinfo;
       if(vdevi->unique != 0)n++;
     }
@@ -5114,7 +5114,7 @@ void SetupWindTreeDevices(void){
     for(j = treei->first; j<=treei->last; j++){
       vdevicesortdata *vdevsorti;
 
-      vdevsorti = vdevices_sorted + j;
+      vdevsorti = global_scase.devicecoll.vdevices_sorted + j;
       if(vdevsorti->dir==ZDIR){
         vd = vdevsorti->vdeviceinfo;
         if(vd->unique==0)continue;
@@ -5146,7 +5146,7 @@ void SetupWindTreeDevices(void){
     for(j = treei->first; j<=treei->last; j++){
       vdevicesortdata *vdevsorti;
 
-      vdevsorti = vdevices_sorted + j;
+      vdevsorti = global_scase.devicecoll.vdevices_sorted + j;
       if(vdevsorti->dir==ZDIR){
         vd = vdevsorti->vdeviceinfo;
         if(vd->unique==0)continue;
@@ -5165,7 +5165,7 @@ void SetupZoneDevs(void){
   int i;
 
   show_missing_objects = 0;
-  for(i=0;i<nzoneinfo;i++){
+  for(i=0;i<global_scase.nzoneinfo;i++){
     FILE *stream;
     char *file;
     int nrows, ncols, buffer_len,ntokens;
@@ -5173,7 +5173,7 @@ void SetupZoneDevs(void){
     zonedata *zonei;
     int j;
 
-    zonei = zoneinfo + i;
+    zonei = global_scase.zoneinfo + i;
     if(zonei->csv!=1)continue;
     file = zonei->file;
 
@@ -5312,27 +5312,27 @@ FILE_SIZE ReadDeviceData(char *file, int filetype, int loadstatus){
 // unload data
 
   if(loadstatus==UNLOAD){
-    for(i=0;i<ndeviceinfo;i++){
+    for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
       devicedata *devicei;
 
-      devicei = deviceinfo + i;
+      devicei = global_scase.devicecoll.deviceinfo + i;
       if(devicei->filetype!=filetype)continue;
       FREEMEMORY(devicei->vals);
       FREEMEMORY(devicei->vals_orig);
       FREEMEMORY(devicei->valids);
     }
-    for(i=0;i<ndeviceinfo;i++){
+    for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
       devicedata *devicei;
       int j;
 
-      devicei = deviceinfo + i;
+      devicei = global_scase.devicecoll.deviceinfo + i;
       if(devicei->filetype!=filetype||devicei->times==NULL)continue;
       times_local = devicei->times;
       FREEMEMORY(devicei->times);
-      for(j=i+1;j<ndeviceinfo;j++){
+      for(j=i+1;j<global_scase.devicecoll.ndeviceinfo;j++){
         devicedata *devicej;
 
-        devicej = deviceinfo + j;
+        devicej = global_scase.devicecoll.deviceinfo + j;
         if(devicej->filetype!=filetype)continue;
         if(times_local==devicej->times)devicej->times=NULL;
       }
@@ -5442,11 +5442,11 @@ FILE_SIZE ReadDeviceData(char *file, int filetype, int loadstatus){
 vdevicedata *GetVDevice(float *xyzval){
   int j;
 
-  for(j=0;j<nvdeviceinfo;j++){
+  for(j=0;j<global_scase.devicecoll.nvdeviceinfo;j++){
     vdevicedata *vdevj;
     float *xyzj;
 
-    vdevj = vdeviceinfo + j;
+    vdevj = global_scase.devicecoll.vdeviceinfo + j;
 
     xyzj = vdevj->valdev->xyz;
     if(ABS(xyzval[0]-xyzj[0])>EPSDEV)continue;
@@ -5462,11 +5462,11 @@ vdevicedata *GetVDevice(float *xyzval){
 devicedata *GetDeviceFromPosition(float *xyzval, char *device_label, int device_type){
   int j;
 
-  for(j=0;j<ndeviceinfo;j++){
+  for(j=0;j<global_scase.devicecoll.ndeviceinfo;j++){
     devicedata *devj;
     float *xyz;
 
-    devj = deviceinfo + j;
+    devj = global_scase.devicecoll.deviceinfo + j;
     if(devj->filetype!=device_type)continue;
     xyz = devj->xyz;
     if(strcmp(devj->quantity,device_label)!=0)continue;
@@ -5486,16 +5486,16 @@ void UpdateColorDevices(void){
 
   colordev = devicetypes[devicetypes_index];
 
-  for(i=0;i<nvdeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.nvdeviceinfo;i++){
     vdevicedata *vdevi;
 
-    vdevi = vdeviceinfo + i;
+    vdevi = global_scase.devicecoll.vdeviceinfo + i;
     vdevi->colordev=NULL;
   }
-  for(i=0;i<ndeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
     devicedata *devi;
     vdevicedata *vdevi;
-    devi = deviceinfo + i;
+    devi = global_scase.devicecoll.deviceinfo + i;
     vdevi = devi->vdevice;
     if(vdevi==NULL)continue;
     if(strcmp(colordev->quantity,devi->quantity)==0){
@@ -5518,15 +5518,15 @@ int IsDupDeviceLabel(int index, int direction){
   }
   else{
     i1=index+1;
-    i2=ndeviceinfo;
+    i2=global_scase.devicecoll.ndeviceinfo;
   }
-  dev_index = deviceinfo + index;
-  if(index<0||index>=ndeviceinfo||STRCMP(dev_index->deviceID,"null")==0||dev_index->in_devc_csv==0)return 0;
+  dev_index = global_scase.devicecoll.deviceinfo + index;
+  if(index<0||index>=global_scase.devicecoll.ndeviceinfo||STRCMP(dev_index->deviceID,"null")==0||dev_index->in_devc_csv==0)return 0;
 
   for(i=i1;i<i2;i++){
     devicedata *devi;
 
-    devi = deviceinfo + i;
+    devi = global_scase.devicecoll.deviceinfo + i;
     if(STRCMP(devi->deviceID, "null")==0)continue;
     if(STRCMP(dev_index->deviceID,devi->deviceID)==0)return 1;
   }
@@ -5541,7 +5541,7 @@ void DeviceData2WindRose(int nr, int ntheta){
   int i;
 
   maxr_windrose = 0.0;
-  for(i = 0; i < nvdeviceinfo; i++){
+  for(i = 0; i < global_scase.devicecoll.nvdeviceinfo; i++){
     vdevicedata *vdevicei;
     windrosedata *windroseinfo;
     devicedata *udev, *vdev, *wdev;
@@ -5551,7 +5551,7 @@ void DeviceData2WindRose(int nr, int ntheta){
     int use_uvw_dev = 0, use_angle_dev=0;
     int k;
 
-    vdevicei = vdeviceinfo + i;
+    vdevicei = global_scase.devicecoll.vdeviceinfo + i;
     udev = vdevicei->udev;
     vdev = vdevicei->vdev;
     wdev = vdevicei->wdev;
@@ -5702,12 +5702,12 @@ void DeviceData2WindRose(int nr, int ntheta){
 
           xyzi = veldev->xyz;
           // find min rmin and max rmax
-          for(j = 0; j<nvdeviceinfo; j++){
+          for(j = 0; j<global_scase.devicecoll.nvdeviceinfo; j++){
             vdevicedata *vdevicej;
             devicedata *angledevj, *veldevj;
             float *xyzj, rminj, rmaxj;
 
-            vdevicej = vdeviceinfo+j;
+            vdevicej = global_scase.devicecoll.vdeviceinfo+j;
             angledevj = vdevicej->angledev;
             veldevj = vdevicej->veldev;
             if(angledevj==NULL||veldevj==NULL)continue;
@@ -5731,12 +5731,12 @@ void DeviceData2WindRose(int nr, int ntheta){
             }
           }
           // update windrose
-          for(j = 0; j<nvdeviceinfo; j++){
+          for(j = 0; j<global_scase.devicecoll.nvdeviceinfo; j++){
             vdevicedata *vdevicej;
             devicedata *angledevj, *veldevj;
             float *xyzj;
 
-            vdevicej = vdeviceinfo+j;
+            vdevicej = global_scase.devicecoll.vdeviceinfo+j;
             angledevj = vdevicej->angledev;
             veldevj = vdevicej->veldev;
             if(angledevj==NULL||veldevj==NULL)continue;
@@ -5766,23 +5766,23 @@ void SetupDeviceData(void){
   char **devcunits=NULL, **devclabels=NULL;
   int is_dup;
 
-  if(ndeviceinfo==0)return; // only setup device data once
+  if(global_scase.devicecoll.ndeviceinfo==0)return; // only setup device data once
   devices_setup = 1;
-  FREEMEMORY(vdeviceinfo);
-  NewMemory((void **)&vdeviceinfo,ndeviceinfo*sizeof(vdevicedata));
-  FREEMEMORY(vdevices_sorted);
-  NewMemory((void **)&vdevices_sorted,3*ndeviceinfo*sizeof(vdevicesortdata));
-  nvdeviceinfo=0;
-  for(i=0;i<ndeviceinfo;i++){
+  FREEMEMORY(global_scase.devicecoll.vdeviceinfo);
+  NewMemory((void **)&global_scase.devicecoll.vdeviceinfo,global_scase.devicecoll.ndeviceinfo*sizeof(vdevicedata));
+  FREEMEMORY(global_scase.devicecoll.vdevices_sorted);
+  NewMemory((void **)&global_scase.devicecoll.vdevices_sorted,3*global_scase.devicecoll.ndeviceinfo*sizeof(vdevicesortdata));
+  global_scase.devicecoll.nvdeviceinfo=0;
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
     vdevicedata *vdevi;
     devicedata *devi,*devj;
     float *xyzval;
 
-    devi = deviceinfo+i;
+    devi = global_scase.devicecoll.deviceinfo+i;
     xyzval = devi->xyz;
     devi->vdevice = NULL;
 
-    vdevi = vdeviceinfo+nvdeviceinfo;
+    vdevi = global_scase.devicecoll.vdeviceinfo+global_scase.devicecoll.nvdeviceinfo;
     vdevi->valdev = devi;
     vdevi->udev = NULL;
     vdevi->vdev = NULL;
@@ -5839,17 +5839,17 @@ void SetupDeviceData(void){
       vdevi->angledev!=NULL||vdevi->veldev!=NULL){
       vdevi->unique=1;
       vdevi->display = 1;
-      nvdeviceinfo++;
+      global_scase.devicecoll.nvdeviceinfo++;
     }
   }
 
   // look for duplicate device labels
 
   is_dup=0;
-  for(i=0;i<ndeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
     devicedata *devi;
 
-    devi = deviceinfo + i;
+    devi = global_scase.devicecoll.deviceinfo + i;
     if(STRCMP(devi->deviceID,"null")==0)continue;
     if(IsDupDeviceLabel(i,AFTER)==1){
       is_dup=1;
@@ -5860,29 +5860,29 @@ void SetupDeviceData(void){
     int ii;
 
     fprintf(stderr,"*** Warning: Duplicate device labels: ");
-    for(ii=0;ii<ndeviceinfo;ii++){
+    for(ii=0;ii<global_scase.devicecoll.ndeviceinfo;ii++){
       devicedata *devi;
 
-      devi = deviceinfo + ii;
+      devi = global_scase.devicecoll.deviceinfo + ii;
       if(STRCMP(devi->deviceID,"null")==0)continue;
       if(IsDupDeviceLabel(ii,BEFORE)==0&& IsDupDeviceLabel(ii,AFTER)==1){
         fprintf(stderr," %s,",devi->deviceID);
       }
     }
-    fprintf(stderr," found in %s\n",fds_filein);
+    fprintf(stderr," found in %s\n",global_scase.paths.fds_filein);
   }
-  for(i=0;i<nvdeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.nvdeviceinfo;i++){
     vdevicedata *vdevi;
     int j;
     float *xyzi;
 
-    vdevi = vdeviceinfo + i;
+    vdevi = global_scase.devicecoll.vdeviceinfo + i;
     xyzi = vdevi->valdev->xyz;
-    for(j=i+1;j<nvdeviceinfo;j++){
+    for(j=i+1;j<global_scase.devicecoll.nvdeviceinfo;j++){
       vdevicedata *vdevj;
       float *xyzj;
 
-      vdevj = vdeviceinfo + j;
+      vdevj = global_scase.devicecoll.vdeviceinfo + j;
       if(vdevj->unique==0)continue;
       xyzj = vdevj->valdev->xyz;
       if(ABS(xyzi[0]-xyzj[0])>EPSDEV)continue;
@@ -5892,12 +5892,12 @@ void SetupDeviceData(void){
     }
   }
   max_dev_vel=-1.0;
-  for(i=0;i<nvdeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.nvdeviceinfo;i++){
     vdevicedata *vdevi;
     devicedata *devval;
     int j;
 
-    vdevi = vdeviceinfo + i;
+    vdevi = global_scase.devicecoll.vdeviceinfo + i;
     if(vdevi->unique==0)continue;
     devval = vdevi->valdev;
     if(vdevi->udev!=NULL)vdevi->udev->vdevice=vdevi;
@@ -5939,13 +5939,13 @@ void SetupDeviceData(void){
 
   // find devices linked with each vdevice
 
-  if(ndeviceinfo>0){
-    for(i=0;i<ndeviceinfo;i++){
+  if(global_scase.devicecoll.ndeviceinfo>0){
+    for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
       devicedata *devi;
       float *xyzi;
       vdevicedata *vdevj;
 
-      devi = deviceinfo + i;
+      devi = global_scase.devicecoll.deviceinfo + i;
       if(devi->vdevice!=NULL)continue;
       xyzi = devi->xyz;
       vdevj = GetVDevice(xyzi);
@@ -5954,29 +5954,29 @@ void SetupDeviceData(void){
   }
 
   //setup devicetypes
-  if(ndeviceinfo>0){
+  if(global_scase.devicecoll.ndeviceinfo>0){
     ndevicetypes=0;
     FREEMEMORY(devicetypes);
-    NewMemory((void **)&devicetypes,ndeviceinfo*sizeof(devicedata *));
-    for(i=0;i<ndeviceinfo;i++){
+    NewMemory((void **)&devicetypes,global_scase.devicecoll.ndeviceinfo*sizeof(devicedata *));
+    for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
       devicedata *devi;
 
-      devi = deviceinfo + i;
+      devi = global_scase.devicecoll.deviceinfo + i;
       devi->type2=-1;
     }
-    for(i=0;i<ndeviceinfo;i++){
+    for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
       int j;
       devicedata *devi;
 
-      devi = deviceinfo + i;
+      devi = global_scase.devicecoll.deviceinfo + i;
       if(devi->type2>=0||devi->nvals==0||strlen(devi->quantity)==0)continue;
       devi->type2=ndevicetypes;
       devi->type2vis=0;
       devicetypes[ndevicetypes++]=devi;
-      for(j=i+1;j<ndeviceinfo;j++){
+      for(j=i+1;j<global_scase.devicecoll.ndeviceinfo;j++){
         devicedata *devj;
 
-        devj = deviceinfo + j;
+        devj = global_scase.devicecoll.deviceinfo + j;
         if(devj->type2<0&&strcmp(devi->quantity,devj->quantity)==0){
           devj->type2=devi->type2;
         }
@@ -5984,25 +5984,25 @@ void SetupDeviceData(void){
     }
     if(ndevicetypes>0)devicetypes[0]->type2vis=1;
   }
-  for(i=0;i<nvdeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.nvdeviceinfo;i++){
     vdevicesortdata *vdevsorti;
 
-    vdevsorti = vdevices_sorted + i;
-    vdevsorti->vdeviceinfo = vdeviceinfo + i;
+    vdevsorti = global_scase.devicecoll.vdevices_sorted + i;
+    vdevsorti->vdeviceinfo = global_scase.devicecoll.vdeviceinfo + i;
     vdevsorti->dir = XDIR;
 
-    vdevsorti = vdevices_sorted + nvdeviceinfo + i;
-    vdevsorti->vdeviceinfo = vdeviceinfo + i;
+    vdevsorti = global_scase.devicecoll.vdevices_sorted + global_scase.devicecoll.nvdeviceinfo + i;
+    vdevsorti->vdeviceinfo = global_scase.devicecoll.vdeviceinfo + i;
     vdevsorti->dir = YDIR;
 
-    vdevsorti = vdevices_sorted + 2*nvdeviceinfo + i;
-    vdevsorti->vdeviceinfo = vdeviceinfo + i;
+    vdevsorti = global_scase.devicecoll.vdevices_sorted + 2*global_scase.devicecoll.nvdeviceinfo + i;
+    vdevsorti->vdeviceinfo = global_scase.devicecoll.vdeviceinfo + i;
     vdevsorti->dir = ZDIR;
   }
-  for(i = 0; i<nvdeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.nvdeviceinfo; i++){
     vdevicedata *vdevicei;
 
-    vdevicei = vdeviceinfo+i;
+    vdevicei = global_scase.devicecoll.vdeviceinfo+i;
     vdevicei->nwindroseinfo = 0;
     vdevicei->windroseinfo = NULL;
   }
@@ -6031,10 +6031,10 @@ void InitializeDeviceCsvData(int flag){
   INIT_PRINT_TIMER(device_timer);
   ReadDeviceData(NULL, CSV_FDS, UNLOAD);
   ReadDeviceData(NULL, CSV_EXP, UNLOAD);
-  for(i = 0; i < ncsvfileinfo; i++){
+  for(i = 0; i < global_scase.csvcoll.ncsvfileinfo; i++){
     csvfiledata *csvi;
 
-    csvi = csvfileinfo + i;
+    csvi = global_scase.csvcoll.csvfileinfo + i;
     if(strcmp(csvi->c_type, "devc") == 0)file_size += ReadDeviceData(csvi->file, CSV_FDS, flag);
     if(strcmp(csvi->c_type, "ext") == 0)file_size += ReadDeviceData(csvi->file, CSV_EXP, flag);
   }
@@ -6063,18 +6063,18 @@ void InitializeDeviceCsvData(int flag){
 void UpdateObjectUsed(void){
   int i;
 
-  for(i = 0; i<objectscoll->nobject_defs; i++){
+  for(i = 0; i<global_scase.objectscoll.nobject_defs; i++){
     sv_object *obj_typei;
 
-    obj_typei = objectscoll->object_defs[i];
+    obj_typei = global_scase.objectscoll.object_defs[i];
     obj_typei->used_by_device = 0;
   }
-  for(i = 0; i<ndeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
     devicedata *devicei;
     propdata *propi;
     int jj;
 
-    devicei = deviceinfo+i;
+    devicei = global_scase.devicecoll.deviceinfo+i;
     propi = devicei->prop;
     if(propi==NULL)continue;
     for(jj = 0; jj<propi->nsmokeview_ids; jj++){
@@ -6089,13 +6089,13 @@ void UpdateObjectUsed(void){
     int j;
 
     partpropi = part5propinfo+i;
-    for(j = 0; j<npartclassinfo; j++){
+    for(j = 0; j<global_scase.npartclassinfo; j++){
       partclassdata *partclassj;
       propdata *propi;
       int jj;
 
       if(partpropi->class_present[j]==0)continue;
-      partclassj = partclassinfo+j;
+      partclassj = global_scase.partclassinfo+j;
       propi = partclassj->prop;
       if(propi==NULL)continue;
       for(jj = 0; jj<propi->nsmokeview_ids; jj++){
@@ -6158,7 +6158,7 @@ void InitDevicePlane(devicedata *devicei){
     devicei->color=GetColorPtr(rgbcolor);
   }
   colorindex=0;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
     meshdata *meshi;
     float xvert[12], yvert[12], zvert[12];
@@ -6170,7 +6170,7 @@ void InitDevicePlane(devicedata *devicei){
     InitIsoSurface(devicei->plane_surface[i],level,devicei->color,colorindex);
     devicei->plane_surface[i]->cullfaces=1;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
 
     xx[0]=meshi->xyz_bar0[XXX];
     xx[1]=SMV2FDS_X(meshi->xyz_bar[XXX]);
@@ -6207,7 +6207,7 @@ void InitDevicePlane(devicedata *devicei){
                      closestnodes, nvert, triangles, ntriangles);
     GetNormalSurface(devicei->plane_surface[i]);
     CompressIsoSurface(devicei->plane_surface[i],1,
-          xbar0,2*xbar,ybar0,2*ybar,zbar0,zbar);
+          global_scase.xbar0,2*global_scase.xbar,global_scase.ybar0,2*global_scase.ybar,global_scase.zbar0,global_scase.zbar);
     SmoothIsoSurface(devicei->plane_surface[i]);
   }
 
@@ -6237,4 +6237,3 @@ void Normalize(float *xyz, int n){
     }
   }
 }
-

--- a/Source/smokeview/IOpart.c
+++ b/Source/smokeview/IOpart.c
@@ -24,10 +24,10 @@
 void ClosePartFiles(void){
   int i;
 
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     if(parti->loaded==1&&parti->stream!=NULL){
       fclose_m(parti->stream);
       parti->stream = NULL;
@@ -153,7 +153,7 @@ int GetTagIndex(const partdata *partin_arg, part5data **datain_arg, int tagval_a
 
   if(flag==LOADING&&partfast==YES)return -1;
 
-  for(i = -1; i < npartinfo; i++){
+  for(i = -1; i < global_scase.npartinfo; i++){
     const partdata *parti_local;
 
     if(i == -1){
@@ -161,7 +161,7 @@ int GetTagIndex(const partdata *partin_arg, part5data **datain_arg, int tagval_a
       data_local = *datain_arg;
     }
     else{
-      parti_local = partinfo + i;
+      parti_local = global_scase.partinfo + i;
       if(parti_local== partin_arg)continue;
       if(parti_local->loaded == 0 || parti_local->display == 0)continue;
       data_local = parti_local->data5 + (*datain_arg- partin_arg->data5);
@@ -198,7 +198,7 @@ void DrawPart(const partdata *parti, int mode){
   float valmin, valmax;
 
   if(nglobal_times<1||parti->times[0] > global_times[itimes])return;
-  if(nterraininfo > 0 && ABS(vertical_factor - 1.0) > 0.01){
+  if(global_scase.nterraininfo > 0 && ABS(vertical_factor - 1.0) > 0.01){
     offset_terrain = 1;
   }
   else{
@@ -221,7 +221,7 @@ void DrawPart(const partdata *parti, int mode){
   CheckMemory;
   glPushMatrix();
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
   if(part5show == 1){
     if(streak5show == 0 || (streak5show == 1 && showstreakhead == 1)){
       for(i = 0;i < parti->nclasses;i++){
@@ -232,7 +232,7 @@ void DrawPart(const partdata *parti, int mode){
         int show_default;
 
         partclassi = parti->partclassptr[i];
-        partclass_index = partclassi - partclassinfo;
+        partclass_index = partclassi - global_scase.partclassinfo;
 
         vistype = current_property->class_present[partclass_index];
         class_vis = current_property->class_vis[partclass_index];
@@ -377,9 +377,9 @@ void DrawPart(const partdata *parti, int mode){
                 CopyDepVals(partclassi, datacopy, colorptr, prop, j);
                 glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
 
-                partfacedir[0] = xbar0 + SCALE2SMV(fds_eyepos[0]) - xpos[j];
-                partfacedir[1] = ybar0 + SCALE2SMV(fds_eyepos[1]) - ypos[j];
-                partfacedir[2] = zbar0 + SCALE2SMV(fds_eyepos[2]) - zpos[j];
+                partfacedir[0] = global_scase.xbar0 + SCALE2SMV(fds_eyepos[0]) - xpos[j];
+                partfacedir[1] = global_scase.ybar0 + SCALE2SMV(fds_eyepos[1]) - ypos[j];
+                partfacedir[2] = global_scase.zbar0 + SCALE2SMV(fds_eyepos[2]) - zpos[j];
 
                 DrawSmvObject(prop->smv_object, 0, prop, 0, NULL, 0);
                 glPopMatrix();
@@ -447,7 +447,7 @@ void DrawPart(const partdata *parti, int mode){
                 float zoffset;
                 int loc;
 
-                zoffset = GetZCellValOffset(meshinfo, xpos[j], ypos[j], &loc);
+                zoffset = GetZCellValOffset(global_scase.meshescoll.meshinfo, xpos[j], ypos[j], &loc);
                 if(vis[j] == 1)glVertex3f(xpos[j], ypos[j], zpos[j] + zoffset);
               }
             }
@@ -484,7 +484,7 @@ void DrawPart(const partdata *parti, int mode){
       int partclass_index, itype, vistype, class_vis;
 
       partclassi = parti->partclassptr[i];
-      partclass_index = partclassi - partclassinfo;
+      partclass_index = partclassi - global_scase.partclassinfo;
 
       vistype = current_property->class_present[partclass_index];
       class_vis = current_property->class_vis[partclass_index];
@@ -587,10 +587,10 @@ void DrawPartFrame(int mode){
   partdata *parti;
   int i;
 
-  if(use_tload_begin==1&&global_times[itimes]<tload_begin)return;
-  if(use_tload_end==1&&global_times[itimes]>tload_end)return;
-  for(i=0;i<npartinfo;i++){
-    parti = partinfo + i;
+  if(use_tload_begin==1&&global_times[itimes]<global_scase.tload_begin)return;
+  if(use_tload_end==1&&global_times[itimes]>global_scase.tload_end)return;
+  for(i=0;i<global_scase.npartinfo;i++){
+    parti = global_scase.partinfo + i;
     if(parti->loaded==0||parti->display==0)continue;
     IF_NOT_USEMESH_CONTINUE(USEMESH_DRAW,parti->blocknumber);
     DrawPart(parti, mode);
@@ -671,8 +671,8 @@ int ComparePart(const void *arg1, const void *arg2){
   i = *(int *)arg1;
   j = *(int *)arg2;
 
-  parti = partinfo + i;
-  partj = partinfo + j;
+  parti = global_scase.partinfo + i;
+  partj = global_scase.partinfo + j;
 
   if(parti->blocknumber<partj->blocknumber)return -1;
   if(parti->blocknumber>partj->blocknumber)return 1;
@@ -1144,11 +1144,11 @@ void MergePartHistograms(void){
   for(i=0;i<npart5prop;i++){
     InitHistogram(full_part_histogram+i, NHIST_BUCKETS, NULL, NULL);
   }
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
     int j;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     if(parti->loaded==0)continue;
     for(j = 0; j < parti->nclasses; j++){
       partclassdata *partclassi;
@@ -1174,10 +1174,10 @@ void MergePartHistograms(void){
 void GeneratePartHistograms(void){
   int i;
 
-  for(i=0;i<npartinfo;i++){
+  for(i=0;i<global_scase.npartinfo;i++){
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     if(parti->loaded==1){
       GetPartHistogramFile(parti);
     }
@@ -1212,10 +1212,10 @@ void *SortAllPartTags(void *arg){
   int i;
 
   INIT_PRINT_TIMER(timer_sortparttags);
-  for(i = 0; i < npartinfo; i++){
+  for(i = 0; i < global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     if(parti->loaded == 0)continue;
     SortPartTags(parti);
   }
@@ -1305,8 +1305,8 @@ void GetPartData(partdata *parti, int nf_all_arg, FILE_SIZE *file_size_arg){
     if(count_read!=1)goto wrapup;
 
     if((tload_step>1       && count_local%tload_step!=0)||
-       (use_tload_begin==1 && time_local<tload_begin-TEPS)||
-       (use_tload_end==1   && time_local>tload_end+TEPS)){
+       (use_tload_begin==1 && time_local<global_scase.tload_begin-TEPS)||
+       (use_tload_end==1   && time_local>global_scase.tload_end+TEPS)){
       doit_local=0;
     }
     else{
@@ -1461,9 +1461,9 @@ int GetPartPropIndex(int class_i, int class_i_j){
   partclassdata *partclassi;
   flowlabels *labels, *labelj;
 
-  assert(class_i>=0&&class_i<npartclassinfo);
-  class_i = CLAMP(class_i,0, npartclassinfo-1);
-  partclassi = partclassinfo+class_i;
+  assert(class_i>=0&&class_i<global_scase.npartclassinfo);
+  class_i = CLAMP(class_i,0, global_scase.npartclassinfo-1);
+  partclassi = global_scase.partclassinfo+class_i;
 
   labels = partclassi->labels;
   assert(class_i_j>=0&&class_i_j<partclassi->ntypes);
@@ -1516,10 +1516,10 @@ void InitPartProp(void){
 
   // 1.  count max number of distinct variables
 
-  for(i=0;i<npartclassinfo;i++){
+  for(i=0;i<global_scase.npartclassinfo;i++){
     partclassdata *partclassi;
 
-    partclassi = partclassinfo + i;
+    partclassi = global_scase.partclassinfo + i;
     npart5prop+=(partclassi->ntypes-1);  // don't include first type which is hidden
   }
 
@@ -1529,10 +1529,10 @@ void InitPartProp(void){
     NewMemory((void **)&part5propinfo,npart5prop*sizeof(partpropdata));
     npart5prop=0;
 
-    for(i=0;i<npartclassinfo;i++){
+    for(i=0;i<global_scase.npartclassinfo;i++){
       partclassdata *partclassi;
 
-      partclassi = partclassinfo + i;
+      partclassi = global_scase.partclassinfo + i;
       for(j=1;j<partclassi->ntypes;j++){ // skip over first type which is hidden
         flowlabels *flowlabel;
         int define_it;
@@ -1590,19 +1590,19 @@ void InitPartProp(void){
     propi->class_present=NULL;
     propi->class_vis=NULL;
     propi->class_types=NULL;
-    NewMemory((void **)&propi->class_types,npartclassinfo*sizeof(unsigned int));
-    NewMemory((void **)&propi->class_present,npartclassinfo*sizeof(unsigned char));
-    NewMemory((void **)&propi->class_vis,npartclassinfo*sizeof(unsigned char));
-    for(ii=0;ii<npartclassinfo;ii++){
+    NewMemory((void **)&propi->class_types,global_scase.npartclassinfo*sizeof(unsigned int));
+    NewMemory((void **)&propi->class_present,global_scase.npartclassinfo*sizeof(unsigned char));
+    NewMemory((void **)&propi->class_vis,global_scase.npartclassinfo*sizeof(unsigned char));
+    for(ii=0;ii<global_scase.npartclassinfo;ii++){
       propi->class_vis[ii]=1;
       propi->class_present[ii]=0;
       propi->class_types[ii]=0;
     }
   }
-  for(i=0;i<npartclassinfo;i++){
+  for(i=0;i<global_scase.npartclassinfo;i++){
     partclassdata *partclassi;
 
-    partclassi = partclassinfo + i;
+    partclassi = global_scase.partclassinfo + i;
     for(j=1;j<partclassi->ntypes;j++){
       flowlabels *flowlabel;
       partpropdata *classprop;
@@ -1697,11 +1697,11 @@ int GetMinPartFrames(int flag){
   int min_frames=-1;
 
   INIT_PRINT_TIMER(timer_nparts);
-  for(i=0;i<npartinfo;i++){
+  for(i=0;i<global_scase.npartinfo;i++){
     partdata *parti;
     int nframes;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     if(flag == PARTFILE_LOADALL ||
       (flag == PARTFILE_RELOADALL&&parti->loaded == 1) ||
       (flag >= 0 && i == flag)){
@@ -1934,7 +1934,7 @@ int GetPartHeader(partdata * parti, int *nf_all, int option_arg, int print_optio
     sscanf(buffer_local,"%f",&time_local);
     exitloop_local =0;
     for(i=0;i<parti->nclasses;i++){
-      if(fgets(buffer_local,255,stream)==NULL||(npartinfo>1&&npartframes_max!=-1&&nframes_all_local+1>npartframes_max)){
+      if(fgets(buffer_local,255,stream)==NULL||(global_scase.npartinfo>1&&npartframes_max!=-1&&nframes_all_local+1>npartframes_max)){
         exitloop_local =1;
         break;
       }
@@ -1942,8 +1942,8 @@ int GetPartHeader(partdata * parti, int *nf_all, int option_arg, int print_optio
     if(exitloop_local == 1)break;
     nframes_all_local++;
     if(tload_step>1       && (nframes_all_local-1)%tload_step!=0)continue;
-    if(use_tload_begin==1 && time_local<tload_begin-TEPS)continue;
-    if(use_tload_end==1   && time_local>tload_end+TEPS)break;
+    if(use_tload_begin==1 && time_local<global_scase.tload_begin-TEPS)continue;
+    if(use_tload_end==1   && time_local>global_scase.tload_end+TEPS)break;
     (parti->ntimes)++;
   }
   rewind(stream);
@@ -2003,8 +2003,8 @@ int GetPartHeader(partdata * parti, int *nf_all, int option_arg, int print_optio
       parti->filepos[count_local] = filepos_local;               // record file position for every frame
       skipit = 0;
       if(tload_step>1       && count_local%tload_step!=0)skipit = 1;
-      if(use_tload_begin==1 && time_local<tload_begin-TEPS)skipit = 1;
-      if(use_tload_end==1   && time_local>tload_end+TEPS)break;
+      if(use_tload_begin==1 && time_local<global_scase.tload_begin-TEPS)skipit = 1;
+      if(use_tload_end==1   && time_local>global_scase.tload_end+TEPS)break;
       if(skipit == 1){
         for(j=0;j<parti->nclasses;j++){
           if(fgets(buffer_local,255,stream)==NULL){
@@ -2107,7 +2107,7 @@ void UpdatePartColors(partdata *parti, int flag){
       for(n = 0; n<MAXRGB; n++){
         colorlabelpart[n] = NULL;
       }
-      for(n = 0; n<nrgb; n++){
+      for(n = 0; n<global_scase.nrgb; n++){
         NewMemory((void **)&colorlabelpart[n], 11);
       }
     }
@@ -2115,7 +2115,7 @@ void UpdatePartColors(partdata *parti, int flag){
   if(parti!=NULL){
     if(parti->loaded==1&&parti->display==1){
       if(parti->stream!=NULL){
-        GetPartColors(parti, nrgb, flag);
+        GetPartColors(parti, global_scase.nrgb, flag);
       }
       else{
         printf("***warning: particle data in %s was unloaded, colors not updated\n",parti->file);
@@ -2123,10 +2123,10 @@ void UpdatePartColors(partdata *parti, int flag){
     }
   }
   else{
-    for(j = 0; j<npartinfo; j++){
+    for(j = 0; j<global_scase.npartinfo; j++){
       partdata *partj;
 
-      partj = partinfo+j;
+      partj = global_scase.partinfo+j;
       if(partj->loaded==1&&partj->display==1){
         if(partj->stream==NULL){
           printf("***warning: particle data in one or more particle files was unloaded, colors not updated\n");
@@ -2134,12 +2134,12 @@ void UpdatePartColors(partdata *parti, int flag){
         }
       }
     }
-    for(j = 0; j<npartinfo; j++){
+    for(j = 0; j<global_scase.npartinfo; j++){
       partdata *partj;
 
-      partj = partinfo+j;
+      partj = global_scase.partinfo+j;
       if(partj->loaded==1&&partj->display==1){
-        GetPartColors(partj, nrgb, flag);
+        GetPartColors(partj, global_scase.nrgb, flag);
       }
     }
   }
@@ -2150,10 +2150,10 @@ void UpdatePartColors(partdata *parti, int flag){
 void FinalizePartLoad(partdata *parti){
   int j;
 
-  for(j = 0; j<npartinfo; j++){
+  for(j = 0; j<global_scase.npartinfo; j++){
     partdata *partj;
 
-    partj = partinfo+j;
+    partj = global_scase.partinfo+j;
     if(partj->request_load==1){
       MakeTimesMap(partj->times, &partj->times_map, partj->ntimes);
       partj->request_load = 0;
@@ -2175,10 +2175,10 @@ void FinalizePartLoad(partdata *parti){
   PRINT_TIMER(part_time1, "particle get bounds time");
   if(cache_part_data==1){
     INIT_PRINT_TIMER(part_time2);
-    for(j = 0; j<npartinfo; j++){
+    for(j = 0; j<global_scase.npartinfo; j++){
       partdata *partj;
 
-      partj = partinfo+j;
+      partj = global_scase.partinfo+j;
       if(partj->loaded==1){
         UpdatePartColors(partj, 0);
       }
@@ -2215,8 +2215,8 @@ FILE_SIZE ReadPart(char *file_arg, int ifile_arg, int load_flag, int *errorcode_
   START_TIMER(total_time);
 #endif
   START_TIMER(load_time_local);
-  assert(ifile_arg>=0&&ifile_arg<npartinfo);
-  parti=partinfo+ifile_arg;
+  assert(ifile_arg>=0&&ifile_arg<global_scase.npartinfo);
+  parti=global_scase.partinfo+ifile_arg;
 
 #ifdef pp_PARTFRAME
   FreeAllPart5Data(parti, load_flag);
@@ -2308,7 +2308,7 @@ FILE_SIZE ReadPart(char *file_arg, int ifile_arg, int load_flag, int *errorcode_
 
   parti->request_load = 1;
   if(use_partload_threads==1){
-    if(npartinfo>1){
+    if(global_scase.npartinfo>1){
       THREADcontrol(partload_threads, THREAD_LOCK);
       PrintPartLoadSummary(PART_AFTER, PART_LOADING);
       THREADcontrol(partload_threads, THREAD_UNLOCK);
@@ -2351,29 +2351,29 @@ void UpdatePartMenuLabels(void){
   char label[128];
   int lenlabel;
 
-  if(npartinfo>0){
+  if(global_scase.npartinfo>0){
     FREEMEMORY(partorderindex);
-    NewMemory((void **)&partorderindex,sizeof(int)*npartinfo);
-    for(i=0;i<npartinfo;i++){
+    NewMemory((void **)&partorderindex,sizeof(int)*global_scase.npartinfo);
+    for(i=0;i<global_scase.npartinfo;i++){
       partorderindex[i]=i;
     }
-    qsort( (int *)partorderindex, (size_t)npartinfo, sizeof(int), ComparePart);
+    qsort( (int *)partorderindex, (size_t)global_scase.npartinfo, sizeof(int), ComparePart);
 
-    for(i=0;i<npartinfo;i++){
-      parti = partinfo + i;
+    for(i=0;i<global_scase.npartinfo;i++){
+      parti = global_scase.partinfo + i;
       STRCPY(parti->menulabel,"");
       STRCAT(parti->menulabel, "particles");
       lenlabel=strlen(parti->menulabel);
-      if(nmeshes>1){
+      if(global_scase.meshescoll.nmeshes>1){
         meshdata *partmesh;
 
-        partmesh = meshinfo + parti->blocknumber;
+        partmesh = global_scase.meshescoll.meshinfo + parti->blocknumber;
         sprintf(label,"%s",partmesh->label);
         if(lenlabel>0)STRCAT(parti->menulabel,", ");
         STRCAT(parti->menulabel,label);
       }
       if(showfiles==1||lenlabel==0){
-        if(nmeshes>1||lenlabel>0)STRCAT(parti->menulabel,", ");
+        if(global_scase.meshescoll.nmeshes>1||lenlabel>0)STRCAT(parti->menulabel,", ");
         STRCAT(parti->menulabel,parti->file);
       }
     }

--- a/Source/smokeview/IOplot2d.c
+++ b/Source/smokeview/IOplot2d.c
@@ -15,7 +15,7 @@ csvdata *GetCsvData(int file_index, int col_index, csvfiledata **csvf_ptr){
   csvfiledata *csvfi;
   csvdata *csvi=NULL;
 
-  csvfi = csvfileinfo    + file_index;
+  csvfi = global_scase.csvcoll.csvfileinfo    + file_index;
   if(csvfi->csvinfo!=NULL)csvi  = csvfi->csvinfo + col_index;
   if(csvf_ptr != NULL)*csvf_ptr = csvfi;
   return csvi;
@@ -96,21 +96,21 @@ void DrawGenCurve(int option, plot2ddata *plot2di, curvedata *curve, float size_
     if(use_tload_begin==1||use_tload_end==1){
       if(use_tload_begin==1){
         for(i=0;i<n;i++){
-          if(tload_begin<x[i]){
+          if(global_scase.tload_begin<x[i]){
             itbeg = i;
             break;
           }
         }
-        xmin = tload_begin;
+        xmin = global_scase.tload_begin;
       }
       if(use_tload_end==1){
         for(i=n-1;i>=0;i--){
-          if(x[i]<tload_end){
+          if(x[i]<global_scase.tload_end){
             itend = i;
             break;
           }
         }
-        xmax = tload_end;
+        xmax = global_scase.tload_end;
       }
     }
     if(xmax==xmin)xmax = xmin+1.0;
@@ -372,11 +372,11 @@ void UpdateCurveBounds(plot2ddata *plot2di, int option){
       strcpy(curve->scaled_unit,  "");
     }
   }
-  for(i = 0; i<ncsvfileinfo; i++){
+  for(i = 0; i<global_scase.csvcoll.ncsvfileinfo; i++){
     int j;
     csvfiledata *csvfi;
 
-    csvfi = csvfileinfo+i;
+    csvfi = global_scase.csvcoll.csvfileinfo+i;
     if(csvfi->defined != CSV_DEFINED)continue;
     for(j = 0; j<csvfi->ncsvinfo; j++){
       csvdata *csvi;
@@ -631,18 +631,18 @@ void DrawGenPlots(void){
 void SetupPlot2DUnitData(void){
 
   //setup deviceunits
-  if(ndeviceinfo > 0){
+  if(global_scase.devicecoll.ndeviceinfo > 0){
     int i;
 
     ndeviceunits = 0;
     FREEMEMORY(deviceunits);
-    NewMemory((void **)&deviceunits, ndeviceinfo * sizeof(devicedata *));
-    for(i = 0; i < ndeviceinfo; i++){
+    NewMemory((void **)&deviceunits, global_scase.devicecoll.ndeviceinfo * sizeof(devicedata *));
+    for(i = 0; i < global_scase.devicecoll.ndeviceinfo; i++){
       int j;
       devicedata *devi;
       int skip_dev;
 
-      devi = deviceinfo + i;
+      devi = global_scase.devicecoll.deviceinfo + i;
       if(devi->nvals == 0 || strlen(devi->quantity) == 0 || strlen(devi->unit) == 0)continue;
       skip_dev = 0;
       for(j = 0; j < ndeviceunits; j++){
@@ -659,18 +659,18 @@ void SetupPlot2DUnitData(void){
     }
   }
   //setup hrrunits
-  if(nhrrinfo > 0){
+  if(global_scase.hrr_coll.nhrrinfo > 0){
     int i;
 
     nhrrunits = 0;
     FREEMEMORY(hrrunits);
-    NewMemory((void **)&hrrunits, nhrrinfo * sizeof(hrrdata *));
-    for(i = 0; i < nhrrinfo; i++){
+    NewMemory((void **)&hrrunits, global_scase.hrr_coll.nhrrinfo * sizeof(hrrdata *));
+    for(i = 0; i < global_scase.hrr_coll.nhrrinfo; i++){
       int j;
       hrrdata *hrri;
       int skip_hrr;
 
-      hrri = hrrinfo + i;
+      hrri = global_scase.hrr_coll.hrrinfo + i;
       if(hrri->nvals == 0 || strlen(hrri->label.shortlabel) == 0 || strlen(hrri->label.unit) == 0)continue;
       if(STRCMP(hrri->label.shortlabel, "Time") == 0)continue;
       skip_hrr = 0;
@@ -750,7 +750,7 @@ void GetPlot2DBounds(plot2ddata *plot2di, float *valmin, float *valmax){
 /* ------------------ InitPlot2D ------------------------ */
 
 void InitPlot2D(plot2ddata *plot2di, int plot_index){
-  if(ndeviceinfo == 0 && nhrrinfo == 0)return;
+  if(global_scase.devicecoll.ndeviceinfo == 0 && global_scase.hrr_coll.nhrrinfo == 0)return;
   plot2di->ncurves = 0;
   plot2di->ncurves_ini = 0;
   plot2di->show = 1;
@@ -976,10 +976,10 @@ void DrawDevicePlots(void){
   int i;
 
   if(vis_device_plot!=DEVICE_PLOT_HIDDEN){
-    for(i = 0; i<ndeviceinfo; i++){
+    for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
       devicedata *devicei;
 
-      devicei = deviceinfo+i;
+      devicei = global_scase.devicecoll.deviceinfo+i;
       if(vis_device_plot==DEVICE_PLOT_SHOW_SELECTED&&devicei->selected==0)continue;
       if(devicei->times==NULL||devicei->vals==NULL)continue;
       if(devicei->update_avg==1){

--- a/Source/smokeview/IOplot3d.c
+++ b/Source/smokeview/IOplot3d.c
@@ -46,7 +46,7 @@ void GetPlot3DHists(plot3ddata *p){
     p->histograms[i] = histi;
     InitHistogramMemID(histi, NHIST_BUCKETS, NULL, NULL, p->memory_id);
 
-    plot3d_mesh = meshinfo+p->blocknumber;
+    plot3d_mesh = global_scase.meshescoll.meshinfo+p->blocknumber;
     nvals = (plot3d_mesh->ibar+1)*(plot3d_mesh->jbar+1)*(plot3d_mesh->kbar+1);
     vals = plot3d_mesh->qdata+i*nvals;
     int use_bounds = 0;
@@ -72,11 +72,11 @@ void MergePlot3DHistograms(void){
       InitHistogram(full_plot3D_histograms+i, NHIST_BUCKETS, NULL, NULL);
     }
   }
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
     int k;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->loaded==0)continue;
     for(k = 0; k<plot3di->nplot3dvars; k++){
       MergeHistogram(full_plot3D_histograms+k, plot3di->histograms[k], MERGE_BOUNDS);
@@ -89,8 +89,8 @@ void MergePlot3DHistograms(void){
 int Plot3dCompare(const void *arg1, const void *arg2){
   plot3ddata *plot3di, *plot3dj;
 
-  plot3di = plot3dinfo + *(int *)arg1;
-  plot3dj = plot3dinfo + *(int *)arg2;
+  plot3di = global_scase.plot3dinfo + *(int *)arg1;
+  plot3dj = global_scase.plot3dinfo + *(int *)arg2;
 
   if(strcmp(plot3di->longlabel,plot3dj->longlabel)<0)return -1;
   if(strcmp(plot3di->longlabel,plot3dj->longlabel)>0)return 1;
@@ -107,7 +107,7 @@ int AllocatePlot3DColorLabels(plot3ddata *plot3di){
   int nn, error;
   int ifile;
 
-  ifile = plot3di-plot3dinfo;
+  ifile = plot3di-global_scase.plot3dinfo;
   for(nn = 0; nn<numplot3dvars; nn++){
     int n;
 
@@ -117,7 +117,7 @@ int AllocatePlot3DColorLabels(plot3ddata *plot3di){
     }
 
     if(p3levels[nn]==NULL){
-      if(NewMemoryMemID((void **)&p3levels[nn], (nrgb+1)*sizeof(float), plot3di->memory_id)==0){
+      if(NewMemoryMemID((void **)&p3levels[nn], (global_scase.nrgb+1)*sizeof(float), plot3di->memory_id)==0){
         ReadPlot3D("", ifile, UNLOAD, &error);
         if(error==1)return 1;
       }
@@ -128,7 +128,7 @@ int AllocatePlot3DColorLabels(plot3ddata *plot3di){
         if(error==1)return 1;
       }
     }
-    for(n = 0; n<nrgb; n++){
+    for(n = 0; n<global_scase.nrgb; n++){
       if(colorlabelp3[nn][n]==NULL){
         if(NewMemoryMemID((void **)&(*(colorlabelp3+nn))[n], 11, plot3di->memory_id)==0){
           ReadPlot3D("", ifile, UNLOAD, &error);
@@ -157,7 +157,7 @@ void  UpdatePlot3DColors(plot3ddata *plot3di, int flag, int *errorcode){
   *errorcode=AllocatePlot3DColorLabels(plot3di);
   if(*errorcode==1)return;
   for(nn = 0; nn < numplot3dvars; nn++){
-    if(nplot3dinfo > 0){
+    if(global_scase.nplot3dinfo > 0){
       shortp3label[nn] = plot3di->label[nn].shortlabel;
       unitp3label[nn] = plot3di->label[nn].unit;
     }
@@ -169,7 +169,7 @@ void  UpdatePlot3DColors(plot3ddata *plot3di, int flag, int *errorcode){
       unitp3label[nn] = blank_global;
     }
     GetPlot3DColors(nn, p3min_all + nn, p3max_all + nn,
-                    nrgb_full, nrgb - 1, colorlabelp3[nn], colorlabeliso[nn], p3levels[nn], p3levels256[nn],
+                    nrgb_full, global_scase.nrgb - 1, colorlabelp3[nn], colorlabeliso[nn], p3levels[nn], p3levels256[nn],
                     plot3di->extreme_min + nn, plot3di->extreme_max + nn, flag);
   }
 }
@@ -182,7 +182,7 @@ int GetPlot3DBounds(plot3ddata *plot3di){
   meshdata *meshi;
   int i, ntotal;
 
-  meshi = meshinfo+plot3di->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo+plot3di->blocknumber;
   if(meshi->qdata==NULL)return 0;
   ntotal = (meshi->ibar+1)*(meshi->jbar+1)*(meshi->kbar+1);
   iblank = meshi->c_iblank_node;
@@ -215,13 +215,13 @@ void ComputeLoadedPlot3DBounds(float *valmin_loaded, float *valmax_loaded){
   int i, first;
 
   plot3d_uvw_max = 1.0;
-  for(first = 1, i = 0; i < nplot3dinfo; i++){
+  for(first = 1, i = 0; i < global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
     meshdata *meshi;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     if(plot3di->loaded == 0)continue;
-    meshi = meshinfo + plot3di->blocknumber;
+    meshi = global_scase.meshescoll.meshinfo + plot3di->blocknumber;
     plot3d_uvw_max = MAX(plot3d_uvw_max, meshi->plot3d_uvw_max);
     if(first == 1){
       first = 0;
@@ -248,10 +248,10 @@ void UpdatePlot3DFileLoad(void){
   int i;
 
   nplot3dloaded = 0;
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->loaded==1)nplot3dloaded++;
   }
 }
@@ -275,18 +275,18 @@ FILE_SIZE ReadPlot3D(char *file, int ifile, int flag, int *errorcode){
   START_TIMER(total_time);
   *errorcode=0;
 
-  assert(ifile>=0&&ifile<nplot3dinfo);
-  p=plot3dinfo+ifile;
+  assert(ifile>=0&&ifile<global_scase.nplot3dinfo);
+  p=global_scase.plot3dinfo+ifile;
   if(flag==UNLOAD&&p->loaded==0)return 0;
 
   highlight_mesh=p->blocknumber;
-  meshi=meshinfo+highlight_mesh;
+  meshi=global_scase.meshescoll.meshinfo+highlight_mesh;
   UpdateCurrentMesh(meshi);
 
   if(meshi->plot3dfilenum!=-1){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+meshi->plot3dfilenum;
+    plot3di = global_scase.plot3dinfo+meshi->plot3dfilenum;
     FreeAllMemory(plot3di->memory_id);
     colorlabeliso = NULL;
     colorlabelp3  = NULL;
@@ -297,8 +297,8 @@ FILE_SIZE ReadPlot3D(char *file, int ifile, int flag, int *errorcode){
   else{
     pn = meshi->plot3dfilenum;
     if(pn!=-1){
-      plot3dinfo[pn].loaded=0;
-      plot3dinfo[pn].display=0;
+      global_scase.plot3dinfo[pn].loaded=0;
+      global_scase.plot3dinfo[pn].display=0;
     }
     meshi->plot3dfilenum=ifile;
   }
@@ -308,13 +308,13 @@ FILE_SIZE ReadPlot3D(char *file, int ifile, int flag, int *errorcode){
   FreeContour(meshi->plot3dcontour1);
   FreeContour(meshi->plot3dcontour2);
   FreeContour(meshi->plot3dcontour3);
-  InitContour(meshi->plot3dcontour1,rgb_plot3d_contour,nrgb);
-  InitContour(meshi->plot3dcontour2,rgb_plot3d_contour,nrgb);
-  InitContour(meshi->plot3dcontour3,rgb_plot3d_contour,nrgb);
+  InitContour(meshi->plot3dcontour1,rgb_plot3d_contour,global_scase.nrgb);
+  InitContour(meshi->plot3dcontour2,rgb_plot3d_contour,global_scase.nrgb);
+  InitContour(meshi->plot3dcontour3,rgb_plot3d_contour,global_scase.nrgb);
 
 
-  for(i=0;i<nmeshes;i++){
-    gbb=meshinfo+i;
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
+    gbb=global_scase.meshescoll.meshinfo+i;
     if(gbb->plot3dfilenum!=-1)nloaded++;
   }
 
@@ -323,7 +323,7 @@ FILE_SIZE ReadPlot3D(char *file, int ifile, int flag, int *errorcode){
     p->display=0;
     UpdatePlot3DFileLoad();
     plotstate = GetPlotState(STATIC_PLOTS);
-    meshi=meshinfo+p->blocknumber;
+    meshi=global_scase.meshescoll.meshinfo+p->blocknumber;
     meshi->plot3dfilenum=-1;
     if(nloaded==0){
       numplot3dvars=0;
@@ -344,10 +344,10 @@ FILE_SIZE ReadPlot3D(char *file, int ifile, int flag, int *errorcode){
   ntotal = nx*ny*nz;
   numplot3dvars=5;
 
-  uindex = plot3dinfo[ifile].u;
-  vindex = plot3dinfo[ifile].v;
-  windex = plot3dinfo[ifile].w;
-  if(uindex!=-1||vindex!=-1||windex!=-1)numplot3dvars=plot3dinfo[ifile].nplot3dvars;
+  uindex = global_scase.plot3dinfo[ifile].u;
+  vindex = global_scase.plot3dinfo[ifile].v;
+  windex = global_scase.plot3dinfo[ifile].w;
+  if(uindex!=-1||vindex!=-1||windex!=-1)numplot3dvars=global_scase.plot3dinfo[ifile].nplot3dvars;
 
   if(NewMemoryMemID((void **)&meshi->qdata,numplot3dvars*ntotal*sizeof(float), p->memory_id)==0){
     *errorcode=1;
@@ -488,7 +488,7 @@ FILE_SIZE ReadPlot3D(char *file, int ifile, int flag, int *errorcode){
         void BoundsUpdate(int file_type);
         if(no_bounds==0 || force_bounds==1)BoundsUpdate(BOUND_PLOT3D);
         ComputeLoadedPlot3DBounds(valmin_loaded, valmax_loaded);
-        GLUISetLoadedMinMaxAll(BOUND_PLOT3D, valmin_loaded, valmax_loaded, plot3dinfo->nplot3dvars);
+        GLUISetLoadedMinMaxAll(BOUND_PLOT3D, valmin_loaded, valmax_loaded, global_scase.plot3dinfo->nplot3dvars);
       }
       UpdateAllPlot3DColors(0);
       UpdatePlotSlice(XDIR);
@@ -988,13 +988,13 @@ void DrawPlot3dTexture(meshdata *meshi){
 void DrawPlot3dFrame(void){
   int i;
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     if(meshi->use == 0)continue;
     if(meshi->plot3dfilenum==-1)continue;
-    if(plot3dinfo[meshi->plot3dfilenum].display==0)continue;
+    if(global_scase.plot3dinfo[meshi->plot3dfilenum].display==0)continue;
     DrawPlot3dTexture(meshi);
   }
 }
@@ -1013,10 +1013,10 @@ void UpdateSurface(void){
   int i;
 
   if(nplot3dloaded==0)return;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     if(meshi->plot3dfilenum==-1)continue;
 
     ibar=meshi->ibar;
@@ -1032,13 +1032,13 @@ void UpdateSurface(void){
     currentsurf2ptr = meshi->currentsurf2;
     qdata=meshi->qdata;
     if(plotiso[plotn-1]<0){
-      plotiso[plotn-1]=nrgb-3;
+      plotiso[plotn-1]=global_scase.nrgb-3;
     }
-    if(plotiso[plotn-1]>nrgb-3){
+    if(plotiso[plotn-1]>global_scase.nrgb-3){
       plotiso[plotn-1]=0;
     }
     colorindex=plotiso[plotn-1];
-    level = p3min_all[plotn-1] + (colorindex+0.5)*(p3max_all[plotn-1]-p3min_all[plotn-1])/((float)nrgb-2.0f);
+    level = p3min_all[plotn-1] + (colorindex+0.5)*(p3max_all[plotn-1]-p3min_all[plotn-1])/((float)global_scase.nrgb-2.0f);
     isolevelindex=colorindex;
     isolevelindex2=colorindex;
     FreeSurface(currentsurfptr);
@@ -1054,9 +1054,9 @@ void UpdateSurface(void){
 
     if(surfincrement!=0){
       colorindex2=colorindex+surfincrement;
-      if(colorindex2<0)colorindex2=nrgb-2;
-      if(colorindex2>nrgb-2)colorindex2=0;
-      level2 = p3min_all[plotn-1] + colorindex2*(p3max_all[plotn-1]-p3min_all[plotn-1])/((float)nrgb-2.0f);
+      if(colorindex2<0)colorindex2=global_scase.nrgb-2;
+      if(colorindex2>global_scase.nrgb-2)colorindex2=0;
+      level2 = p3min_all[plotn-1] + colorindex2*(p3max_all[plotn-1]-p3min_all[plotn-1])/((float)global_scase.nrgb-2.0f);
       FreeSurface(currentsurf2ptr);
       InitIsoSurface(currentsurf2ptr, level2, rgb_plot3d_contour[colorindex2],-999);
       GetIsoSurface(currentsurf2ptr,qdata+(plotn-1)*plot3dsize,NULL,iblank_cell,level2,
@@ -1129,13 +1129,13 @@ void UpdatePlotXYZ(meshdata *current_mesh_local){
   yval = current_mesh_local->yplt[current_mesh_local->ploty];
   zval = current_mesh_local->zplt[current_mesh_local->plotz];
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     float xmin, xmax;
     float ymin, ymax;
     float zmin, zmax;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     if(meshi==current_mesh_local)continue;
 
     xmin = meshi->xplt[0];
@@ -1307,7 +1307,7 @@ void UpdatePlotSliceMesh(meshdata *mesh_in, int slicedir){
     dy_yzcopy = dy_yz;
     dz_yzcopy = dz_yz;
     iblank_yz = NULL;
-    if(use_iblank == 1 && c_iblank_x != NULL){
+    if(global_scase.use_iblank == 1 && c_iblank_x != NULL){
       NewMemory((void **)&iblank_yz, (jbar + 1)*(kbar + 1) * sizeof(char));
       for(j = 0;j < jbar;j++){
         for(k = 0;k < kbar;k++){
@@ -1339,7 +1339,7 @@ void UpdatePlotSliceMesh(meshdata *mesh_in, int slicedir){
       }
     }
     FreeContour(plot3dcontour1ptr);
-    InitContour(plot3dcontour1ptr, rgb_plot3d_contour, nrgb);
+    InitContour(plot3dcontour1ptr, rgb_plot3d_contour, global_scase.nrgb);
     SetContourSlice(plot3dcontour1ptr, 1, xplt[plotx]);
     GetContours(yplt, zplt, jbar + 1, kbar + 1, yzcolorfbase, iblank_yz, p3levels[plotn - 1], DONT_GET_AREAS, DATA_FORTRAN, plot3dcontour1ptr);
     FREEMEMORY(iblank_yz);
@@ -1356,7 +1356,7 @@ void UpdatePlotSliceMesh(meshdata *mesh_in, int slicedir){
     dy_xzcopy = dy_xz;
     dz_xzcopy = dz_xz;
     iblank_xz = NULL;
-    if(use_iblank == 1 && c_iblank_y != NULL){
+    if(global_scase.use_iblank == 1 && c_iblank_y != NULL){
       NewMemory((void **)&iblank_xz, (ibar + 1)*(kbar + 1) * sizeof(char));
       for(i = 0;i < ibar;i++){
         for(k = 0;k < kbar;k++){
@@ -1388,7 +1388,7 @@ void UpdatePlotSliceMesh(meshdata *mesh_in, int slicedir){
       }
     }
     FreeContour(plot3dcontour2ptr);
-    InitContour(plot3dcontour2ptr, rgb_plot3d_contour, nrgb);
+    InitContour(plot3dcontour2ptr, rgb_plot3d_contour, global_scase.nrgb);
     SetContourSlice(plot3dcontour2ptr, 2, yplt[ploty]);
     GetContours(xplt, zplt, ibar + 1, kbar + 1, xzcolorfbase, iblank_xz, p3levels[plotn - 1], DONT_GET_AREAS, DATA_FORTRAN, plot3dcontour2ptr);
     FREEMEMORY(iblank_xz);
@@ -1405,7 +1405,7 @@ void UpdatePlotSliceMesh(meshdata *mesh_in, int slicedir){
     dy_xycopy = dy_xy;
     dz_xycopy = dz_xy;
     iblank_xy = NULL;
-    if(use_iblank == 1 && c_iblank_z != NULL){
+    if(global_scase.use_iblank == 1 && c_iblank_z != NULL){
       NewMemory((void **)&iblank_xy, (ibar + 1)*(jbar + 1) * sizeof(char));
       for(i = 0;i < ibar;i++){
         for(j = 0;j < jbar;j++){
@@ -1437,7 +1437,7 @@ void UpdatePlotSliceMesh(meshdata *mesh_in, int slicedir){
       }
     }
     FreeContour(plot3dcontour3ptr);
-    InitContour(plot3dcontour3ptr, rgb_plot3d_contour, nrgb);
+    InitContour(plot3dcontour3ptr, rgb_plot3d_contour, global_scase.nrgb);
     SetContourSlice(plot3dcontour3ptr, 3, zplt[plotz]);
     GetContours(xplt, yplt, ibar + 1, jbar + 1, xycolorfbase, iblank_xy, p3levels[plotn - 1], DONT_GET_AREAS, DATA_FORTRAN, plot3dcontour3ptr);
     FREEMEMORY(iblank_xy);
@@ -1450,10 +1450,10 @@ void UpdatePlotSlice(int slicedir){
   int i;
 
   UpdatePlotXYZ(current_mesh);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshjj;
 
-    meshjj = meshinfo + i;
+    meshjj = global_scase.meshescoll.meshinfo + i;
     if(meshjj->plot3dfilenum==-1)continue;
     UpdatePlotSliceMesh(meshjj,slicedir);
   }
@@ -1500,13 +1500,13 @@ void UpdateShowStep(int val, int slicedir){
     ymax = current_mesh->yplt[current_mesh->jbar];
     zmin = current_mesh->zplt[0];
     zmax = current_mesh->zplt[current_mesh->kbar];
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       float xmin2, xmax2;
       float ymin2, ymax2;
       float zmin2, zmax2;
 
-      meshi = meshinfo+i;
+      meshi = global_scase.meshescoll.meshinfo+i;
       if(meshi==current_mesh)continue;
 
       xmin2 = meshi->xplt[0];
@@ -1650,16 +1650,16 @@ void UpdatePlot3dMenuLabels(void){
   plot3ddata *plot3di;
   char label[128];
 
-  if(nplot3dinfo>0){
+  if(global_scase.nplot3dinfo>0){
     FREEMEMORY(plot3dorderindex);
-    NewMemory((void **)&plot3dorderindex,sizeof(int)*nplot3dinfo);
-    for(i=0;i<nplot3dinfo;i++){
+    NewMemory((void **)&plot3dorderindex,sizeof(int)*global_scase.nplot3dinfo);
+    for(i=0;i<global_scase.nplot3dinfo;i++){
       plot3dorderindex[i]=i;
     }
-    qsort( (int *)plot3dorderindex, (size_t)nplot3dinfo, sizeof(int), Plot3dCompare);
+    qsort( (int *)plot3dorderindex, (size_t)global_scase.nplot3dinfo, sizeof(int), Plot3dCompare);
 
-    for(i=0;i<nplot3dinfo;i++){
-      plot3di = plot3dinfo + i;
+    for(i=0;i<global_scase.nplot3dinfo;i++){
+      plot3di = global_scase.plot3dinfo + i;
       STRCPY(plot3di->menulabel,plot3di->longlabel);
       STRCPY(plot3di->menulabel,"");
       if(plot3di->time>=0.0){
@@ -1668,17 +1668,17 @@ void UpdatePlot3dMenuLabels(void){
         STRCAT(label," s");
         STRCAT(plot3di->menulabel,label);
       }
-      if(nmeshes>1){
+      if(global_scase.meshescoll.nmeshes>1){
         meshdata *plot3dmesh;
 
-        plot3dmesh = meshinfo + plot3di->blocknumber;
+        plot3dmesh = global_scase.meshescoll.meshinfo + plot3di->blocknumber;
         sprintf(label,"%s",plot3dmesh->label);
         if(plot3di->time>=0.0)STRCAT(plot3di->menulabel,", ");
         sprintf(label,"%s",plot3dmesh->label);
         STRCAT(plot3di->menulabel,label);
       }
       if(showfiles==1||plot3di->time<0.0){
-        if(plot3di->time>=0.0||nmeshes>1)STRCAT(plot3di->menulabel,", ");
+        if(plot3di->time>=0.0||global_scase.meshescoll.nmeshes>1)STRCAT(plot3di->menulabel,", ");
         STRCAT(plot3di->menulabel,plot3di->file);
       }
     }
@@ -1707,18 +1707,18 @@ void InitPlot3dTimeList(void){
 
   FREEMEMORY(plot3dtimelist);
   nplot3dtimelist=0;
-  if(nplot3dinfo>0){
-    NewMemory((void **)&plot3dtimelist,nplot3dinfo*sizeof(float));
+  if(global_scase.nplot3dinfo>0){
+    NewMemory((void **)&plot3dtimelist,global_scase.nplot3dinfo*sizeof(float));
   }
   if(plot3dtimelist==NULL)return;
 
-  for(i=0;i<nplot3dinfo;i++){
-    plot3di = plot3dinfo + i;
+  for(i=0;i<global_scase.nplot3dinfo;i++){
+    plot3di = global_scase.plot3dinfo + i;
     plot3dtimelist[i]=plot3di->time;
   }
-  qsort( (float *)plot3dtimelist, (size_t)nplot3dinfo, sizeof(int), Plot3dListCompare);
+  qsort( (float *)plot3dtimelist, (size_t)global_scase.nplot3dinfo, sizeof(int), Plot3dListCompare);
   lasttime_local=-999999.0;
-  for(i=0;i<nplot3dinfo;i++){
+  for(i=0;i<global_scase.nplot3dinfo;i++){
     val=plot3dtimelist[i];
     if(ABS((double)(val-lasttime_local))>0.1){
       nplot3dtimelist++;
@@ -1737,7 +1737,7 @@ void GetPlot3dUVW(float xyz[3], float uvw[3]){
   uvw[0]=0.0;
   uvw[1]=0.0;
   uvw[2]=0.0;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int ibar, jbar, kbar;
     float *udata,  *vdata, *wdata, *qdata;
@@ -1745,7 +1745,7 @@ void GetPlot3dUVW(float xyz[3], float uvw[3]){
     int ix, iy, iz;
     int ijk;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
 
     xplt = meshi->xplt_orig;
     yplt = meshi->yplt_orig;
@@ -1802,10 +1802,10 @@ void GetPlot3dUVW(float xyz[3], float uvw[3]){
 int GetPlot3dTime(float *time_local){
   int i;
 
-  for(i=0;i<nplot3dinfo;i++){
+  for(i=0;i<global_scase.nplot3dinfo;i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     if(plot3di->loaded==0||plot3di->display==0)continue;
     *time_local = plot3di->time;
     return 1;

--- a/Source/smokeview/IOshooter.c
+++ b/Source/smokeview/IOshooter.c
@@ -60,7 +60,7 @@ void IncrementShooterData(shootpointdata *pold, shootpointdata *pnew, float dtst
 
       GetShooterVel(uvw_air,xyznew);
       meshpoint = GetMeshNoFail(xyznew);
-      if(meshpoint==NULL)meshpoint=meshinfo;
+      if(meshpoint==NULL)meshpoint=global_scase.meshescoll.meshinfo;
       grid_vel =  sqrt(uvwnew[0]*uvwnew[0]+uvwnew[1]*uvwnew[1]+uvwnew[2]*uvwnew[2]);
       if(grid_vel<0.01)grid_vel=0.01;
       dt = MIN(meshpoint->cellsize/grid_vel,dtstep-tstep);
@@ -172,7 +172,7 @@ void DrawShooter(void){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
   //glColor4fv(static_color);
   glBegin(GL_POINTS);

--- a/Source/smokeview/IOslice.c
+++ b/Source/smokeview/IOslice.c
@@ -171,7 +171,7 @@ float Get3DSliceVal(slicedata *sd, float *xyz){
 
   meshdata *valmesh;
 
-  valmesh = meshinfo + sd->blocknumber;
+  valmesh = global_scase.meshescoll.meshinfo + sd->blocknumber;
 
   xplt = valmesh->xplt_orig;
   yplt = valmesh->yplt_orig;
@@ -806,21 +806,21 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
 
   valmin = 1000000000.0;
   valmax = -valmin;
-  vd = slicecoll.vsliceinfo + ivslice;
+  vd = global_scase.slicecoll.vsliceinfo + ivslice;
   vd->u=NULL;
   vd->v=NULL;
   vd->w=NULL;
   vd->val=NULL;
 
-  if(vd->iu!=-1)slicecoll.sliceinfo[vd->iu].uvw = 1;
-  if(vd->iv!=-1)slicecoll.sliceinfo[vd->iv].uvw = 1;
-  if(vd->iw!=-1)slicecoll.sliceinfo[vd->iw].uvw = 1;
+  if(vd->iu!=-1)global_scase.slicecoll.sliceinfo[vd->iu].uvw = 1;
+  if(vd->iv!=-1)global_scase.slicecoll.sliceinfo[vd->iv].uvw = 1;
+  if(vd->iw!=-1)global_scase.slicecoll.sliceinfo[vd->iw].uvw = 1;
   if(load_flag==UNLOAD){
     if(vd->loaded==0)return 0;
     if(vd->iu!=-1){
       slicedata *u=NULL;
 
-      u = slicecoll.sliceinfo + vd->iu;
+      u = global_scase.slicecoll.sliceinfo + vd->iu;
       display=u->display;
       if(u->loaded==1){
         if(u->slice_filetype == SLICE_GEOM){
@@ -836,7 +836,7 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
     if(vd->iv!=-1){
       slicedata *v=NULL;
 
-      v = slicecoll.sliceinfo + vd->iv;
+      v = global_scase.slicecoll.sliceinfo + vd->iv;
       display=v->display;
       if(v->loaded==1){
         if(v->slice_filetype == SLICE_GEOM){
@@ -852,7 +852,7 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
     if(vd->iw!=-1){
       slicedata *w=NULL;
 
-      w = slicecoll.sliceinfo + vd->iw;
+      w = global_scase.slicecoll.sliceinfo + vd->iw;
       display=w->display;
       if(w->loaded==1){
         if(w->slice_filetype == SLICE_GEOM){
@@ -868,7 +868,7 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
     if(vd->ival!=-1){
       slicedata *val=NULL;
 
-      val = slicecoll.sliceinfo + vd->ival;
+      val = global_scase.slicecoll.sliceinfo + vd->ival;
       display=val->display;
       if(val->loaded==1){
         if(val->slice_filetype == SLICE_GEOM){
@@ -896,13 +896,13 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
   if(vd->finalize == 1 && vd->ival != -1){
     slicedata *sd = NULL;
 
-    sd = slicecoll.sliceinfo + vd->ival;
+    sd = global_scase.slicecoll.sliceinfo + vd->ival;
     GLUIGetMinMax(BOUND_SLICE, sd->label.shortlabel, &set_valmin_save, &qmin_save, &set_valmax_save, &qmax_save);
   }
   if(vd->iu!=-1){
     slicedata *u=NULL;
 
-    u = slicecoll.sliceinfo + vd->iu;
+    u = global_scase.slicecoll.sliceinfo + vd->iu;
     u->finalize = vd->finalize;
     finalize = vd->finalize;
     vd->u=u;
@@ -929,7 +929,7 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
   if(vd->iv!=-1){
     slicedata *v=NULL;
 
-    v = slicecoll.sliceinfo + vd->iv;
+    v = global_scase.slicecoll.sliceinfo + vd->iv;
     v->finalize = vd->finalize;
     finalize = vd->finalize;
     vd->v=v;
@@ -957,7 +957,7 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
   if(vd->iw!=-1){
     slicedata *w=NULL;
 
-    w = slicecoll.sliceinfo + vd->iw;
+    w = global_scase.slicecoll.sliceinfo + vd->iw;
     w->finalize = vd->finalize;
     finalize = vd->finalize;
     vd->w=w;
@@ -986,7 +986,7 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
   if(vd->ival!=-1){
     slicedata *val=NULL;
 
-    val = slicecoll.sliceinfo + vd->ival;
+    val = global_scase.slicecoll.sliceinfo + vd->ival;
     val->finalize = vd->finalize;
     finalize = vd->finalize;
     vd->val=val;
@@ -1021,29 +1021,29 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
 
     valmax = -100000.0;
     valmin = 100000.0;
-    for(i = 0;i<slicecoll.nvsliceinfo;i++){
+    for(i = 0;i<global_scase.slicecoll.nvsliceinfo;i++){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo+i;
+      vslicei = global_scase.slicecoll.vsliceinfo+i;
       if(vslicei->loaded==0)continue;
       if(vslicei->iu!=-1){
         slicedata *u = NULL;
 
-        u = slicecoll.sliceinfo+vslicei->iu;
+        u = global_scase.slicecoll.sliceinfo+vslicei->iu;
         valmin = MIN(u->valmin_slice, valmin);
         valmax = MAX(u->valmax_slice, valmax);
       }
       if(vslicei->iv!=-1){
         slicedata *v = NULL;
 
-        v = slicecoll.sliceinfo+vslicei->iv;
+        v = global_scase.slicecoll.sliceinfo+vslicei->iv;
         valmin = MIN(v->valmin_slice, valmin);
         valmax = MAX(v->valmax_slice, valmax);
       }
       if(vslicei->iw!=-1){
         slicedata *w = NULL;
 
-        w = slicecoll.sliceinfo+vslicei->iw;
+        w = global_scase.slicecoll.sliceinfo+vslicei->iw;
         valmin = MIN(w->valmin_slice, valmin);
         valmax = MAX(w->valmax_slice, valmax);
       }
@@ -1052,7 +1052,7 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
     if(vd->ival != -1){
       slicedata *sd = NULL;
 
-      sd = slicecoll.sliceinfo + vd->ival;
+      sd = global_scase.slicecoll.sliceinfo + vd->ival;
       if(set_valmin_save == 0){
         SetSliceMin(set_valmin_save, qmin_save, sd->label.shortlabel);
       }
@@ -1065,13 +1065,13 @@ FILE_SIZE ReadVSlice(int ivslice, int time_frame, float *time_value, int load_fl
         for(i = 0; i<256; i++){
           cbvals[i] = (qmin_save*(float)(255 - i) + qmax_save*(float)i) / 255.0;
         }
-        for(i=0;i<slicecoll.nvsliceinfo;i++){
+        for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
           vslicedata *vslicei;
           slicedata *slicei;
 
-          vslicei = slicecoll.vsliceinfo + i;
+          vslicei = global_scase.slicecoll.vsliceinfo + i;
           if(vslicei->loaded == 0 || vslicei->display == 0 || vslicei->ival == -1)continue;
-          slicei = slicecoll.sliceinfo + vslicei->ival;
+          slicei = global_scase.slicecoll.sliceinfo + vslicei->ival;
           if(slicei->loaded==0||strcmp(sd->label.shortlabel,slicei->label.shortlabel)!=0)continue;
           slicei->valmin_slice = qmin_save;
           slicei->valmax_slice = qmax_save;
@@ -1099,7 +1099,7 @@ void UpdateSliceFilenum(void){
 
   for(ii=0;ii<nslice_loaded;ii++){
     i = slice_loaded_list[ii];
-    sd = slicecoll.sliceinfo+i;
+    sd = global_scase.slicecoll.sliceinfo+i;
     if(sd->display==0||slicefile_labelindex!=sd->slicefile_labelindex)continue;
     slicefilenum=i;
     break;
@@ -1138,10 +1138,10 @@ void MergeLoadedSliceHist(char *label, histogramdata **histptr){
   *histptr = hist;
 
   InitHistogram(hist, NHIST_BUCKETS, NULL, NULL);
-  for(i = 0; i < slicecoll.nsliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     if(slicei->loaded == 0 || strcmp(slicei->label.shortlabel, label) != 0)continue;
     MergeHistogram(hist, slicei->histograms, MERGE_BOUNDS);
   }
@@ -1164,7 +1164,7 @@ void GetSliceHists(slicedata *sd, int use_bounds, float valmin, float valmax){
   float *xplt, *yplt, *zplt;
 
   if(sd->histograms != NULL)return;
-  meshi = meshinfo + sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
   iblank_node = meshi->c_iblank_node;
   iblank_cell = meshi->c_iblank_cell;
   xplt = meshi->xplt_orig;
@@ -1217,7 +1217,7 @@ void GetSliceHists(slicedata *sd, int use_bounds, float valmin, float valmax){
         slice_weight0[n] = dx * dy * dz;
         if(sd->slice_filetype == SLICE_CELL_CENTER &&
           ((k == 0 && sd->nslicek != 1) || (j == 0 && sd->nslicej != 1) || (i == 0 && sd->nslicei != 1)))continue;
-        if(show_slice_in_obst == ONLY_IN_GAS){
+        if(global_scase.show_slice_in_obst == ONLY_IN_GAS){
           if(sd->slice_filetype != SLICE_CELL_CENTER && iblank_node != NULL && iblank_node[IJKNODE(sd->is1 + i, sd->js1 + j, sd->ks1 + k)] == SOLID)continue;
           if(sd->slice_filetype == SLICE_CELL_CENTER && iblank_cell != NULL && iblank_cell[IJKCELL(sd->is1 + i - 1, sd->js1 + j - 1, sd->ks1 + k - 1)] == EMBED_YES)continue;
         }
@@ -1296,10 +1296,10 @@ void GetSliceGeomHists(slicedata *sd, int use_bounds, float valmin, float valmax
 void ComputeLoadedSliceHist(char *label, float valmin, float valmax){
   int i;
 
-  for(i = 0; i < slicecoll.nsliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     if(slicei->loaded == 0)continue;
     if(label != NULL && strcmp(slicei->label.shortlabel, label) != 0)continue;
     if(slicei->histograms == NULL){
@@ -1332,7 +1332,7 @@ void UpdateSliceBounds(void){
       slicedata *slicej;
 
       j = slice_loaded_list[jj];
-      slicej = slicecoll.sliceinfo + j;
+      slicej = global_scase.slicecoll.sliceinfo + j;
       if(slicej->slicefile_labelindex!=i)continue;
       if(slicebounds[i].dlg_setvalmin!=SET_MIN){
         if(minflag==0){
@@ -1340,11 +1340,11 @@ void UpdateSliceBounds(void){
           minflag=1;
         }
         else{
-          if(slicecoll.sliceinfo[j].valmin_slice <valmin)valmin=slicej->valmin_slice;
+          if(global_scase.slicecoll.sliceinfo[j].valmin_slice <valmin)valmin=slicej->valmin_slice;
         }
       }
       if(minflag2==0){
-        valmin_data=slicecoll.sliceinfo[j].globalmin_slice;
+        valmin_data=global_scase.slicecoll.sliceinfo[j].globalmin_slice;
         minflag2=1;
       }
       else{
@@ -1355,15 +1355,15 @@ void UpdateSliceBounds(void){
       slicedata *slicej;
 
       j = slice_loaded_list[jj];
-      slicej = slicecoll.sliceinfo + j;
+      slicej = global_scase.slicecoll.sliceinfo + j;
       if(slicej->slicefile_labelindex!=i)continue;
       if(slicebounds[i].dlg_setvalmax!=SET_MAX){
         if(maxflag==0){
-          valmax=slicecoll.sliceinfo[j].valmax_slice;
+          valmax=global_scase.slicecoll.sliceinfo[j].valmax_slice;
           maxflag=1;
         }
         else{
-          if(slicecoll.sliceinfo[j].valmax_slice >valmax)valmax=slicej->valmax_slice;
+          if(global_scase.slicecoll.sliceinfo[j].valmax_slice >valmax)valmax=slicej->valmax_slice;
         }
       }
       if(maxflag2==0){
@@ -1398,7 +1398,7 @@ void SetSliceLabels(float smin, float smax,
     if(pd!=NULL)sb->label = &(pd->label);
 
     *errorcode = 0;
-    GetColorbarLabels(smin, smax, nrgb, sb->colorlabels, sb->levels256);
+    GetColorbarLabels(smin, smax, global_scase.nrgb, sb->colorlabels, sb->levels256);
   }
 }
 
@@ -1431,7 +1431,7 @@ void UpdateAllSliceLabels(int slicetype, int *errorcode){
   }
   for(ii=0;ii<nslice_loaded;ii++){
     i = slice_loaded_list[ii];
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     if(sd->slicefile_labelindex == slicetype){
       SetSliceLabels(valmin, valmax, sd, NULL, errorcode);
     }
@@ -1458,7 +1458,7 @@ void SetSliceColors(float smin, float smax, slicedata *sd, int flag, int *errorc
     patchgeom = sd->patchgeom;
     GetSliceColors(patchgeom->geom_vals, patchgeom->geom_nvals, patchgeom->geom_ivals,
       smin, smax,
-      nrgb_full, nrgb,
+      nrgb_full, global_scase.nrgb,
       sb->colorlabels, sb->colorvalues, sb->levels256,
       &sd->extreme_min, &sd->extreme_max, flag
     );
@@ -1467,7 +1467,7 @@ void SetSliceColors(float smin, float smax, slicedata *sd, int flag, int *errorc
     if(sd->qslicedata == NULL)return;
     GetSliceColors(sd->qslicedata, sd->nslicetotal, sd->slicelevel,
       smin, smax,
-      nrgb_full, nrgb,
+      nrgb_full, global_scase.nrgb,
       sb->colorlabels, sb->colorvalues, sb->levels256,
       &sd->extreme_min, &sd->extreme_max, flag
     );
@@ -1503,7 +1503,7 @@ void UpdateAllSliceColors(int slicetype, int *errorcode){
   }
   for(ii=0;ii<nslice_loaded;ii++){
     i = slice_loaded_list[ii];
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     if(sd->slicefile_labelindex!=slicetype)continue;
     SetSliceColors(valmin,valmax,sd,1,errorcode);
     if(*errorcode!=0)return;
@@ -1516,8 +1516,8 @@ void UpdateAllSliceColors(int slicetype, int *errorcode){
 int SliceCompare(const void *arg1, const void *arg2){
   slicedata *slicei, *slicej;
 
-  slicei = slicecoll.sliceinfo + *(int *)arg1;
-  slicej = slicecoll.sliceinfo + *(int *)arg2;
+  slicei = global_scase.slicecoll.sliceinfo + *(int *)arg1;
+  slicej = global_scase.slicecoll.sliceinfo + *(int *)arg2;
 
   if(strcmp(slicei->label.longlabel,slicej->label.longlabel)<0)return -1;
   if(strcmp(slicei->label.longlabel,slicej->label.longlabel)>0)return 1;
@@ -1541,8 +1541,8 @@ int SliceCompare(const void *arg1, const void *arg2){
 int VSliceCompare(const void *arg1, const void *arg2){
   vslicedata *vslicei, *vslicej;
 
-  vslicei = slicecoll.vsliceinfo+*(int *)arg1;
-  vslicej = slicecoll.vsliceinfo+*(int *)arg2;
+  vslicei = global_scase.slicecoll.vsliceinfo+*(int *)arg1;
+  vslicej = global_scase.slicecoll.vsliceinfo+*(int *)arg2;
   return SliceCompare(&(vslicei->ival), &(vslicej->ival));
 }
 
@@ -1554,7 +1554,7 @@ void UpdateSliceMenuShow(sliceparmdata *sp){
   for(i=0;i<sp->nsliceinfo;i++){
     slicedata *sd;
 
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     sd->menu_show=1;
     sd->constant_color = NULL;
   }
@@ -1573,8 +1573,8 @@ char *GetMSliceDir(multislicedata *mslicei){
     meshdata *meshi;
     float delta;
 
-    slicei = slicecoll.sliceinfo+mslicei->islices[i];
-    meshi = meshinfo+slicei->blocknumber;
+    slicei = global_scase.slicecoll.sliceinfo+mslicei->islices[i];
+    meshi = global_scase.meshescoll.meshinfo+slicei->blocknumber;
     if(slicei->idir==0){
       return slicei->cdir;
     }
@@ -1605,8 +1605,8 @@ void UpdateSliceMenuLabels(sliceparmdata *sp){
   if(sp->nsliceinfo>0){
     char *cdir;
 
-    mslicei = slicecoll.multisliceinfo;
-    sd = slicecoll.sliceinfo + sliceorderindex[0];
+    mslicei = global_scase.slicecoll.multisliceinfo;
+    sd = global_scase.slicecoll.sliceinfo + global_scase.sliceorderindex[0];
     cdir = GetMSliceDir(mslicei);
     STRCPY(mslicei->menulabel, cdir);
     STRCPY(sd->menulabel,mslicei->menulabel);
@@ -1615,10 +1615,10 @@ void UpdateSliceMenuLabels(sliceparmdata *sp){
     STRCAT(mslicei->menulabel2,", ");
     STRCAT(mslicei->menulabel2,sd->menulabel);
 
-    if(nmeshes>1){
+    if(global_scase.meshescoll.nmeshes>1){
       meshdata *slicemesh;
 
-      slicemesh = meshinfo + sd->blocknumber;
+      slicemesh = global_scase.meshescoll.meshinfo + sd->blocknumber;
       sprintf(label,", %s",slicemesh->label);
       STRCAT(sd->menulabel,label);
     }
@@ -1633,8 +1633,8 @@ void UpdateSliceMenuLabels(sliceparmdata *sp){
       STRCAT(sd->menulabel," (RLE)");
     }
     for(i=1;i<sp->nsliceinfo;i++){
-      sdold = slicecoll.sliceinfo + sliceorderindex[i - 1];
-      sd = slicecoll.sliceinfo + sliceorderindex[i];
+      sd = global_scase.slicecoll.sliceinfo + global_scase.sliceorderindex[i];
+      sdold = global_scase.slicecoll.sliceinfo + global_scase.sliceorderindex[i - 1];
       cdir = GetMSliceDir(mslicei);
       STRCPY(sd->menulabel, cdir);
       if(NewMultiSlice(sdold,sd)==1){
@@ -1645,10 +1645,10 @@ void UpdateSliceMenuLabels(sliceparmdata *sp){
         STRCAT(mslicei->menulabel2,", ");
         STRCAT(mslicei->menulabel2, cdir);
       }
-      if(nmeshes>1){
+      if(global_scase.meshescoll.nmeshes>1){
         meshdata *slicemesh;
 
-        slicemesh = meshinfo + sd->blocknumber;
+        slicemesh = global_scase.meshescoll.meshinfo + sd->blocknumber;
         sprintf(label,", %s",slicemesh->label);
         STRCAT(sd->menulabel,label);
       }
@@ -1664,7 +1664,7 @@ void UpdateSliceMenuLabels(sliceparmdata *sp){
       }
     }
     for(i=0;i<sp->nsliceinfo;i++){
-      sd = slicecoll.sliceinfo + i;
+      sd = global_scase.slicecoll.sliceinfo + i;
       STRCPY(sd->menulabel2,sd->label.longlabel);
       STRCAT(sd->menulabel2,", ");
       STRCAT(sd->menulabel2,sd->menulabel);
@@ -1739,18 +1739,18 @@ void UpdateMeshSkip(meshdata *meshi, int skip, int dir){
 void UpdateAllMeshSkips(int skip){
   int i;
 
-  for(i = 0; i < nmeshes; i++){
+  for(i = 0; i < global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     meshi->n_imap = 0;
     meshi->n_jmap = 0;
     meshi->n_kmap = 0;
   }
-  for(i = 0; i < nmeshes; i++){
+  for(i = 0; i < global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     UpdateMeshSkip(meshi, skip, 0);
     UpdateMeshSkip(meshi, skip, 1);
     UpdateMeshSkip(meshi, skip, 2);
@@ -1762,11 +1762,11 @@ void UpdateAllMeshSkips(int skip){
 void UpdateVectorSkipDefault(void){
   int i;
 
-  for(i = 0; i < slicecoll.nsliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     int ii, jj, kk;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     if(slicei->loaded == 0)continue;
     for(ii = slicei->iis1; ii <= slicei->iis2; ii++){
       slicei->imap[ii - slicei->iis1] = ii;
@@ -1792,7 +1792,7 @@ void UpdateVectorSkipNonUniform(slicedata *slicei, int factor_x, int factor_y, i
   int ii, jj, kk;
 
   if(slicei->loaded == 0)return;
-  slicemesh = meshinfo + slicei->blocknumber;
+  slicemesh = global_scase.meshescoll.meshinfo + slicei->blocknumber;
 
   int n = 0;
   for(ii = 0; ii < slicemesh->n_imap; ii+=factor_x){
@@ -1827,15 +1827,15 @@ void UpdateVectorSkipNonUniform(slicedata *slicei, int factor_x, int factor_y, i
 void UpdateVectorSkipUniform(int skip){
   int i;
 
-  for(i = 0; i < slicecoll.nsliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     meshdata *slicemesh;
     float mesh_dx, mesh_dy, mesh_dz;
     int factor_i, factor_j, factor_k;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     if(slicei->loaded == 0)continue;
-    slicemesh = meshinfo + slicei->blocknumber;
+    slicemesh = global_scase.meshescoll.meshinfo + slicei->blocknumber;
 
     mesh_dx = slicemesh->xplt_orig[1] - slicemesh->xplt_orig[0];
     mesh_dy = slicemesh->yplt_orig[1] - slicemesh->yplt_orig[0];
@@ -1854,16 +1854,16 @@ void UpdateVectorSkipUniform(int skip){
 void UpdateVectorSkip(int skip){
   int i;
 
-  if(slicecoll.nsliceinfo > 0){
+  if(global_scase.slicecoll.nsliceinfo > 0){
     UpdateAllMeshSkips(skip);
   }
-  for(i = 0; i < slicecoll.nsliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     meshdata *slicemesh;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     if(slicei->loaded == 0)continue;
-    slicemesh = meshinfo + slicei->blocknumber;
+    slicemesh = global_scase.meshescoll.meshinfo + slicei->blocknumber;
     if(slicei->imap == NULL){
       int *imap;
 
@@ -1894,8 +1894,8 @@ void UpdateVectorSkip(int skip){
       UpdateVectorSkipDefault();
     }
     else{
-      for(i = 0; i < slicecoll.nsliceinfo; i++){
-        UpdateVectorSkipNonUniform(slicecoll.sliceinfo + i, 1, 1, 1);
+      for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
+        UpdateVectorSkipNonUniform(global_scase.slicecoll.sliceinfo + i, 1, 1, 1);
       }
     }
   }
@@ -1912,9 +1912,9 @@ void UpdateVsliceMenuLabels(sliceparmdata *sp){
 
 
   if(sp->nvsliceinfo>0){
-    mvslicei = slicecoll.multivsliceinfo;
-    vsd = slicecoll.vsliceinfo + vsliceorderindex[0];
-    sd = slicecoll.sliceinfo + vsd->ival;
+    mvslicei = global_scase.slicecoll.multivsliceinfo;
+    vsd = global_scase.slicecoll.vsliceinfo + global_scase.vsliceorderindex[0];
+    sd = global_scase.slicecoll.sliceinfo + vsd->ival;
 
     STRCPY(mvslicei->menulabel,  sd->cdir);
     STRCPY(mvslicei->menulabel2, sd->label.longlabel);
@@ -1923,10 +1923,10 @@ void UpdateVsliceMenuLabels(sliceparmdata *sp){
 
     STRCPY(vsd->menulabel,mvslicei->menulabel);
     STRCPY(vsd->menulabel2,mvslicei->menulabel2);
-    if(nmeshes>1){
+    if(global_scase.meshescoll.nmeshes>1){
       meshdata *slicemesh;
 
-      slicemesh = meshinfo + sd->blocknumber;
+      slicemesh = global_scase.meshescoll.meshinfo + sd->blocknumber;
       sprintf(label,", %s",slicemesh->label);
       STRCAT(vsd->menulabel,label);
     }
@@ -1935,10 +1935,10 @@ void UpdateVsliceMenuLabels(sliceparmdata *sp){
       STRCAT(vsd->menulabel,sd->file);
     }
     for(i=1;i<sp->nvsliceinfo;i++){
-      vsdold = slicecoll.vsliceinfo + vsliceorderindex[i - 1];
-      sdold = slicecoll.sliceinfo + vsdold->ival;
-      vsd = slicecoll.vsliceinfo + vsliceorderindex[i];
-      sd = slicecoll.sliceinfo + vsd->ival;
+      vsdold = global_scase.slicecoll.vsliceinfo + global_scase.vsliceorderindex[i - 1];
+      sdold = global_scase.slicecoll.sliceinfo + vsdold->ival;
+      vsd = global_scase.slicecoll.vsliceinfo + global_scase.vsliceorderindex[i];
+      sd = global_scase.slicecoll.sliceinfo + vsd->ival;
       STRCPY(vsd->menulabel,sd->cdir);
       if(NewMultiSlice(sdold,sd)==1){
         mvslicei++;
@@ -1947,10 +1947,10 @@ void UpdateVsliceMenuLabels(sliceparmdata *sp){
         STRCAT(mvslicei->menulabel2,", ");
         STRCAT(mvslicei->menulabel2,mvslicei->menulabel);
       }
-      if(nmeshes>1){
+      if(global_scase.meshescoll.nmeshes>1){
         meshdata *slicemesh;
 
-        slicemesh = meshinfo + sd->blocknumber;
+        slicemesh = global_scase.meshescoll.meshinfo + sd->blocknumber;
         sprintf(label,", %s",slicemesh->label);
         STRCAT(vsd->menulabel,label);
       }
@@ -1960,8 +1960,8 @@ void UpdateVsliceMenuLabels(sliceparmdata *sp){
       }
     }
     for(i=0;i<sp->nvsliceinfo;i++){
-      vsd = slicecoll.vsliceinfo + vsliceorderindex[i];
-      sd = slicecoll.sliceinfo + vsd->ival;
+      vsd = global_scase.slicecoll.vsliceinfo + global_scase.vsliceorderindex[i];
+      sd = global_scase.slicecoll.sliceinfo + vsd->ival;
       STRCPY(vsd->menulabel2,sd->label.longlabel);
       STRCAT(vsd->menulabel2,", ");
       STRCAT(vsd->menulabel2,vsd->menulabel);
@@ -1974,8 +1974,8 @@ void UpdateVsliceMenuLabels(sliceparmdata *sp){
 int NewMultiSlice(slicedata *sdold, slicedata *sd){
   int i, j;
 
-  i = sdold - slicecoll.sliceinfo;
-  j = sd - slicecoll.sliceinfo;
+  i = sdold - global_scase.slicecoll.sliceinfo;
+  j = sd - global_scase.slicecoll.sliceinfo;
   if(SliceCompare(&i, &j) == 0)return 0;
   return 1;
 }
@@ -1985,13 +1985,13 @@ int NewMultiSlice(slicedata *sdold, slicedata *sd){
 void GetGSliceParams(void){
   int i;
 
-  for(i = 0; i < npatchinfo;i++){
+  for(i = 0; i < global_scase.npatchinfo;i++){
     int ii1, ii2, jj1, jj2, kk1, kk2;
     patchdata *patchi;
     meshdata *meshi;
 
-    patchi = patchinfo + i;
-    meshi = meshinfo + patchi->blocknumber;
+    patchi = global_scase.patchinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + patchi->blocknumber;
     strcpy(patchi->gslicedir, "");
     if(patchi->structured == YES)continue;
     ii1 = patchi->ijk[0];
@@ -2057,8 +2057,8 @@ int IsSliceDuplicate(multislicedata *mslicei, int ii, int flag){
 
 
   if(flag==FIND_DUPLICATES&&slicedup_option==SLICEDUP_KEEPALL)return 0;
-  slicei = slicecoll.sliceinfo+mslicei->islices[ii];
-  meshi = meshinfo+slicei->blocknumber;
+  slicei = global_scase.slicecoll.sliceinfo+mslicei->islices[ii];
+  meshi = global_scase.meshescoll.meshinfo+slicei->blocknumber;
   xyzmini = slicei->xyz_min;
   xyzmaxi = slicei->xyz_max;
   for(jj=0;jj<mslicei->nslices;jj++){ // identify duplicate slices
@@ -2066,8 +2066,8 @@ int IsSliceDuplicate(multislicedata *mslicei, int ii, int flag){
     float *xyzminj, *xyzmaxj;
     meshdata *meshj;
 
-    slicej = slicecoll.sliceinfo + mslicei->islices[jj];
-    meshj = meshinfo+slicej->blocknumber;
+    slicej = global_scase.slicecoll.sliceinfo + mslicei->islices[jj];
+    meshj = global_scase.meshescoll.meshinfo+slicej->blocknumber;
     if(slicej==slicei||slicej->skipdup==1)continue;
     if(slicei->above_ground_level>0.0&&slicej->above_ground_level>0.0){
       if(slicei->ks1==0&&slicej->ks2==meshj->kbar)return 0;
@@ -2104,9 +2104,9 @@ int IsVectorSliceDuplicate(multivslicedata *mvslicei, int i){
 
 
   if(vectorslicedup_option==SLICEDUP_KEEPALL)return 0;
-  vslicei = slicecoll.vsliceinfo + mvslicei->ivslices[i];
-  slicei = slicecoll.sliceinfo + vslicei->ival;
-  meshi = meshinfo+slicei->blocknumber;
+  vslicei = global_scase.slicecoll.vsliceinfo + mvslicei->ivslices[i];
+  slicei = global_scase.slicecoll.sliceinfo + vslicei->ival;
+  meshi = global_scase.meshescoll.meshinfo+slicei->blocknumber;
   xyzmini = slicei->xyz_min;
   xyzmaxi = slicei->xyz_max;
   for(jj=0;jj<mvslicei->nvslices;jj++){ // identify duplicate slices
@@ -2115,9 +2115,9 @@ int IsVectorSliceDuplicate(multivslicedata *mvslicei, int i){
     float *xyzminj, *xyzmaxj;
     meshdata *meshj;
 
-    vslicej = slicecoll.vsliceinfo + mvslicei->ivslices[jj];
-    slicej = slicecoll.sliceinfo + vslicej->ival;
-    meshj = meshinfo+slicej->blocknumber;
+    vslicej = global_scase.slicecoll.vsliceinfo + mvslicei->ivslices[jj];
+    slicej = global_scase.slicecoll.sliceinfo + vslicej->ival;
+    meshj = global_scase.meshescoll.meshinfo+slicej->blocknumber;
     if(slicej==slicei||slicej->skipdup==1)continue;
     if(slicei->above_ground_level>0.0&&slicej->above_ground_level>0.0){
       if(slicei->ks1==0&&slicej->ks2==meshj->kbar)return 0;
@@ -2139,11 +2139,11 @@ int CountSliceDups(void){
   int i, count;
 
   count = 0;
-  for(i = 0; i < slicecoll.nmultisliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nmultisliceinfo; i++){
     int ii;
     multislicedata *mslicei;
 
-    mslicei = slicecoll.multisliceinfo + i;
+    mslicei = global_scase.slicecoll.multisliceinfo + i;
     for(ii = 0; ii < mslicei->nslices; ii++){
       count += IsSliceDuplicate(mslicei, ii, COUNT_DUPLICATES);
     }
@@ -2160,11 +2160,11 @@ void UpdateSliceDups(sliceparmdata *sp){
     int ii;
     multislicedata *mslicei;
 
-    mslicei = slicecoll.multisliceinfo + i;
+    mslicei = global_scase.slicecoll.multisliceinfo + i;
     for(ii=0;ii<mslicei->nslices;ii++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + mslicei->islices[ii];
+      slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[ii];
       slicei->skipdup =0;
     }
   }
@@ -2173,11 +2173,11 @@ void UpdateSliceDups(sliceparmdata *sp){
     int ii;
     multislicedata *mslicei;
 
-    mslicei = slicecoll.multisliceinfo + i;
+    mslicei = global_scase.slicecoll.multisliceinfo + i;
     for(ii=0;ii<mslicei->nslices;ii++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + mslicei->islices[ii];
+      slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[ii];
       slicei->skipdup = IsSliceDuplicate(mslicei,ii, FIND_DUPLICATES);
     }
   }
@@ -2188,21 +2188,21 @@ void UpdateSliceDups(sliceparmdata *sp){
 void UpdateVSliceDups(void){
   int ii;
 
-  for(ii=0;ii<slicecoll.nvsliceinfo;ii++){
+  for(ii=0;ii<global_scase.slicecoll.nvsliceinfo;ii++){
     vslicedata *vslicei;
 
-    vslicei = slicecoll.vsliceinfo + ii;
+    vslicei = global_scase.slicecoll.vsliceinfo + ii;
     vslicei->skip = 0;
   }
-  for(ii = 0; ii < slicecoll.nmultivsliceinfo; ii++){
+  for(ii = 0; ii < global_scase.slicecoll.nmultivsliceinfo; ii++){
     multivslicedata *mvslicei;
     int i;
 
-    mvslicei = slicecoll.multivsliceinfo + ii;
+    mvslicei = global_scase.slicecoll.multivsliceinfo + ii;
     for(i = 0; i < mvslicei->nvslices; i++){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo + mvslicei->ivslices[i];
+      vslicei = global_scase.slicecoll.vsliceinfo + mvslicei->ivslices[i];
       vslicei->skip = IsVectorSliceDuplicate(mvslicei,i);
     }
   }
@@ -2213,12 +2213,12 @@ void UpdateVSliceDups(void){
 void UpdateSliceinfoPtrs(sliceparmdata *sp){
   int i;
 
-  meshinfo->isliceinfo    = 0;
-  for(i=1; i<nmeshes; i++){
+  global_scase.meshescoll.meshinfo->isliceinfo    = 0;
+  for(i=1; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshim1, *meshi;
 
-    meshim1               = meshinfo + i - 1;
-    meshi                 = meshinfo + i;
+    meshim1               = global_scase.meshescoll.meshinfo + i - 1;
+    meshi                 = global_scase.meshescoll.meshinfo + i;
     meshi->isliceinfo     = meshim1->isliceinfo + meshim1->nsliceinfo;
   }
   for(i=0; i<sp->nsliceinfo; i++){
@@ -2228,16 +2228,16 @@ void UpdateSliceinfoPtrs(sliceparmdata *sp){
     slicedata *slicei;
     meshdata *meshi;
 
-    slicei                             = slicecoll.sliceinfo + i;
-    meshi                              = meshinfo + slicei->blocknumber;
+    slicei                             = global_scase.slicecoll.sliceinfo + i;
+    meshi                              = global_scase.meshescoll.meshinfo + slicei->blocknumber;
     sliceinfoptrs[meshi->isliceinfo++] = slicei;
   }
-  meshinfo->isliceinfo    = 0;
-  for(i=1; i<nmeshes; i++){
+  global_scase.meshescoll.meshinfo->isliceinfo    = 0;
+  for(i=1; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshim1, *meshi;
 
-    meshim1               = meshinfo + i - 1;
-    meshi                 = meshinfo + i;
+    meshim1               = global_scase.meshescoll.meshinfo + i - 1;
+    meshi                 = global_scase.meshescoll.meshinfo + i;
     meshi->isliceinfo     = meshim1->isliceinfo + meshim1->nsliceinfo;
   }
   CheckMemory;
@@ -2259,7 +2259,7 @@ void GetSliceParams(sliceparmdata *sp){
     int iis1, iis2;
     int ni, nj, nk;
 
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
 
 #ifdef _DEBUG
     if(sp->nsliceinfo>100&&(i%100==0||i==sp->nsliceinfo-1)){
@@ -2345,8 +2345,8 @@ void GetSliceParams(sliceparmdata *sp){
     int is1, is2, js1, js2, ks1, ks2;
     meshdata *meshi;
 
-    sd = slicecoll.sliceinfo + i;
-    meshi = meshinfo + sd->blocknumber;
+    sd = global_scase.slicecoll.sliceinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
 
     is1 = sd->is1;
     is2=sd->is2;
@@ -2496,40 +2496,40 @@ void GetSliceParams(sliceparmdata *sp){
   INIT_PRINT_TIMER(timer_getsliceparams5);
   if(stream!=NULL)fclose(stream);
   if(sp->nsliceinfo>0){
-    FREEMEMORY(sliceorderindex);
-    NewMemory((void **)&sliceorderindex,sizeof(int)*sp->nsliceinfo);
+    FREEMEMORY(global_scase.sliceorderindex);
+    NewMemory((void **)&global_scase.sliceorderindex,sizeof(int)*sp->nsliceinfo);
     for(i=0;i<sp->nsliceinfo;i++){
-      sliceorderindex[i]=i;
+      global_scase.sliceorderindex[i]=i;
     }
-    qsort( (int *)sliceorderindex, (size_t)sp->nsliceinfo, sizeof(int), SliceCompare );
+    qsort( (int *)global_scase.sliceorderindex, (size_t)sp->nsliceinfo, sizeof(int), SliceCompare );
 
     for(i=0;i<sp->nmultisliceinfo;i++){
       multislicedata *mslicei;
 
-      mslicei = slicecoll.multisliceinfo + i;
+      mslicei = global_scase.slicecoll.multisliceinfo + i;
       FREEMEMORY(mslicei->islices);
     }
-    FREEMEMORY(slicecoll.multisliceinfo);
+    FREEMEMORY(global_scase.slicecoll.multisliceinfo);
     sp->nmultisliceinfo=0;
 
-    NewMemory((void **)&slicecoll.multisliceinfo,sizeof(multislicedata)*sp->nsliceinfo);
+    NewMemory((void **)&global_scase.slicecoll.multisliceinfo,sizeof(multislicedata)*sp->nsliceinfo);
 
     {
       multislicedata *mslicei;
       slicedata *sd;
 
       sp->nmultisliceinfo=1;
-      mslicei = slicecoll.multisliceinfo;
+      mslicei = global_scase.slicecoll.multisliceinfo;
       mslicei->islices=NULL;
       NewMemory((void **)&mslicei->islices,sizeof(int)*sp->nsliceinfo);
       mslicei->nslices=1;
-      sd = slicecoll.sliceinfo + sliceorderindex[0];
-      mslicei->islices[0] = sliceorderindex[0];
+      sd = global_scase.slicecoll.sliceinfo + global_scase.sliceorderindex[0];
+      mslicei->islices[0] = global_scase.sliceorderindex[0];
       for(i=1;i<sp->nsliceinfo;i++){
         slicedata *sdold;
 
-        sdold = slicecoll.sliceinfo + sliceorderindex[i - 1];
-        sd = slicecoll.sliceinfo + sliceorderindex[i];
+        sdold = global_scase.slicecoll.sliceinfo + global_scase.sliceorderindex[i - 1];
+        sd = global_scase.slicecoll.sliceinfo + global_scase.sliceorderindex[i];
         mslicei->autoload=0;
         if(NewMultiSlice(sdold,sd)==1){
           sp->nmultisliceinfo++;
@@ -2539,7 +2539,7 @@ void GetSliceParams(sliceparmdata *sp){
           NewMemory((void **)&mslicei->islices,sizeof(int)*sp->nsliceinfo);
         }
         mslicei->nslices++;
-        mslicei->islices[mslicei->nslices-1]=sliceorderindex[i];
+        mslicei->islices[mslicei->nslices-1]=global_scase.sliceorderindex[i];
       }
     }
     have_multislice = 0;
@@ -2551,7 +2551,7 @@ void GetSliceParams(sliceparmdata *sp){
   for(i = 0; i < sp->nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     slicei->mslice = NULL;
     slicei->skipdup = 0;
   }
@@ -2565,11 +2565,11 @@ void GetSliceParams(sliceparmdata *sp){
     int ii;
     multislicedata *mslicei;
 
-    mslicei = slicecoll.multisliceinfo + i;
+    mslicei = global_scase.slicecoll.multisliceinfo + i;
     for(ii = 0; ii < mslicei->nslices; ii++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + mslicei->islices[ii];
+      slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[ii];
       if(ii==0){
         mslicei->slice_filetype = slicei->slice_filetype;
       }
@@ -2595,21 +2595,21 @@ void GetSliceParams2(void){
 
   trainer_temp_n=0;
   trainer_oxy_n=0;
-  if(slicecoll.nmultisliceinfo>0){
+  if(global_scase.slicecoll.nmultisliceinfo>0){
     FREEMEMORY(trainer_temp_indexes);
     FREEMEMORY(trainer_oxy_indexes);
-    NewMemory((void **)&trainer_temp_indexes,slicecoll.nmultisliceinfo*sizeof(int));
-    NewMemory((void **)&trainer_oxy_indexes,slicecoll.nmultisliceinfo*sizeof(int));
+    NewMemory((void **)&trainer_temp_indexes,global_scase.slicecoll.nmultisliceinfo*sizeof(int));
+    NewMemory((void **)&trainer_oxy_indexes,global_scase.slicecoll.nmultisliceinfo*sizeof(int));
   }
-  for(i=0;i<slicecoll.nmultisliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nmultisliceinfo;i++){
     multislicedata *mslicei;
 
-    mslicei = slicecoll.multisliceinfo + i;
+    mslicei = global_scase.slicecoll.multisliceinfo + i;
     if(mslicei->autoload==1){
       slicedata *slicei;
       char *longlabel;
 
-      slicei = slicecoll.sliceinfo + mslicei->islices[0];
+      slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[0];
       longlabel = slicei->label.longlabel;
 
       if(STRCMP(longlabel,"TEMPERATURE")==0){
@@ -2629,14 +2629,14 @@ void *UpdateVSlices(void *arg){
   sliceparmdata *sp;
 
   sp = (sliceparmdata *)arg;
-  max_dx = meshinfo->xplt_orig[1] - meshinfo->xplt_orig[0];
-  max_dy = meshinfo->yplt_orig[1] - meshinfo->yplt_orig[0];
-  max_dz = meshinfo->zplt_orig[1] - meshinfo->zplt_orig[0];
-  for(i = 1; i<nmeshes; i++){
+  max_dx = global_scase.meshescoll.meshinfo->xplt_orig[1] - global_scase.meshescoll.meshinfo->xplt_orig[0];
+  max_dy = global_scase.meshescoll.meshinfo->yplt_orig[1] - global_scase.meshescoll.meshinfo->yplt_orig[0];
+  max_dz = global_scase.meshescoll.meshinfo->zplt_orig[1] - global_scase.meshescoll.meshinfo->zplt_orig[0];
+  for(i = 1; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     float *xplt, *yplt, *zplt;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     xplt = meshi->xplt_orig;
     yplt = meshi->yplt_orig;
     zplt = meshi->zplt_orig;
@@ -2659,7 +2659,7 @@ void *UpdateVSlices(void *arg){
   for(i=0;i<sp->nsliceinfo;i++){
     slicedata *sdi;
 
-    sdi = slicecoll.sliceinfo+i;
+    sdi = global_scase.slicecoll.sliceinfo+i;
     sdi->vec_comp=0;
     if(strncmp(sdi->label.shortlabel,"U-VEL",5)==0){
        sdi->vec_comp=1;
@@ -2687,9 +2687,9 @@ void *UpdateVSlices(void *arg){
       PRINTF("    examining %i'st slice file for vectors\n",i+1);
     }
 #endif
-    vd = slicecoll.vsliceinfo + sp->nvsliceinfo;
-    sdi = slicecoll.sliceinfo+i;
-    meshi = meshinfo + sdi->blocknumber;
+    vd = global_scase.slicecoll.vsliceinfo + sp->nvsliceinfo;
+    sdi = global_scase.slicecoll.sliceinfo+i;
+    meshi = global_scase.meshescoll.meshinfo + sdi->blocknumber;
     vd->iu=-1;
     vd->iv=-1;
     vd->iw=-1;
@@ -2705,9 +2705,9 @@ void *UpdateVSlices(void *arg){
         if(sdi->blocknumber!=sdj->blocknumber)continue;
         if(sdi->is1!=sdj->is1||sdi->is2!=sdj->is2||sdi->js1!=sdj->js1)continue;
         if(sdi->js2!=sdj->js2||sdi->ks1!=sdj->ks1||sdi->ks2!=sdj->ks2)continue;
-        if(sdj->vec_comp==1)vd->iu=sdj-slicecoll.sliceinfo;
-        if(sdj->vec_comp==2)vd->iv=sdj-slicecoll.sliceinfo;
-        if(sdj->vec_comp==3)vd->iw=sdj-slicecoll.sliceinfo;
+        if(sdj->vec_comp==1)vd->iu=sdj-global_scase.slicecoll.sliceinfo;
+        if(sdj->vec_comp==2)vd->iv=sdj-global_scase.slicecoll.sliceinfo;
+        if(sdj->vec_comp==3)vd->iw=sdj-global_scase.slicecoll.sliceinfo;
       }
     }
     else if(vd->vslice_filetype == SLICE_GEOM){
@@ -2719,9 +2719,9 @@ void *UpdateVSlices(void *arg){
         if(sdi->blocknumber!=sdj->blocknumber)continue;
         if(sdi->is1!=sdj->is1||sdi->is2!=sdj->is2||sdi->js1!=sdj->js1)continue;
         if(sdi->js2!=sdj->js2||sdi->ks1!=sdj->ks1||sdi->ks2!=sdj->ks2)continue;
-        if(sdj->vec_comp==1)vd->iu=sdj-slicecoll.sliceinfo;
-        if(sdj->vec_comp==2)vd->iv=sdj-slicecoll.sliceinfo;
-        if(sdj->vec_comp==3)vd->iw=sdj-slicecoll.sliceinfo;
+        if(sdj->vec_comp==1)vd->iu=sdj-global_scase.slicecoll.sliceinfo;
+        if(sdj->vec_comp==2)vd->iv=sdj-global_scase.slicecoll.sliceinfo;
+        if(sdj->vec_comp==3)vd->iw=sdj-global_scase.slicecoll.sliceinfo;
       }
     }
     else{
@@ -2733,9 +2733,9 @@ void *UpdateVSlices(void *arg){
         if(sdi->blocknumber != sdj->blocknumber)continue;
         if(sdi->is1 != sdj->is1 || sdi->is2 != sdj->is2 || sdi->js1 != sdj->js1)continue;
         if(sdi->js2 != sdj->js2 || sdi->ks1 != sdj->ks1 || sdi->ks2 != sdj->ks2)continue;
-        if(sdj->vec_comp == 1)vd->iu = sdj-slicecoll.sliceinfo;
-        if(sdj->vec_comp == 2)vd->iv = sdj-slicecoll.sliceinfo;
-        if(sdj->vec_comp == 3)vd->iw = sdj-slicecoll.sliceinfo;
+        if(sdj->vec_comp == 1)vd->iu = sdj-global_scase.slicecoll.sliceinfo;
+        if(sdj->vec_comp == 2)vd->iv = sdj-global_scase.slicecoll.sliceinfo;
+        if(sdj->vec_comp == 3)vd->iw = sdj-global_scase.slicecoll.sliceinfo;
       }
     }
     if(vd->iu!=-1||vd->iv!=-1||vd->iw!=-1){
@@ -2755,38 +2755,38 @@ void *UpdateVSlices(void *arg){
     vslicedata *vsd;
     multivslicedata *mvslicei;
 
-    FREEMEMORY(vsliceorderindex);
-    NewMemory((void **)&vsliceorderindex,sizeof(int)*sp->nvsliceinfo);
+    FREEMEMORY(global_scase.vsliceorderindex);
+    NewMemory((void **)&global_scase.vsliceorderindex,sizeof(int)*sp->nvsliceinfo);
     for(i=0;i<sp->nvsliceinfo;i++){
-      vsliceorderindex[i]=i;
+      global_scase.vsliceorderindex[i]=i;
     }
-    qsort( (int *)vsliceorderindex, (size_t)sp->nvsliceinfo, sizeof(int), VSliceCompare );
+    qsort( (int *)global_scase.vsliceorderindex, (size_t)sp->nvsliceinfo, sizeof(int), VSliceCompare );
 
     for(i=0;i<sp->nmultivsliceinfo;i++){
-      mvslicei = slicecoll.multivsliceinfo + i;
+      mvslicei = global_scase.slicecoll.multivsliceinfo + i;
       FREEMEMORY(mvslicei->ivslices);
     }
-    FREEMEMORY(slicecoll.multivsliceinfo);
+    FREEMEMORY(global_scase.slicecoll.multivsliceinfo);
     sp->nmultivsliceinfo=0;
 
-    NewMemory((void **)&slicecoll.multivsliceinfo,sizeof(multislicedata)*sp->nvsliceinfo);
+    NewMemory((void **)&global_scase.slicecoll.multivsliceinfo,sizeof(multislicedata)*sp->nvsliceinfo);
 
     sp->nmultivsliceinfo=1;
-    mvslicei = slicecoll.multivsliceinfo;
+    mvslicei = global_scase.slicecoll.multivsliceinfo;
     mvslicei->ivslices=NULL;
     NewMemory((void **)&mvslicei->ivslices,sizeof(int)*sp->nvsliceinfo);
     mvslicei->nvslices=1;
-    vsd = slicecoll.vsliceinfo + vsliceorderindex[0];
-    mvslicei->ivslices[0] = vsliceorderindex[0];
-    mvslicei->mvslicefile_labelindex=slicecoll.sliceinfo[vsd->ival].slicefile_labelindex;
+    vsd = global_scase.slicecoll.vsliceinfo + global_scase.vsliceorderindex[0];
+    mvslicei->ivslices[0] = global_scase.vsliceorderindex[0];
+    mvslicei->mvslicefile_labelindex=global_scase.slicecoll.sliceinfo[vsd->ival].slicefile_labelindex;
     for(i=1;i<sp->nvsliceinfo;i++){
       slicedata *sd, *sdold;
       vslicedata *vsdold;
 
-      vsdold = slicecoll.vsliceinfo + vsliceorderindex[i - 1];
-      sdold = slicecoll.sliceinfo + vsdold->ival;
-      vsd = slicecoll.vsliceinfo + vsliceorderindex[i];
-      sd = slicecoll.sliceinfo + vsd->ival;
+      vsdold = global_scase.slicecoll.vsliceinfo + global_scase.vsliceorderindex[i - 1];
+      sdold = global_scase.slicecoll.sliceinfo + vsdold->ival;
+      vsd = global_scase.slicecoll.vsliceinfo + global_scase.vsliceorderindex[i];
+      sd = global_scase.slicecoll.sliceinfo + vsd->ival;
       if(NewMultiSlice(sdold,sd)==1){
         sp->nmultivsliceinfo++;
         mvslicei++;
@@ -2796,7 +2796,7 @@ void *UpdateVSlices(void *arg){
         NewMemory((void **)&mvslicei->ivslices,sizeof(int)*sp->nvsliceinfo);
       }
       mvslicei->nvslices++;
-      mvslicei->ivslices[mvslicei->nvslices-1]=vsliceorderindex[i];
+      mvslicei->ivslices[mvslicei->nvslices-1]=global_scase.vsliceorderindex[i];
     }
 
     // define sequence id's for auto file loading
@@ -2806,8 +2806,8 @@ void *UpdateVSlices(void *arg){
       slicedata *sliceval;
       int seq_id;
 
-      vslicei = slicecoll.vsliceinfo + i;
-      sliceval = slicecoll.sliceinfo + vslicei->ival;
+      vslicei = global_scase.slicecoll.vsliceinfo + i;
+      sliceval = global_scase.slicecoll.sliceinfo + vslicei->ival;
       seq_id=-1;
       if(vslicei->ival>=0)seq_id = sliceval->seq_id;
       vslicei->seq_id=seq_id;
@@ -2837,12 +2837,12 @@ void *UpdateVSlices(void *arg){
 void UpdateVSliceBoundIndexes(void){
   int i;
 
-  for(i=0;i<slicecoll.nvsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
     vslicedata *vd;
     slicedata *val;
 
-    vd = slicecoll.vsliceinfo+i;
-    val = slicecoll.sliceinfo + vd->ival;
+    vd = global_scase.slicecoll.vsliceinfo+i;
+    val = global_scase.slicecoll.sliceinfo + vd->ival;
     vd->vslicefile_labelindex= GetSliceBoundsIndex(val);
   }
 }
@@ -2861,7 +2861,7 @@ void UpdateSliceContours(int slice_type_index, float line_min, float line_max, i
   }
 
   sb = slicebounds + slice_type_index;
-  for(j=0;j<slicecoll.nsliceinfo;j++){
+  for(j=0;j<global_scase.slicecoll.nsliceinfo;j++){
     slicedata *sd;
     meshdata *meshi;
     int nx, ny, nz;
@@ -2871,7 +2871,7 @@ void UpdateSliceContours(int slice_type_index, float line_min, float line_max, i
     float constval;
     int i;
 
-    sd = slicecoll.sliceinfo + j;
+    sd = global_scase.slicecoll.sliceinfo + j;
     if(sd->loaded==0)continue;
 
     slice_type_j = GetSliceBoundsIndex(sd);
@@ -2906,7 +2906,7 @@ void UpdateSliceContours(int slice_type_index, float line_min, float line_max, i
       if(val_index>255)val_index=255;
       sd->rgb_slice_ptr[i]=&rgb_full[val_index][0];
     }
-    meshi = meshinfo + sd->blocknumber;
+    meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
 
     xplt=meshi->xplt;
     yplt=meshi->yplt;
@@ -2995,10 +2995,10 @@ void UpdateSliceContours(int slice_type_index, float line_min, float line_max, i
 void UpdateSliceBoundIndexes(void){
   int i;
 
-  for(i=0;i<slicecoll.nsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
     slicedata *sd;
 
-    sd = slicecoll.sliceinfo+i;
+    sd = global_scase.slicecoll.sliceinfo+i;
     sd->slicefile_labelindex= GetSliceBoundsIndex(sd);
   }
 }
@@ -3037,12 +3037,12 @@ int GetSliceBoundsIndexFromLabel(char *label){
 void UpdateSliceBoundLabels(){
   int i;
 
-  for(i=0;i<slicecoll.nsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
     int j;
     boundsdata *sb;
     slicedata *sd;
 
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     j = GetSliceBoundsIndex(sd);
     sb = slicebounds + j;
     sb->label=&(sd->label);
@@ -3079,7 +3079,7 @@ void GetSliceDataBounds(slicedata *sd, float *pmin, float *pmax){
     }
     return;
   }
-  meshi = meshinfo + sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
   iblank_node = meshi->c_iblank_node;
   iblank_cell = meshi->c_iblank_cell;
 
@@ -3102,7 +3102,7 @@ void GetSliceDataBounds(slicedata *sd, float *pmin, float *pmax){
       for(k=0;k<sd->nslicek;k++){
         n++;
         if(sd->slice_filetype==SLICE_CELL_CENTER&&((k==0&&sd->nslicek!=1)||(j==0&&sd->nslicej!=1)||(i==0&&sd->nslicei!=1)))continue;
-        if(show_slice_in_obst == ONLY_IN_GAS){
+        if(global_scase.show_slice_in_obst == ONLY_IN_GAS){
           if(sd->slice_filetype!=SLICE_CELL_CENTER&& iblank_node!=NULL){
             if(iblank_node[IJKNODE(sd->is1+i, sd->js1+j, sd->ks1+k)]==SOLID)continue;
           }
@@ -3779,25 +3779,25 @@ void HideSlices(char *longlabel){
 
   if(longlabel==NULL)return;
   len = strlen(longlabel);
-  for(i = 0; i<slicecoll.nvsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nvsliceinfo; i++){
     vslicedata *vslicei;
 
-    vslicei = slicecoll.vsliceinfo+i;
+    vslicei = global_scase.slicecoll.vsliceinfo+i;
     if(vslicei->display==1){
       char *label2;
       int len2;
 
-      label2 = slicecoll.sliceinfo[vslicei->ival].label.longlabel;
+      label2 = global_scase.slicecoll.sliceinfo[vslicei->ival].label.longlabel;
       len2 = strlen(label2);
       if(strncmp(label2, longlabel, MIN(len, len2))!=0){
         vslicei->display = 0;
       }
     }
   }
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     if(slicei->display==1){
       char *label2;
       int len2;
@@ -3871,12 +3871,12 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
   error = 0;
   show_slice_average = 0;
   slicefilenumber = ifile;
-  assert(slicefilenumber>=0&&slicefilenumber<slicecoll.nsliceinfo);
+  assert(slicefilenumber>=0&&slicefilenumber<global_scase.slicecoll.nsliceinfo);
   slicefilenum = ifile;
-  sd = slicecoll.sliceinfo+slicefilenumber;
+  sd = global_scase.slicecoll.sliceinfo+slicefilenumber;
 
   blocknumber = sd->blocknumber;
-  meshi = meshinfo + blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + blocknumber;
 
   if(load_flag != RESETBOUNDS){
     if(sd->loaded == 0 && load_flag == UNLOAD)return 0;
@@ -3926,7 +3926,7 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
         int i;
 
         i = slice_loaded_list[ii];
-        sdi = slicecoll.sliceinfo + i;
+        sdi = global_scase.slicecoll.sliceinfo + i;
         if(sdi->volslice == 1)ReadVolSlice = 1;
       }
       for(ii = 0; ii<nslice_loaded; ii++){
@@ -3934,7 +3934,7 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
       	int i;
 
         i = slice_loaded_list[ii];
-        sdi = slicecoll.sliceinfo + i;
+        sdi = global_scase.slicecoll.sliceinfo + i;
         if(sdi->slicefile_labelindex == slicefile_labelindex){
           slicefilenum = i;
           flag2 = 1;
@@ -3947,7 +3947,7 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
           int i;
 
           i = slice_loaded_list[ii];
-          sdi = slicecoll.sliceinfo + i;
+          sdi = global_scase.slicecoll.sliceinfo + i;
           if(sdi->slicefile_labelindex != slicefile_labelindex){
             slicefilenum = i;
             flag2 = 1;
@@ -3961,8 +3961,8 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
       }
 
       int i;
-      for(i = 0; i<slicecoll.nvsliceinfo; i++){
-        vd = slicecoll.vsliceinfo + i;
+      for(i = 0; i<global_scase.slicecoll.nvsliceinfo; i++){
+        vd = global_scase.slicecoll.vsliceinfo + i;
         if(vd->iu == ifile)vd->u = NULL;
         if(vd->iv == ifile)vd->v = NULL;
         if(vd->iw == ifile)vd->w = NULL;
@@ -4012,13 +4012,13 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
 #ifndef pp_SLICEFRAME
       sd->ntimes_old = sd->ntimes;
       GetSliceSizes(file, time_frame, &sd->nslicei, &sd->nslicej, &sd->nslicek, &sd->ntimes, tload_step, &error,
-                    use_tload_begin, use_tload_end, tload_begin, tload_end, &headersize, &framesize);
+                    use_tload_begin, use_tload_end, global_scase.tload_begin, global_scase.tload_end, &headersize, &framesize);
 #endif
     }
     else if(sd->compression_type != UNCOMPRESSED){
       if(
         GetSliceHeader(sd->comp_file, sd->size_file, sd->compression_type,
-          tload_step, use_tload_begin, use_tload_end, tload_begin, tload_end,
+          tload_step, use_tload_begin, use_tload_end, global_scase.tload_begin, global_scase.tload_end,
           &sd->nslicei, &sd->nslicej, &sd->nslicek, &sd->ntimes, &sd->ncompressed, &sd->valmin_slice, &sd->valmax_slice) == 0){
         ReadSlice("", ifile, time_frame, time_value, UNLOAD, set_slicecolor, &error);
         *errorcode = 1;
@@ -4075,7 +4075,7 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
         return 0;
       }
       return_code=GetSliceCompressedData(sd->comp_file, sd->compression_type,
-        use_tload_begin, use_tload_end, tload_begin, tload_end, sd->ncompressed, tload_step, sd->ntimes,
+        use_tload_begin, use_tload_end, global_scase.tload_begin, global_scase.tload_end, sd->ncompressed, tload_step, sd->ntimes,
         sd->times, sd->qslicedata_compressed, sd->compindex, &sd->globalmin_slice, &sd->globalmax_slice);
       if(return_code == 0){
         ReadSlice("", ifile, time_frame, time_value, UNLOAD,  set_slicecolor, &error);
@@ -4119,7 +4119,7 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
 #else
         file_size = GetSliceData(sd, file, time_frame, &sd->is1, &sd->is2, &sd->js1, &sd->js2, &sd->ks1, &sd->ks2, &sd->idir,
             &qmin, &qmax, sd->qslicedata, sd->times, ntimes_slice_old, &sd->ntimes,
-            tload_step, use_tload_begin, use_tload_end, tload_begin, tload_end
+            tload_step, use_tload_begin, use_tload_end, global_scase.tload_begin, global_scase.tload_end
           );
 #endif
         MakeTimesMap(sd->times, &sd->times_map, sd->ntimes);
@@ -4183,10 +4183,10 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
     /* estimate the slice offset, the distance to move a slice so
     that it does not "interfere" with an adjacent block */
 
-    blocknumber = slicecoll.sliceinfo[ifile].blocknumber;
-    xplt_local = meshinfo[blocknumber].xplt;
-    yplt_local = meshinfo[blocknumber].yplt;
-    zplt_local = meshinfo[blocknumber].zplt;
+    blocknumber = global_scase.slicecoll.sliceinfo[ifile].blocknumber;
+    xplt_local = global_scase.meshescoll.meshinfo[blocknumber].xplt;
+    yplt_local = global_scase.meshescoll.meshinfo[blocknumber].yplt;
+    zplt_local = global_scase.meshescoll.meshinfo[blocknumber].zplt;
 
     xslicemid = (xplt_local[sd->is1] + xplt_local[sd->is2]) / 2.0;
     yslicemid = (yplt_local[sd->js1] + yplt_local[sd->js2]) / 2.0;
@@ -4304,10 +4304,10 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
     if(set_valmin != 0 || set_valmax != 0){
       int i;
 
-      for(i = 0;i < slicecoll.nsliceinfo;i++){
+      for(i = 0;i < global_scase.slicecoll.nsliceinfo;i++){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         if(slicei->loaded == 0 || strcmp(sd->label.shortlabel,slicei->label.shortlabel) != 0)continue;
         if(valmin_loaded > valmax_loaded){
           valmin_loaded = slicei->valmin_slice;
@@ -4349,11 +4349,11 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
       if(sd->compression_type==UNCOMPRESSED){
         int i;
 
-        for(i = 0; i<slicecoll.nsliceinfo; i++){
+        for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
           int ii;
           slicedata *slicei;
 
-          slicei = slicecoll.sliceinfo+i;
+          slicei = global_scase.slicecoll.sliceinfo+i;
           if(slicei->loaded==0)continue;
           if(slicei->vloaded==0&&slicei->display==0)continue;
           if(slicei->slicefile_labelindex!=slicefile_labelindex)continue;
@@ -4375,7 +4375,7 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
         sb->data_valmax = qmax;
 
         UpdateAllSliceLabels(slicefile_labelindex, errorcode);
-        MakeColorLabels(sb->colorlabels, sb->colorvalues, qmin, qmax, nrgb);
+        MakeColorLabels(sb->colorlabels, sb->colorvalues, qmin, qmax, global_scase.nrgb);
       }
     }
     if(sd->compression_type == COMPRESSED_ZLIB){
@@ -4477,7 +4477,7 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
   if(sd->volslice == 1){
     meshdata *meshj;
 
-    meshj = meshinfo + sd->blocknumber;
+    meshj = global_scase.meshescoll.meshinfo + sd->blocknumber;
 
     meshj->slice_min[0] = SMV2FDS_X(sd->xyz_min[0]);
     meshj->slice_min[1] = SMV2FDS_Y(sd->xyz_min[1]);
@@ -4496,7 +4496,7 @@ FILE_SIZE ReadSlice(const char *file, int ifile, int time_frame, float *time_val
   else{
     meshdata *meshj;
 
-    meshj = meshinfo + sd->blocknumber;
+    meshj = global_scase.meshescoll.meshinfo + sd->blocknumber;
     meshj->slice_min[0] = 1.0;
     meshj->slice_min[1] = 0.0;
     meshj->slice_min[2] = 1.0;
@@ -4608,7 +4608,7 @@ void DrawGSliceDataGpu(slicedata *slicei){
 
   if(slicei->loaded == 0 || slicei->display == 0 || slicei->volslice == 0)return;
 
-  meshi = meshinfo + slicei->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + slicei->blocknumber;
   verts = meshi->gsliceinfo->verts;
   triangles = meshi->gsliceinfo->triangles;
 
@@ -4617,7 +4617,7 @@ void DrawGSliceDataGpu(slicedata *slicei){
   UpdateSlice3DTexture(meshi, slicei, slicei->qsliceframe);
   glPushMatrix();
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
 
   if(cullfaces == 1)glDisable(GL_CULL_FACE);
   if(use_transparency_data == 1)TransparentOn();
@@ -4670,7 +4670,7 @@ void DrawVolSliceCellFaceCenter(const slicedata *sd, int is1, int is2, int js1, 
 
   rgb_ptr = rgb_slice;
 
-  meshi = meshinfo + sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
 
   float valmin, valmax;
 
@@ -4932,7 +4932,7 @@ void DrawVolSliceValues(slicedata *sd){
   int nx, ny, nxy;
   float *rgb_ptr;
 
-  meshi = meshinfo + sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
   xplttemp = meshi->xplt;
   yplttemp = meshi->yplt;
   zplttemp = meshi->zplt;
@@ -5104,7 +5104,7 @@ void DrawVolSliceCellFaceCenterValues(const slicedata *sd){
 
   meshdata *meshi;
 
-  meshi = meshinfo + sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
 
   xplt = meshi->xplt;
   yplt = meshi->yplt;
@@ -5328,7 +5328,7 @@ void DrawVolSliceTerrain(const slicedata *sd){
   meshdata *meshi;
 
   if(sd->have_agl_data==0)return;
-  meshi = meshinfo + sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
   if(meshi->in_frustum == 0)return;
   nycell = meshi->jbar;
 
@@ -5389,7 +5389,7 @@ void DrawVolSliceTerrain(const slicedata *sd){
 
     glPushMatrix();
     glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),vertical_factor*SCALE2SMV(1.0));
-    glTranslatef(-xbar0,-ybar0,-zbar0 + voffset);
+    glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0 + voffset);
 
     glBegin(GL_TRIANGLES);
     maxi = sd->is2;
@@ -5422,8 +5422,8 @@ void DrawVolSliceTerrain(const slicedata *sd){
         }
         if(draw123==0&&z31>=zmin&&z31<=zmax)draw123=1;
         if(draw134==0&&z13>=zmin&&z13<=zmax)draw134=1;
-        if(z11<zbar0||z31<zbar0||z33<zbar0)draw123=0;
-        if(z11<zbar0||z33<zbar0||z13<zbar0)draw134=0;
+        if(z11<global_scase.zbar0||z31<global_scase.zbar0||z33<global_scase.zbar0)draw123=0;
+        if(z11<global_scase.zbar0||z33<global_scase.zbar0||z13<global_scase.zbar0)draw134=0;
 
         if(draw123==0&&draw134==0)continue;
 
@@ -5495,7 +5495,7 @@ void DrawVolAllSlicesTextureDiag(const slicedata *sd, int direction){
   meshdata *meshi;
 
   if(sd->volslice == 1 && visx_all == 0 && visy_all == 0 && visz_all == 0)return;
-  meshi = meshinfo+sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo+sd->blocknumber;
 
   xplt = meshi->xplt;
   yplt = meshi->yplt;
@@ -5553,8 +5553,8 @@ void DrawVolAllSlicesTextureDiag(const slicedata *sd, int direction){
           float rmid, zmid;
 
           n++; n2++;ijk+=nxy;
-          if(show_slice_in_obst==ONLY_IN_SOLID && c_iblank_x != NULL&&c_iblank_x[ijk]==GASGAS)continue;
-          if(show_slice_in_obst==ONLY_IN_GAS   && c_iblank_x != NULL&&c_iblank_x[ijk]!=GASGAS)continue;
+          if(global_scase.show_slice_in_obst==ONLY_IN_SOLID && c_iblank_x != NULL&&c_iblank_x[ijk]==GASGAS)continue;
+          if(global_scase.show_slice_in_obst==ONLY_IN_GAS   && c_iblank_x != NULL&&c_iblank_x[ijk]!=GASGAS)continue;
           if(skip_slice_in_embedded_mesh==1&&iblank_embed!=NULL&&iblank_embed[ijk]==EMBED_YES)continue;
           r11 = (float)sd->iqsliceframe[n] / 255.0;
           r31 = (float)sd->iqsliceframe[n2] / 255.0;
@@ -5623,8 +5623,8 @@ void DrawVolAllSlicesTextureDiag(const slicedata *sd, int direction){
 
         for(k = sd->ks1; k<sd->ks2; k++){
           n++; n2++; ijk+=nxy;
-          if(show_slice_in_obst==ONLY_IN_SOLID && c_iblank_y!=NULL&&c_iblank_y[ijk]==GASGAS)continue;
-          if(show_slice_in_obst==ONLY_IN_GAS   && c_iblank_y!=NULL&&c_iblank_y[ijk]!=GASGAS)continue;
+          if(global_scase.show_slice_in_obst==ONLY_IN_SOLID && c_iblank_y!=NULL&&c_iblank_y[ijk]==GASGAS)continue;
+          if(global_scase.show_slice_in_obst==ONLY_IN_GAS   && c_iblank_y!=NULL&&c_iblank_y[ijk]!=GASGAS)continue;
           if(skip_slice_in_embedded_mesh==1&&iblank_embed!=NULL&&iblank_embed[ijk]==EMBED_YES)continue;
           r11 = (float)sd->iqsliceframe[n] / 255.0;
           r31 = (float)sd->iqsliceframe[n2] / 255.0;
@@ -5692,7 +5692,7 @@ void DrawVolSliceTexture(const slicedata *sd, int is1, int is2, int js1, int js2
     valmax = 1.0;
   }
   if(sd->volslice == 1 && visx_all == 0 && visy_all == 0 && visz_all == 0)return;
-  meshi = meshinfo + sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
 
   int slice_interp;
   int set_chopmin=0, set_chopmax=0;
@@ -6101,7 +6101,7 @@ void DrawVolSliceLines(const slicedata *sd){
   meshdata *meshi;
 
   if(sd->volslice==1&&visx_all==0&&visy_all==0&&visz_all==0)return;
-  meshi = meshinfo+sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo+sd->blocknumber;
 
   float valmin, valmax;
 
@@ -6438,7 +6438,7 @@ void DrawVolSliceVerts(const slicedata *sd){
   meshdata *meshi;
 
   if(sd->volslice==1&&visx_all==0&&visy_all==0&&visz_all==0)return;
-  meshi = meshinfo+sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo+sd->blocknumber;
 
   float valmin, valmax;
 
@@ -6780,8 +6780,8 @@ int CompareLoadedSliceList(const void *arg1, const void *arg2){
   float position_i, position_j;
   int dir;
 
-  slicei = slicecoll.sliceinfo + *(int *)arg1;
-  slicej = slicecoll.sliceinfo + *(int *)arg2;
+  slicei = global_scase.slicecoll.sliceinfo + *(int *)arg1;
+  slicej = global_scase.slicecoll.sliceinfo + *(int *)arg2;
   if(slicei->idir < slicej->idir)return -1;
   if(slicei->idir > slicej->idir)return 1;
   dir = slicei->idir - 1;
@@ -6882,7 +6882,7 @@ int GetSliceOffsetReg(slicedata *sd, float *xyz, float *device_xyz){
   int offset=0;
 
   memcpy(device_xyz, xyz, 3*sizeof(float));
-  slicemesh = meshinfo+sd->blocknumber;
+  slicemesh = global_scase.meshescoll.meshinfo+sd->blocknumber;
   xplt = slicemesh->xplt_orig;
   yplt = slicemesh->yplt_orig;
   zplt = slicemesh->zplt_orig;
@@ -7002,7 +7002,7 @@ int InSliceMesh(slicedata *slicei, float *xyz){
   meshdata *meshi;
   int plotx, ploty, plotz;
 
-  meshi = meshinfo + slicei->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + slicei->blocknumber;
   dir = slicei->idir;
   boxmin = meshi->boxmin;
   boxmax = meshi->boxmax;
@@ -7070,13 +7070,13 @@ void Slice2Device(void){
   int offsets[NOFFSETS*NOFFSETS*NOFFSETS];
 
   if(vis_slice_plot==0)return;
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     devicedata *sdev;
     int offset;
     float xyz[3], dxyz[3];
     int ii;
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     sdev = &(slicei->vals2d);
     sdev->valid = 0;
     if(slicei->loaded==0||slicei->ntimes==0)continue;
@@ -7180,11 +7180,11 @@ void Slice2Device(void){
     sb->dev_min = 1.0;
     sb->dev_max = 0.0;
 
-    for(j = 0; j<slicecoll.nsliceinfo; j++){
+    for(j = 0; j<global_scase.slicecoll.nsliceinfo; j++){
       slicedata *slicej;
       float valmin, valmax;
 
-      slicej = slicecoll.sliceinfo+j;
+      slicej = global_scase.slicecoll.sliceinfo+j;
       if(slicej->loaded==0||strcmp(sb->label->longlabel, slicej->label.longlabel)!=0)continue;
       if(slice_plot_bound_option==1){
         valmin = slicej->valmin_slice;
@@ -7207,12 +7207,12 @@ void Slice2Device(void){
       }
     }
   }
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     devicedata *sdev;
     float time_average;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     sdev = &(slicei->vals2d);
     if(slicei->loaded==0||slicei->ntimes==0)continue;
     if(InSliceMesh(slicei, slice_xyz)==0)continue;
@@ -7228,17 +7228,17 @@ void DrawSlicePlots(void){
   int i;
 
   if(show_plot2d_slice_position==0)return;
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     devicedata *devicei;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     devicei = &(slicei->vals2d);
     if(slicei->loaded==0||devicei->valid==0)continue;
 
     glPushMatrix();
     glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),vertical_factor*SCALE2SMV(1.0));
-    glTranslatef(-xbar0,-ybar0,-zbar0);
+    glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
     if(average_plot2d_slice_region==0||(slice_dxyz[0]<0.001&&slice_dxyz[1]<0.001&&slice_dxyz[2]<0.001)){
       glPointSize(10.0);
       glBegin(GL_POINTS);
@@ -7346,8 +7346,8 @@ void DrawSliceFrame(){
     DrawSlicePlots();
   }
 
-  if(use_tload_begin==1 && global_times[itimes]<tload_begin)return;
-  if(use_tload_end==1   && global_times[itimes]>tload_end)return;
+  if(use_tload_begin==1 && global_times[itimes]<global_scase.tload_begin)return;
+  if(use_tload_end==1   && global_times[itimes]>global_scase.tload_end)return;
   SortLoadedSliceList();
 
   if(sortslices==1){
@@ -7366,7 +7366,7 @@ void DrawSliceFrame(){
     int jjjj;
 
     i=slice_sorted_loaded_list[ii];
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     if(SetupSlice(sd) == 0)continue;
     IF_NOT_USEMESH_CONTINUE(USEMESH_DRAW,sd->blocknumber);
     orien = 0;
@@ -7381,7 +7381,7 @@ void DrawSliceFrame(){
       slice_normal[0] = 0.0;
       slice_normal[1] = 0.0;
       slice_normal[2] = 0.0;
-      slicemesh = meshinfo+sd->blocknumber;
+      slicemesh = global_scase.meshescoll.meshinfo+sd->blocknumber;
       if(slicemesh->smokedir<0)direction = -1;
       switch(ABS(slicemesh->smokedir)){
       case 4:  // -45 slope slices
@@ -7572,10 +7572,10 @@ void DrawSliceFrame(){
       glBlendEquation(GL_FUNC_ADD);
     }
   }
-  for(ii = 0; ii < npatchinfo; ii++){
+  for(ii = 0; ii < global_scase.npatchinfo; ii++){
     patchdata *patchi;
 
-    patchi = patchinfo + ii;
+    patchi = global_scase.patchinfo + ii;
     if(patchi->boundary==0 && patchi->loaded == 1 && patchi->display == 1){
       DrawGeomData(DRAW_TRANSPARENT, NULL, patchi, GEOM_STATIC);
       DrawGeomData(DRAW_TRANSPARENT, NULL, patchi, GEOM_DYNAMIC);
@@ -7597,8 +7597,8 @@ void DrawVVolSliceCellCenter(const vslicedata *vd){
   char *iblank_cell;
   int ibar, jbar;
 
-  sd = slicecoll.sliceinfo + vd->ival;
-  meshi = meshinfo + sd->blocknumber;
+  sd = global_scase.slicecoll.sliceinfo + vd->ival;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
   xplttemp = meshi->xplt;
   yplttemp = meshi->yplt;
   zplttemp = meshi->zplt;
@@ -8022,8 +8022,8 @@ void DrawVVolSliceTerrain(const vslicedata *vd){
   int nycell;
   int plotz;
 
-  sd = slicecoll.sliceinfo + vd->ival;
-  meshi = meshinfo + sd->blocknumber;
+  sd = global_scase.slicecoll.sliceinfo + vd->ival;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
   xplttemp = meshi->xplt;
   yplttemp = meshi->yplt;
   if(vd->volslice == 1){
@@ -8073,7 +8073,7 @@ void DrawVVolSliceTerrain(const vslicedata *vd){
 
     glPushMatrix();
     glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),vertical_factor*SCALE2SMV(1.0));
-    glTranslatef(-xbar0,-ybar0,-zbar0 + voffset);
+    glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0 + voffset);
 
     glLineWidth(vectorlinewidth);
 
@@ -8255,8 +8255,8 @@ void DrawVVolSlice(const vslicedata *vd){
   int nx, ny, nxy;
   float *rgb_ptr;
 
-  sd = slicecoll.sliceinfo + vd->ival;
-  meshi = meshinfo + sd->blocknumber;
+  sd = global_scase.slicecoll.sliceinfo + vd->ival;
+  meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
   xplttemp = meshi->xplt;
   yplttemp = meshi->yplt;
   zplttemp = meshi->zplt;
@@ -8569,22 +8569,22 @@ void DrawVVolSlice(const vslicedata *vd){
 void DrawVSliceFrame(void){
   int i;
 
-  if(use_tload_begin==1 && global_times[itimes]<tload_begin)return;
-  if(use_tload_end==1   && global_times[itimes]>tload_end)return;
-  for(i=0;i<slicecoll.nvsliceinfo;i++){
+  if(use_tload_begin==1 && global_times[itimes]<global_scase.tload_begin)return;
+  if(use_tload_end==1   && global_times[itimes]>global_scase.tload_end)return;
+  for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
     vslicedata *vd;
     slicedata *u, *v, *w, *val;
 
-    vd = slicecoll.vsliceinfo + i;
-    if(vd->loaded==0||vd->display==0||slicecoll.sliceinfo[vd->ival].slicefile_labelindex!=slicefile_labelindex)continue;
+    vd = global_scase.slicecoll.vsliceinfo + i;
+    if(vd->loaded==0||vd->display==0||global_scase.slicecoll.sliceinfo[vd->ival].slicefile_labelindex!=slicefile_labelindex)continue;
     val = vd->val;
     if(val==NULL)continue;
     u = vd->u;
     v = vd->v;
     w = vd->w;
     if(u==NULL&&v==NULL&&w==NULL)continue;
-    if(slicecoll.sliceinfo[vd->ival].times[0]>global_times[itimes])continue;
-    IF_NOT_USEMESH_CONTINUE(USEMESH_DRAW,slicecoll.sliceinfo[vd->ival].blocknumber);
+    if(global_scase.slicecoll.sliceinfo[vd->ival].times[0]>global_times[itimes])continue;
+    IF_NOT_USEMESH_CONTINUE(USEMESH_DRAW,global_scase.slicecoll.sliceinfo[vd->ival].blocknumber);
     if(vd->vslice_filetype!=SLICE_GEOM){
       if(val->compression_type!=UNCOMPRESSED){
         UncompressSliceDataFrame(val, val->itime);
@@ -8704,14 +8704,14 @@ void UpdateGslicePlanes(void){
   xyz0 = gslice_xyz;
 
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int j;
     float vals[8],xx[2],yy[2],zz[2];
     float *xyzmin, *xyzmax;
     float level;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
 
     xyzmin = meshi->slice_min;
     xyzmax = meshi->slice_max;
@@ -8744,19 +8744,19 @@ void DrawGSliceOutline(void){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
   glColor3fv(foregroundcolor);
 
   if(show_gslice_triangles==1){
     glBegin(GL_LINES);
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       int j;
       int *triangles;
       float *verts;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       verts = meshi->gsliceinfo->verts;
       triangles = meshi->gsliceinfo->triangles;
 
@@ -8780,14 +8780,14 @@ void DrawGSliceOutline(void){
   }
 
   if(show_gslice_triangulation==1){
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       int j;
       float del;
       int *triangles;
       float *verts;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       verts = meshi->gsliceinfo->verts;
       triangles = meshi->gsliceinfo->triangles;
 
@@ -8839,7 +8839,7 @@ void DrawGSliceData(slicedata *slicei){
 
   if(slicei->loaded==0||slicei->display==0||slicei->volslice==0)return;
 
-  meshi = meshinfo + slicei->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + slicei->blocknumber;
   verts = meshi->gsliceinfo->verts;
   triangles = meshi->gsliceinfo->triangles;
 
@@ -8850,7 +8850,7 @@ void DrawGSliceData(slicedata *slicei){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
   if(cullfaces==1)glDisable(GL_CULL_FACE);
   if(use_transparency_data==1)TransparentOn();
@@ -8895,11 +8895,11 @@ void DrawVGSliceData(vslicedata *vslicei){
   float *verts;
   int *triangles;
 
-  slicei = slicecoll.sliceinfo + vslicei->ival;
+  slicei = global_scase.slicecoll.sliceinfo + vslicei->ival;
 
   if(slicei->loaded==0/*||slicei->display==0*/||slicei->volslice==0)return;
 
-  meshi = meshinfo + slicei->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + slicei->blocknumber;
   verts = meshi->gsliceinfo->verts;
   triangles = meshi->gsliceinfo->triangles;
 
@@ -8910,7 +8910,7 @@ void DrawVGSliceData(vslicedata *vslicei){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
   if(cullfaces==1)glDisable(GL_CULL_FACE);
   if(use_transparency_data==1)TransparentOn();
@@ -8957,7 +8957,7 @@ void InitSliceData(void){
 
   for(ii = 0; ii < nslice_loaded; ii++){
     i = slice_loaded_list[ii];
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     if(sd->display == 0 || sd->slicefile_labelindex != slicefile_labelindex)continue;
     if(sd->times[0] > global_times[itimes])continue;
 
@@ -8975,7 +8975,7 @@ void InitSliceData(void){
     if(fileout == NULL)continue;
     fprintf(fileout, "%s\n", sd->label.longlabel);
     fprintf(fileout, "%s\n", sd->label.unit);
-    meshi = meshinfo + sd->blocknumber;
+    meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
 
     xplt = meshi->xplt_orig;
     yplt = meshi->yplt_orig;
@@ -9051,7 +9051,7 @@ void SliceData2Hist(slicedata *sd, float *xyz, float *dxyz, float time, float dt
   int nvals,ival;
   float *vals;
 
-  meshi = meshinfo+sd->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo+sd->blocknumber;
   xplt = meshi->xplt;
   yplt = meshi->yplt;
   zplt = meshi->zplt;
@@ -9164,19 +9164,19 @@ void GenerateSliceMenu(int option){
   int i;
   FILE *stream = NULL;
 
-  if(slicecoll.nsliceinfo==0)return;
+  if(global_scase.slicecoll.nsliceinfo==0)return;
 
   char *slicemenu_filename = GetUserConfigSubPath(".slcf");
 
   // if we can't write out to the slice menu file then abort
 
   nslicemenuinfo = 0;
-  NewMemory((void **)&slicemenuinfo, slicecoll.nsliceinfo*sizeof(slicemenudata));
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  NewMemory((void **)&slicemenuinfo, global_scase.slicecoll.nsliceinfo*sizeof(slicemenudata));
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     slicemenudata *slicemi;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     if(slicei->volslice==1)continue;
     if(IsSliceMenuDup(slicemenuinfo, nslicemenuinfo, slicei->label.longlabel, slicei->slcf_index, slicei->position_orig)==1)continue;
     slicemi = slicemenuinfo+nslicemenuinfo;
@@ -9345,28 +9345,28 @@ void SortSlices(void){
   int i;
   slicedata **slicex0, **slicey0, **slicez0;
 
-  if(slicex==NULL)NewMemory((void **)&slicex, slicecoll.nsliceinfo*sizeof(slicedata *));
-  if(slicey==NULL)NewMemory((void **)&slicey, slicecoll.nsliceinfo*sizeof(slicedata *));
-  if(slicez==NULL)NewMemory((void **)&slicez, slicecoll.nsliceinfo*sizeof(slicedata *));
+  if(slicex==NULL)NewMemory((void **)&slicex, global_scase.slicecoll.nsliceinfo*sizeof(slicedata *));
+  if(slicey==NULL)NewMemory((void **)&slicey, global_scase.slicecoll.nsliceinfo*sizeof(slicedata *));
+  if(slicez==NULL)NewMemory((void **)&slicez, global_scase.slicecoll.nsliceinfo*sizeof(slicedata *));
   nsplitsliceinfo = 0;
   slicex0 = slicex;
   slicey0 = slicey;
   slicez0 = slicez;
-  for(i = 0;i < nmeshes;i++){
+  for(i = 0;i < global_scase.meshescoll.nmeshes;i++){
     int j, nx, ny, nz;
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     meshi->slicex = slicex0;
     meshi->slicey = slicey0;
     meshi->slicez = slicez0;
     nx = 0;
     ny = 0;
     nz = 0;
-    for(j = 0;j < slicecoll.nsliceinfo;j++){
+    for(j = 0;j < global_scase.slicecoll.nsliceinfo;j++){
       slicedata *slicej;
 
-      slicej = slicecoll.sliceinfo + j;
+      slicej = global_scase.slicecoll.sliceinfo + j;
 
       if(slicej->loaded == 0 || slicej->blocknumber != i)continue;
       if(slicej->slice_filetype!=SLICE_NODE_CENTER&&
@@ -9415,13 +9415,13 @@ void SortSlices(void){
     nsplitsliceinfoMAX = nsplitsliceinfo;
   }
   nsplitsliceinfo = 0;
-  for(i = 0;i < nmeshes;i++){
+  for(i = 0;i < global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int ii, jj, kk;
     int is1, is2, js1, js2, ks1, ks2;
     slicedata **slicexx, **sliceyy, **slicezz;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
 
     slicexx = meshi->slicex;
     sliceyy = meshi->slicey;
@@ -9568,7 +9568,7 @@ void DrawSortSlicesDebug(void){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
   glLineWidth(4.0);
   glColor3f(0.0, 0.0, 0.0);

--- a/Source/smokeview/IOtour.c
+++ b/Source/smokeview/IOtour.c
@@ -18,8 +18,8 @@ void UpdateViewTour(void){
 
   viewalltours=1;
   viewanytours=0;
-  for(i=0;i<tourcoll.ntourinfo;i++){
-    touri = tourcoll.tourinfo + i;
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+    touri = global_scase.tourcoll.tourinfo + i;
     if(touri->display==0){
       viewalltours=0;
     }
@@ -35,9 +35,9 @@ void UpdateTourMenuLabels(void){
   int i;
   tourdata *touri;
 
-  if(tourcoll.ntourinfo>0){
-    for(i=0;i<tourcoll.ntourinfo;i++){
-      touri = tourcoll.tourinfo + i;
+  if(global_scase.tourcoll.ntourinfo>0){
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+      touri = global_scase.tourcoll.tourinfo + i;
       STRCPY(touri->menulabel,touri->label);
     }
   }
@@ -73,7 +73,7 @@ void DrawTours(void){
   tmp_tourcol_pathknots=tourcol_pathknots;
   if(tourcol_pathknots[0]<0.0)tmp_tourcol_pathknots=foregroundcolor;
 
-  if(selected_frame!=NULL)selectedtour_index = selected_tour-tourcoll.tourinfo;
+  if(selected_frame!=NULL)selectedtour_index = selected_tour-global_scase.tourcoll.tourinfo;
 
   if(edittour==1){
     tourdata *tour_sel;
@@ -84,14 +84,14 @@ void DrawTours(void){
       AntiAliasLine(ON);
       glColor3fv(tmp_tourcol_pathline);
       glBegin(GL_LINES);
-      for(i=0;i<tourcoll.ntourinfo;i++){
+      for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
         tourdata *touri;
         int j;
 
-        touri =tourcoll.tourinfo + i;
+        touri =global_scase.tourcoll.tourinfo + i;
         if(touri->display==0||touri->nkeyframes<=1||selectedtour_index==i)continue;
 
-        for(j=0;j<tourcoll.tour_ntimes-1;j++){
+        for(j=0;j<global_scase.tourcoll.tour_ntimes-1;j++){
           float xyz[3], xyz2[3], *times;
 
           times = touri->path_times;
@@ -107,16 +107,16 @@ void DrawTours(void){
 
     /* path line (selected)*/
 
-    tour_sel = tourcoll.tourinfo + selectedtour_index;
+    tour_sel = global_scase.tourcoll.tourinfo + selectedtour_index;
     if(selectedtour_index!=TOURINDEX_MANUAL&&tour_sel->display==1&&tour_sel->nkeyframes>1){
       int j;
       tourdata *touri;
 
       glColor3fv(tourcol_selectedpathline);
       glBegin(GL_LINES);
-      touri = tourcoll.tourinfo + selectedtour_index;
+      touri = global_scase.tourcoll.tourinfo + selectedtour_index;
 
-      for(j=0;j<tourcoll.tour_ntimes-1;j++){
+      for(j=0;j<global_scase.tourcoll.tour_ntimes-1;j++){
         float xyz[3], xyz2[3], *times;
 
         times = touri->path_times;
@@ -134,14 +134,14 @@ void DrawTours(void){
       glColor3f(0.0f,0.0f,1.0f);
       glPointSize(5.0f);
       glBegin(GL_POINTS);
-      for(i=0;i<tourcoll.ntourinfo;i++){
+      for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
         int j;
         tourdata *touri;
 
-        touri = tourcoll.tourinfo + i;
+        touri = global_scase.tourcoll.tourinfo + i;
         if(touri->display==0||selectedtour_index!=i)continue;
 
-        for(j=0;j<tourcoll.tour_ntimes-1;j++){
+        for(j=0;j<global_scase.tourcoll.tour_ntimes-1;j++){
         float xyz[3], *times;
 
         times = touri->path_times;
@@ -178,11 +178,11 @@ void DrawTours(void){
       glColor3fv(tmp_tourcol_pathknots);
       glPointSize(10.0f);
       glBegin(GL_POINTS);
-      for(i=0;i<tourcoll.ntourinfo;i++){
+      for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
         int j;
         tourdata *touri;
 
-        touri = tourcoll.tourinfo + i;
+        touri = global_scase.tourcoll.tourinfo + i;
         if(touri->display==0||i==selectedtour_index)continue;
 
         for(j=0;j<touri->nkeyframes;j++){
@@ -218,11 +218,11 @@ void DrawTours(void){
     CheckMemory;
 
     if(fontindex==SCALED_FONT)ScaleFont3D();
-    for(i=0;i<tourcoll.ntourinfo;i++){
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
       int j;
       tourdata *touri;
 
-      touri = tourcoll.tourinfo + i;
+      touri = global_scase.tourcoll.tourinfo + i;
       if(touri->display==0)continue;
       if(showtours_whenediting==0&&selectedtour_index!=i)continue;
 
@@ -256,9 +256,9 @@ void DrawTours(void){
         AntiAliasLine(ON);
         glBegin(GL_LINES);
         glColor3fv(tourcol_avatar);
-        for(i=0;i<tourcoll.ntourinfo;i++){
+        for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
           tourdata *touri;
-          touri = tourcoll.tourinfo + i;
+          touri = global_scase.tourcoll.tourinfo + i;
           if(touri->display==0||touri->nkeyframes<=1)continue;
           if(touri->timeslist==NULL)continue;
 
@@ -277,10 +277,10 @@ void DrawTours(void){
         AntiAliasLine(OFF);
         break;
       case 1:
-        for(i=0;i<tourcoll.ntourinfo;i++){
+        for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
           tourdata *touri;
 
-          touri = tourcoll.tourinfo + i;
+          touri = global_scase.tourcoll.tourinfo + i;
           if(touri->display==0||touri->nkeyframes<=1)continue;
           if(touri->timeslist==NULL)continue;
 
@@ -292,11 +292,11 @@ void DrawTours(void){
         }
         break;
       case 2:
-        for(i=0;i<tourcoll.ntourinfo;i++){
+        for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
           tourdata *touri;
           float az_angle, dxy[2];
 
-          touri = tourcoll.tourinfo + i;
+          touri = global_scase.tourcoll.tourinfo + i;
           if(touri->display==0||touri->nkeyframes<=1)continue;
           if(touri->timeslist==NULL)continue;
 
@@ -320,7 +320,7 @@ void DrawTours(void){
 
           glRotatef(az_angle,0.0,0.0,1.0);
 
-          DrawSmvObject(objectscoll->avatar_types[touri->glui_avatar_index],0,NULL,0,NULL,0);
+          DrawSmvObject(global_scase.objectscoll.avatar_types[touri->glui_avatar_index],0,NULL,0,NULL,0);
           glPopMatrix();
         }
         break;
@@ -342,8 +342,8 @@ void DrawSelectTours(void){
 
   glPointSize(20.0f);
   glBegin(GL_POINTS);
-  for(i=0;i<tourcoll.ntourinfo;i++){
-    touri = tourcoll.tourinfo + i;
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+    touri = global_scase.tourcoll.tourinfo + i;
     for(j=0;j<touri->nkeyframes;j++){
 
       if(showtours_whenediting==1||selectedtour_index==i){
@@ -483,7 +483,7 @@ void GetTourProperties(tourdata *touri){
     touri->global_dist += dist;
   }
   thiskey = (touri->first_frame).next;
-  thiskey->time = tourcoll.tour_tstart;
+  thiskey->time = global_scase.tourcoll.tour_tstart;
   float cum_dist = 0.0;
   int cum_npoints = 0;
   float *tour_times, *xyzs, *views, total_distance;
@@ -507,18 +507,18 @@ void GetTourProperties(tourdata *touri){
       break;
     }
 
-    npoints_i = tourcoll.tour_ntimes*(thiskey->arc_dist/touri->global_dist);
+    npoints_i = global_scase.tourcoll.tour_ntimes*(thiskey->arc_dist/touri->global_dist);
     cum_npoints += npoints_i;
     if(nextkey->next==NULL){
-      npoints_i   += (tourcoll.tour_ntimes-cum_npoints);
-      cum_npoints += (tourcoll.tour_ntimes-cum_npoints);
+      npoints_i   += (global_scase.tourcoll.tour_ntimes-cum_npoints);
+      cum_npoints += (global_scase.tourcoll.tour_ntimes-cum_npoints);
     }
     thiskey->npoints = npoints_i;
     cum_dist       += thiskey->arc_dist;
-    nextkey->time   = tourcoll.tour_tstart + thiskey->cum_pause_time + (tourcoll.tour_tstop-total_pause_time-tourcoll.tour_tstart)*(cum_dist/touri->global_dist);
+    nextkey->time   = global_scase.tourcoll.tour_tstart + thiskey->cum_pause_time + (global_scase.tourcoll.tour_tstop-total_pause_time-global_scase.tourcoll.tour_tstart)*(cum_dist/touri->global_dist);
   }
 
-  (touri->last_frame).prev->time = tourcoll.tour_tstop;
+  (touri->last_frame).prev->time = global_scase.tourcoll.tour_tstop;
 
   for(thiskey = (touri->first_frame).next, j = 0; thiskey->next!=NULL; thiskey = thiskey->next, j++){
     touri->keyframe_list[j]  = thiskey;
@@ -528,16 +528,16 @@ void GetTourProperties(tourdata *touri){
   touri->nkeyframes = j;
 
 
-  NewMemory((void **)&(tour_times), tourcoll.tour_ntimes*sizeof(float));
-  NewMemory((void **)&(xyzs),       3*tourcoll.tour_ntimes*sizeof(float));
-  NewMemory((void **)&(views),      3*tourcoll.tour_ntimes*sizeof(float));
+  NewMemory((void **)&(tour_times), global_scase.tourcoll.tour_ntimes*sizeof(float));
+  NewMemory((void **)&(xyzs),       3*global_scase.tourcoll.tour_ntimes*sizeof(float));
+  NewMemory((void **)&(views),      3*global_scase.tourcoll.tour_ntimes*sizeof(float));
 
-  for(j=0;j<tourcoll.tour_ntimes;j++){
+  for(j=0;j<global_scase.tourcoll.tour_ntimes;j++){
     float f1, vtime;
 
     f1 = 0.0;
-    if(tourcoll.tour_ntimes>1)f1 = (float)j/(float)(tourcoll.tour_ntimes - 1);
-    vtime                = tourcoll.tour_tstart*(1.0-f1) + tourcoll.tour_tstop*f1;
+    if(global_scase.tourcoll.tour_ntimes>1)f1 = (float)j/(float)(global_scase.tourcoll.tour_ntimes - 1);
+    vtime                = global_scase.tourcoll.tour_tstart*(1.0-f1) + global_scase.tourcoll.tour_tstop*f1;
     tour_times[j]        = vtime;
     touri->path_times[j] = vtime;
     {
@@ -555,9 +555,9 @@ void GetTourProperties(tourdata *touri){
       }
     }
   }
-  total_distance = tour_times[tourcoll.tour_ntimes-1];
-  for(j=0;j<tourcoll.tour_ntimes;j++){
-    tour_times[j] = tourcoll.tour_tstart + tour_times[j]*(tourcoll.tour_tstop - tourcoll.tour_tstart)/total_distance;
+  total_distance = tour_times[global_scase.tourcoll.tour_ntimes-1];
+  for(j=0;j<global_scase.tourcoll.tour_ntimes;j++){
+    tour_times[j] = global_scase.tourcoll.tour_tstart + tour_times[j]*(global_scase.tourcoll.tour_tstop - global_scase.tourcoll.tour_tstart)/total_distance;
   }
   FREEMEMORY(tour_times);
   FREEMEMORY(xyzs);
@@ -576,14 +576,14 @@ void CreateTourPaths(void){
   printf("updating tour path\n");
 #endif
   ntourknots=0;
-  if(tourcoll.ntourinfo==0)return;
+  if(global_scase.tourcoll.ntourinfo==0)return;
 
-  for(i=0;i<tourcoll.ntourinfo;i++){
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
     tourdata *touri;
     keyframe *keyj;
     int nframes;
 
-    touri = tourcoll.tourinfo + i;
+    touri = global_scase.tourcoll.tourinfo + i;
     nframes=0;
     for(keyj=(touri->first_frame).next;keyj->next!=NULL;keyj=keyj->next){
       ntourknots++;
@@ -628,12 +628,12 @@ void CreateTourPaths(void){
 
   tourknotskeylist_copy=tourknotskeylist;
   tourknotstourlist_copy=tourknotstourlist;
-  for(i = 0; i<tourcoll.ntourinfo; i++){
+  for(i = 0; i<global_scase.tourcoll.ntourinfo; i++){
     tourdata *touri;
     keyframe *keyj;
     int j;
 
-    touri = tourcoll.tourinfo+i;
+    touri = global_scase.tourcoll.tourinfo+i;
     for(keyj = (touri->first_frame).next, j = 0; keyj->next!=NULL; keyj = keyj->next, j++){
       FDS2SMV_XYZ(keyj->xyz_smv, keyj->xyz_fds);
     }
@@ -703,18 +703,18 @@ void CreateTourPaths(void){
   }
 
   // get tour properties
-  for(i = 0; i<tourcoll.ntourinfo; i++){
+  for(i = 0; i<global_scase.tourcoll.ntourinfo; i++){
     tourdata *touri;
 
-    touri = tourcoll.tourinfo+i;
+    touri = global_scase.tourcoll.tourinfo+i;
     GetTourProperties(touri);
   }
 
-  for(i = 0; i<tourcoll.ntourinfo; i++){
+  for(i = 0; i<global_scase.tourcoll.ntourinfo; i++){
     tourdata *touri;
     keyframe *keyj;
 
-    touri = tourcoll.tourinfo+i;
+    touri = global_scase.tourcoll.tourinfo+i;
 
     for(keyj = (touri->first_frame).next; keyj->next!=NULL; keyj = keyj->next){
       float denom, view_smv[3];
@@ -830,16 +830,16 @@ void SetupCircularTourNodes(void){
   float dx, dy, dz, max_xyz;
   int i;
 
-  tour_circular_view[0]=(xbar0+xbarORIG)/2.0;
-  tour_circular_view[1]=(ybar0+ybarORIG)/2.0;
-  tour_circular_view[2]=(zbar0+zbarORIG)/2.0;
+  tour_circular_view[0]=(global_scase.xbar0+xbarORIG)/2.0;
+  tour_circular_view[1]=(global_scase.ybar0+ybarORIG)/2.0;
+  tour_circular_view[2]=(global_scase.zbar0+zbarORIG)/2.0;
   tour_circular_center[0]=tour_circular_view[0];
   tour_circular_center[1]=tour_circular_view[1];
   tour_circular_center[2]=tour_circular_view[2];
 
-  dx = ABS(xbarORIG - xbar0)/2.0;
-  dy = ABS(ybarORIG - ybar0)/2.0;
-  dz = ABS(zbarORIG-zbar0)/2.0;
+  dx = ABS(xbarORIG - global_scase.xbar0)/2.0;
+  dy = ABS(ybarORIG - global_scase.ybar0)/2.0;
+  dz = ABS(zbarORIG-global_scase.zbar0)/2.0;
   max_xyz=MAX(dx,dy);
   max_xyz=MAX(max_xyz,dz);
   tour_circular_radius = max_xyz+max_xyz/tan(20.0*DEG2RAD);
@@ -865,14 +865,14 @@ void InitCircularTour(tourdata *touri, int nkeyframes, int option){
     FREEMEMORY(touri->keyframe_times);
     FREEMEMORY(touri->path_times);
   }
-  InitTour(&tourcoll, touri);
+  InitTour(&global_scase.tourcoll, touri);
   touri->isDefault=1;
   touri->startup=1;
   touri->periodic=1;
-  tour_circular_index = touri - tourcoll.tourinfo;
+  tour_circular_index = touri - global_scase.tourcoll.tourinfo;
   strcpy(touri->label,"Circular");
   NewMemory((void **)&touri->keyframe_times, nkeyframes*sizeof(float));
-  NewMemory((void **)&touri->path_times,tourcoll.tour_ntimes*sizeof(float));
+  NewMemory((void **)&touri->path_times,global_scase.tourcoll.tour_ntimes*sizeof(float));
   key_view[0]=tour_circular_view[0];
   key_view[1]=tour_circular_view[1];
   key_view[2]=tour_circular_view[2];
@@ -903,7 +903,7 @@ void InitCircularTour(tourdata *touri, int nkeyframes, int option){
     else{
       f1 = (float)j / (float)(nkeyframes - 1);
     }
-    key_time = tourcoll.tour_tstart*(1.0-f1) + tourcoll.tour_tstop*f1;
+    key_time = global_scase.tourcoll.tour_tstart*(1.0-f1) + global_scase.tourcoll.tour_tstop*f1;
 
     addedframe = AddFrame(thisframe, key_time, 0.0, key_xyz, key_view);
     thisframe=addedframe;
@@ -925,12 +925,12 @@ void ReverseTour(char *label){
   int i;
 
   if(label==NULL)return;
-  for(i = 0;i<tourcoll.ntourinfo;i++){
+  for(i = 0;i<global_scase.tourcoll.ntourinfo;i++){
     tourdata *tourj;
 
-    tourj = tourcoll.tourinfo+i;
+    tourj = global_scase.tourcoll.tourinfo+i;
     if(strcmp(tourj->label, label)==0){
-      tourreverse = tourcoll.tourinfo+i;
+      tourreverse = global_scase.tourcoll.tourinfo+i;
       break;
     }
   }
@@ -980,19 +980,19 @@ tourdata *AddTour(char *label){
   int itour=-1;
 
   GLUIDeleteTourList();
-  tourcoll.ntourinfo++;
-  NewMemory( (void **)&tourtemp, tourcoll.ntourinfo*sizeof(tourdata));
-  if(tourcoll.ntourinfo>1)memcpy(tourtemp,tourcoll.tourinfo,(tourcoll.ntourinfo-1)*sizeof(tourdata));
-  FREEMEMORY(tourcoll.tourinfo);
-  tourcoll.tourinfo=tourtemp;
-  touri = tourcoll.tourinfo + tourcoll.ntourinfo - 1;
+  global_scase.tourcoll.ntourinfo++;
+  NewMemory( (void **)&tourtemp, global_scase.tourcoll.ntourinfo*sizeof(tourdata));
+  if(global_scase.tourcoll.ntourinfo>1)memcpy(tourtemp,global_scase.tourcoll.tourinfo,(global_scase.tourcoll.ntourinfo-1)*sizeof(tourdata));
+  FREEMEMORY(global_scase.tourcoll.tourinfo);
+  global_scase.tourcoll.tourinfo=tourtemp;
+  touri = global_scase.tourcoll.tourinfo + global_scase.tourcoll.ntourinfo - 1;
 
-  InitTour(&tourcoll, touri);
+  InitTour(&global_scase.tourcoll, touri);
   if(label!=NULL){
-    for(i = 0;i<tourcoll.ntourinfo-1;i++){
+    for(i = 0;i<global_scase.tourcoll.ntourinfo-1;i++){
       tourdata *tourj;
 
-      tourj = tourcoll.tourinfo+i;
+      tourj = global_scase.tourcoll.tourinfo+i;
       if(strcmp(tourj->label, label)==0){
         itour = i;
         sprintf(touri->label, "Copy of %s", TrimFront(label));
@@ -1003,28 +1003,28 @@ tourdata *AddTour(char *label){
     if(itour==-1)label=NULL;
   }
   if(label==NULL){
-    sprintf(touri->label,"Tour %i",tourcoll.ntourinfo);
+    sprintf(touri->label,"Tour %i",global_scase.tourcoll.ntourinfo);
     nkeyframes=2;
   }
 
   NewMemory((void **)&touri->keyframe_times, nkeyframes*sizeof(float));
-  NewMemory((void **)&touri->path_times,tourcoll.tour_ntimes*sizeof(float));
+  NewMemory((void **)&touri->path_times,global_scase.tourcoll.tour_ntimes*sizeof(float));
 
   if(itour==-1){
     VEC3EQCONS(key_view,0.0);
 
-    key_xyz[0] = xbar0 - 1.0;
-    key_xyz[1] = ybar0 - 1.0;
-    key_xyz[2] = (zbar0 + zbarORIG)/2.0;
-    key_time = tourcoll.tour_tstart;
+    key_xyz[0] = global_scase.xbar0 - 1.0;
+    key_xyz[1] = global_scase.ybar0 - 1.0;
+    key_xyz[2] = (global_scase.zbar0 + zbarORIG)/2.0;
+    key_time = global_scase.tourcoll.tour_tstart;
     thisframe=&touri->first_frame;
     addedframe = AddFrame(thisframe, key_time, 0.0, key_xyz, key_view);
     touri->keyframe_times[0]=key_time;
 
     key_xyz[0] = xbarORIG + 1.0;
     key_xyz[1] = ybarORIG + 1.0;
-    key_xyz[2] = (zbar0 + zbarORIG)/2.0;
-    key_time = tourcoll.tour_tstop;
+    key_xyz[2] = (global_scase.zbar0 + zbarORIG)/2.0;
+    key_time = global_scase.tourcoll.tour_tstop;
     thisframe=addedframe;
     addedframe = AddFrame(thisframe, key_time, 0.0, key_xyz, key_view);
     touri->keyframe_times[1]=key_time;
@@ -1034,7 +1034,7 @@ tourdata *AddTour(char *label){
     tourdata *tourfrom;
     int first=1;
 
-    tourfrom = tourcoll.tourinfo+itour;
+    tourfrom = global_scase.tourcoll.tourinfo+itour;
 
     keylast=NULL;
     keyfrom = &(tourfrom->first_frame);
@@ -1059,14 +1059,14 @@ tourdata *AddTour(char *label){
   }
   touri->display=1;
 
-  for(i=0;i<tourcoll.ntourinfo;i++){
-    touri=tourcoll.tourinfo+i;
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+    touri=global_scase.tourcoll.tourinfo+i;
     touri->first_frame.next->prev=&touri->first_frame;
     touri->last_frame.prev->next=&touri->last_frame;
   }
   viewalltours=1;
-  for(i=0;i<tourcoll.ntourinfo;i++){
-    touri = tourcoll.tourinfo + i;
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+    touri = global_scase.tourcoll.tourinfo + i;
     if(touri->display==0)viewalltours=0;
   }
   updatemenu=1;
@@ -1075,7 +1075,7 @@ tourdata *AddTour(char *label){
   CreateTourPaths();
   UpdateTimes();
   GLUICreateTourList();
-  return tourcoll.tourinfo + tourcoll.ntourinfo-1;
+  return global_scase.tourcoll.tourinfo + global_scase.tourcoll.ntourinfo-1;
 }
 
 /* ------------------ DeleteTour  ------------------------ */
@@ -1085,36 +1085,36 @@ void DeleteTour(int tour_index){
   int i;
 
   GLUIDeleteTourList();
-  touri = tourcoll.tourinfo + tour_index;
+  touri = global_scase.tourcoll.tourinfo + tour_index;
   FreeTour(touri);
-  tourcoll.ntourinfo--;
-  if(tourcoll.ntourinfo>0){
-    NewMemory( (void **)&tourtemp, tourcoll.ntourinfo*sizeof(tourdata));
-    if(tour_index>0)memcpy(tourtemp,tourcoll.tourinfo,tour_index*sizeof(tourdata));
-    if(tour_index<tourcoll.ntourinfo)memcpy(tourtemp+tour_index,tourcoll.tourinfo+tour_index+1,(tourcoll.ntourinfo-tour_index)*sizeof(tourdata));
-    FREEMEMORY(tourcoll.tourinfo);
-    tourcoll.tourinfo=tourtemp;
-    for(i=0;i<tourcoll.ntourinfo;i++){
-      touri=tourcoll.tourinfo+i;
+  global_scase.tourcoll.ntourinfo--;
+  if(global_scase.tourcoll.ntourinfo>0){
+    NewMemory( (void **)&tourtemp, global_scase.tourcoll.ntourinfo*sizeof(tourdata));
+    if(tour_index>0)memcpy(tourtemp,global_scase.tourcoll.tourinfo,tour_index*sizeof(tourdata));
+    if(tour_index<global_scase.tourcoll.ntourinfo)memcpy(tourtemp+tour_index,global_scase.tourcoll.tourinfo+tour_index+1,(global_scase.tourcoll.ntourinfo-tour_index)*sizeof(tourdata));
+    FREEMEMORY(global_scase.tourcoll.tourinfo);
+    global_scase.tourcoll.tourinfo=tourtemp;
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+      touri=global_scase.tourcoll.tourinfo+i;
       touri->first_frame.next->prev=&touri->first_frame;
       touri->last_frame.prev->next=&touri->last_frame;
     }
   }
   viewalltours=1;
-  for(i=0;i<tourcoll.ntourinfo;i++){
-    touri = tourcoll.tourinfo + i;
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+    touri = global_scase.tourcoll.tourinfo + i;
     if(touri->display==0)viewalltours=0;
   }
-  if(tourcoll.ntourinfo==0){
+  if(global_scase.tourcoll.ntourinfo==0){
     viewalltours=0;
   }
   updatemenu=1;
   CreateTourPaths();
   selectedtour_index=tour_index-1;
   selectedtour_index_old=selectedtour_index;
-  if(tourcoll.ntourinfo>0){
+  if(global_scase.tourcoll.ntourinfo>0){
     if(selectedtour_index<0)selectedtour_index=0;
-    selected_tour=tourcoll.tourinfo+selectedtour_index;
+    selected_tour=global_scase.tourcoll.tourinfo+selectedtour_index;
     selected_frame=selected_tour->first_frame.next;
   }
   else{
@@ -1132,11 +1132,11 @@ void DeleteTour(int tour_index){
 
 void SetupTour(void){
 
-  if(tourcoll.ntourinfo==0){
-    ReallocTourMemory(&tourcoll);
-    tourcoll.ntourinfo=1;
-    NewMemory( (void **)&tourcoll.tourinfo, tourcoll.ntourinfo*sizeof(tourdata));
-    InitCircularTour(tourcoll.tourinfo,ncircletournodes,INIT);
+  if(global_scase.tourcoll.ntourinfo==0){
+    ReallocTourMemory(&global_scase.tourcoll);
+    global_scase.tourcoll.ntourinfo=1;
+    NewMemory( (void **)&global_scase.tourcoll.tourinfo, global_scase.tourcoll.ntourinfo*sizeof(tourdata));
+    InitCircularTour(global_scase.tourcoll.tourinfo,ncircletournodes,INIT);
     UpdateTourMenuLabels();
     CreateTourPaths();
     UpdateTimes();

--- a/Source/smokeview/IOvolsmoke.c
+++ b/Source/smokeview/IOvolsmoke.c
@@ -696,12 +696,12 @@ void GetFireEmission(float *smoke_tran, float *fire_emission, float dlength, flo
 void InitVolRenderSurface(int flag){
   int i;
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int ii;
     float dx, dy, dz;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     meshi->ivolbar=meshi->ibar*nongpu_vol_factor;
     meshi->jvolbar=meshi->jbar*nongpu_vol_factor;
     meshi->kvolbar=meshi->kbar*nongpu_vol_factor;
@@ -725,19 +725,19 @@ void InitVolRenderSurface(int flag){
     }
   }
   ijkbarmax=0;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     ijkbarmax=MAX(ijkbarmax,meshi->ivolbar);
     ijkbarmax=MAX(ijkbarmax,meshi->jvolbar);
     ijkbarmax=MAX(ijkbarmax,meshi->kvolbar);
   }
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     vr = meshi->volrenderinfo;
     if(flag==FIRSTCALL){
       vr->smokecolor_yz0=NULL;
@@ -939,11 +939,11 @@ meshdata *GetMinMesh(void){
 
   // find mesh closes to origin that is not already in a supermesh
 
-  for(i = 0;i<nmeshes;i++){
+  for(i = 0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     float dist2;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     if(meshi->super!=NULL)continue;
     dist2 = meshi->x0*meshi->x0+meshi->y0*meshi->y0+meshi->z0*meshi->z0;
     if(mindist<0.0||dist2<mindist){
@@ -987,7 +987,7 @@ int ExtendMesh(supermeshdata *smesh, int direction){
 void MakeSMesh(supermeshdata *smesh, meshdata *firstmesh){
   meshdata **meshptrs;
 
-  NewMemory((void **)&meshptrs, nmeshes*sizeof(meshdata *));
+  NewMemory((void **)&meshptrs, global_scase.meshescoll.nmeshes*sizeof(meshdata *));
   smesh->meshes = meshptrs;
 
   smesh->meshes[0] = firstmesh;
@@ -1057,18 +1057,18 @@ void *InitNabors(void *arg){
   int i;
 
   INIT_PRINT_TIMER(timer_init_nabors);
-  for(i = 0;i<nmeshes;i++){
+  for(i = 0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int j;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     meshi->is_bottom = IsBottomMesh(meshi);
-    for(j = 0;j<nmeshes;j++){
+    for(j = 0;j<global_scase.meshescoll.nmeshes;j++){
       meshdata *meshj;
 
       if(i==j)continue;
 
-      meshj = meshinfo+j;
+      meshj = global_scase.meshescoll.meshinfo+j;
 
       if(MeshConnect(meshi, MLEFT, meshj)==1){
         meshi->nabors[MRIGHT] = meshj;
@@ -1096,11 +1096,11 @@ void *InitNabors(void *arg){
       }
     }
   }
-  for(i = 0;i < nmeshes;i++){
+  for(i = 0;i < global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     float xyzmid[3], xyz[3];
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     memcpy(xyzmid, meshi->boxmiddle, 3*sizeof(float));
 
     memcpy(xyz, xyzmid, 3*sizeof(float));
@@ -1144,14 +1144,14 @@ void InitSuperMesh(void){
 
   // merge connected meshes to form supermeshes
 
-  nsupermeshinfo = 0;
+  global_scase.nsupermeshinfo = 0;
   thismesh = GetMinMesh();
-  for(smesh = supermeshinfo, thismesh = GetMinMesh();thismesh!=NULL;thismesh = GetMinMesh(), smesh++){
+  for(smesh = global_scase.supermeshinfo, thismesh = GetMinMesh();thismesh!=NULL;thismesh = GetMinMesh(), smesh++){
     MakeSMesh(smesh, thismesh);
-    nsupermeshinfo++;
+    global_scase.nsupermeshinfo++;
   }
 
-  for(smesh = supermeshinfo;smesh!=supermeshinfo+nsupermeshinfo;smesh++){
+  for(smesh = global_scase.supermeshinfo;smesh!=global_scase.supermeshinfo+global_scase.nsupermeshinfo;smesh++){
     meshdata *nab;
     float *smin, *smax;
     int nsize;
@@ -1238,8 +1238,8 @@ void InitSuperMesh(void){
   }
 #ifdef pp_GPU
   if(gpuactive==1){
-    for(i = 0;i<nsupermeshinfo;i++){
-      smesh = supermeshinfo+i;
+    for(i = 0;i<global_scase.nsupermeshinfo;i++){
+      smesh = global_scase.supermeshinfo+i;
       InitVolsmokeSuperTexture(smesh);
     }
   }
@@ -1301,11 +1301,11 @@ void InitVolRender(void){
   int i;
 
   nvolrenderinfo=0;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     vr = meshi->volrenderinfo;
     vr->rendermeshlabel=meshi->label;
 
@@ -1322,23 +1322,23 @@ void InitVolRender(void){
     vr->is_compressed=0;
     vr->times_defined=0;
   }
-  for(i=0;i<slicecoll.nsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
     slicedata *slicei;
     char *shortlabel, *longlabel;
     int blocknumber;
     meshdata *meshi;
     volrenderdata *vr;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     blocknumber = slicei->blocknumber;
-    if(blocknumber<0||blocknumber>=nmeshes)continue;
+    if(blocknumber<0||blocknumber>=global_scase.meshescoll.nmeshes)continue;
     shortlabel = slicei->label.shortlabel;
     longlabel = slicei->label.longlabel;
     if(STRCMP(shortlabel, "temp")!=0&&IsSootFile(shortlabel, longlabel)==0&&STRCMP(shortlabel, "frac")!=0&&STRCMP(shortlabel, "X_CO2")!=0)continue;
     if(slicei->full_mesh==NO)continue;
     if(FILE_EXISTS(slicei->reg_file)==NO)continue;
 
-    meshi = meshinfo + blocknumber;
+    meshi = global_scase.meshescoll.meshinfo + blocknumber;
 
     vr = meshi->volrenderinfo;
 
@@ -1351,11 +1351,11 @@ void InitVolRender(void){
       continue;
     }
   }
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     vr = meshi->volrenderinfo;
     vr->ntimes=0;
 
@@ -1399,8 +1399,8 @@ void InitVolRender(void){
     }
   }
   if(nvolrenderinfo>0){
-    NewMemory((void **)&volfacelistinfo,6*nmeshes*sizeof(volfacelistdata));
-    NewMemory((void **)&volfacelistinfoptrs,6*nmeshes*sizeof(volfacelistdata *));
+    NewMemory((void **)&volfacelistinfo,6*global_scase.meshescoll.nmeshes*sizeof(volfacelistdata));
+    NewMemory((void **)&volfacelistinfoptrs,6*global_scase.meshescoll.nmeshes*sizeof(volfacelistdata *));
   }
   if(nvolrenderinfo>0){
     InitSuperMesh();
@@ -1656,7 +1656,7 @@ void ComputeAllSmokecolors(void){
   int ii;
 
   if(freeze_volsmoke==1)return;
-  for(ii=0;ii<nmeshes;ii++){
+  for(ii=0;ii<global_scase.meshescoll.nmeshes;ii++){
     meshdata *meshi;
     volrenderdata *vr;
     int iwall;
@@ -1666,7 +1666,7 @@ void ComputeAllSmokecolors(void){
     int ibar, jbar, kbar;
     float *smokecolor;
 
-    meshi = meshinfo + ii;
+    meshi = global_scase.meshescoll.meshinfo + ii;
     vr = meshi->volrenderinfo;
     if(vr->loaded==0||vr->display==0)continue;
 
@@ -2049,7 +2049,7 @@ void DrawSmoke3DVol(void){
     vi = volfacelistinfoptrs[ii];
     iwall=vi->iwall;
     meshi = vi->facemesh;
-    if(meshvisptr[meshi-meshinfo]==0)continue;
+    if(meshvisptr[meshi-global_scase.meshescoll.meshinfo]==0)continue;
     xplt = meshi->xvolplt;
     yplt = meshi->yvolplt;
     zplt = meshi->zvolplt;
@@ -2425,7 +2425,7 @@ void DrawSmoke3DGPUVol(void){
     iwall=vi->iwall;
     meshi = vi->facemesh;
 
-    if(meshvisptr[meshi-meshinfo]==0)continue;
+    if(meshvisptr[meshi-global_scase.meshescoll.meshinfo]==0)continue;
     if(iwall==0||meshi->drawsides[iwall+3]==0)continue;
 
     vr = meshi->volrenderinfo;
@@ -2886,11 +2886,11 @@ void UnloadVolsmokeFrameAllMeshes(int framenum){
   int i;
 
   PRINTF("Unloading smoke frame: %i\n",framenum);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     vr = meshi->volrenderinfo;
     if(vr->smokeslice==NULL||vr->fireslice==NULL||vr->loaded==0)continue;
     FREEMEMORY(vr->firedataptrs[framenum]);
@@ -2953,7 +2953,7 @@ void ReadVolsmokeFrameAllMeshes(int framenum, supermeshdata *smesh){
   int nm;
 
   if(smesh==NULL){
-    nm=nmeshes;
+    nm=global_scase.meshescoll.nmeshes;
   }
   else{
     nm=smesh->nmeshes;
@@ -2963,7 +2963,7 @@ void ReadVolsmokeFrameAllMeshes(int framenum, supermeshdata *smesh){
     volrenderdata *vr;
 
     if(smesh==NULL){
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
     }
     else{
       meshi = smesh->meshes[i];
@@ -2979,7 +2979,7 @@ void ReadVolsmokeFrameAllMeshes(int framenum, supermeshdata *smesh){
     volrenderdata *vr;
 
     if(smesh==NULL){
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
     }
     else{
       meshi = smesh->meshes[i];
@@ -3008,11 +3008,11 @@ void *ReadVolsmokeAllFramesAllMeshes2(void *arg){
   int i;
   int nframes=0;
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     vr = meshi->volrenderinfo;
     if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
     if(read_vol_mesh!=VOL_READALL&&read_vol_mesh!=i)continue;
@@ -3034,10 +3034,10 @@ void UnloadVolsmokeSuperTextures(void){
   int i, doit;
 
   doit = 0;
-  for(i = 0;i<nsupermeshinfo;i++){
+  for(i = 0;i<global_scase.nsupermeshinfo;i++){
     supermeshdata *smesh;
 
-    smesh = supermeshinfo+i;
+    smesh = global_scase.supermeshinfo+i;
     if(smesh->volsmoke_texture_buffer!=NULL||smesh->volfire_texture_buffer!=NULL){
       doit = 1;
       break;
@@ -3045,10 +3045,10 @@ void UnloadVolsmokeSuperTextures(void){
   }
   if(doit==0)return;
   PRINTF("Unloading smoke and fire textures for each supermesh\n");
-  for(i = 0;i<nsupermeshinfo;i++){
+  for(i = 0;i<global_scase.nsupermeshinfo;i++){
     supermeshdata *smesh;
 
-    smesh = supermeshinfo+i;
+    smesh = global_scase.supermeshinfo+i;
     FREEMEMORY(smesh->volfire_texture_buffer);
     FREEMEMORY(smesh->volsmoke_texture_buffer);
   }
@@ -3156,19 +3156,19 @@ void DefineVolsmokeTextures(void){
 
   if(combine_meshes==1&&gpuactive==1){
 #ifdef pp_GPU
-    for(i=0;i<nsupermeshinfo;i++){
+    for(i=0;i<global_scase.nsupermeshinfo;i++){
       supermeshdata *smesh;
 
-      smesh = supermeshinfo + i;
+      smesh = global_scase.supermeshinfo + i;
       InitVolsmokeSuperTexture(smesh);
     }
 #endif
   }
   else{
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
 
-      meshi = meshinfo  + i;
+      meshi = global_scase.meshescoll.meshinfo  + i;
       InitVolsmokeTexture(meshi);
     }
   }
@@ -3181,11 +3181,11 @@ void ReadVolsmokeAllFramesAllMeshes(void){
 
   compress_volsmoke=glui_compress_volsmoke;
   load_volcompressed=glui_load_volcompressed;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     vr = meshi->volrenderinfo;
     if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
     if(read_vol_mesh!=VOL_READALL&&read_vol_mesh!=i)continue;
@@ -3220,10 +3220,10 @@ void UnloadVolsmokeTextures(void){
 
   PRINTF("Unloading smoke and fire textures for each mesh\n");
   FFLUSH();
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     FREEMEMORY(meshi->volsmoke_texture_buffer);
     FREEMEMORY(meshi->volfire_texture_buffer);
   }

--- a/Source/smokeview/IOwui.c
+++ b/Source/smokeview/IOwui.c
@@ -22,8 +22,8 @@ void GenerateTerrainGeom(float **vertices_arg, unsigned int **indices_arg, int *
   int i, sizeof_indices, sizeof_vertices, sizeof_tvertices, terrain_nindices_local;
   float terrain_xmin, terrain_xmax, terrain_ymin, terrain_ymax;
 
-  if(geominfo->geomlistinfo==NULL)return;
-  terrain = geominfo->geomlistinfo - 1;
+  if(global_scase.geominfo->geomlistinfo==NULL)return;
+  terrain = global_scase.geominfo->geomlistinfo - 1;
 
   sizeof_vertices  = 9*terrain->nverts*sizeof(float);
   sizeof_tvertices = 2*terrain->nverts*sizeof(float);
@@ -134,10 +134,10 @@ int HaveTerrainTexture(int *draw_surfaceptr){
   int draw_texture = 0, draw_surface = 1;
   int i;
 
-  for(i = 0; i < nterrain_textures; i++){
+  for(i = 0; i < global_scase.terrain_texture_coll.nterrain_textures; i++){
     texturedata *texti;
 
-    texti = terrain_textures + i;
+    texti = global_scase.terrain_texture_coll.terrain_textures + i;
     if(texti->loaded == 1 && texti->display == 1){
       draw_texture = 1;
       if(texti->is_transparent == 0)draw_surface = 0; // don't draw a surface if we are drawing a texture
@@ -152,10 +152,10 @@ int HaveTerrainTexture(int *draw_surfaceptr){
 int GetNTerrainTexturesLoaded(void){
   int count, i, opaque_texture_index = -1;
 
-  for(i = 0; i < nterrain_textures; i++){
+  for(i = 0; i < global_scase.terrain_texture_coll.nterrain_textures; i++){
     texturedata *texti;
 
-    texti = terrain_textures + i;
+    texti = global_scase.terrain_texture_coll.terrain_textures + i;
     if(texti->loaded == 1 && texti->display == 1 && texti->is_transparent == 0){
       opaque_texture_index = i;
       break;
@@ -163,16 +163,16 @@ int GetNTerrainTexturesLoaded(void){
   }
 
   count = 0;
-  for(i = -1; i<nterrain_textures; i++){
+  for(i = -1; i<global_scase.terrain_texture_coll.nterrain_textures; i++){
     texturedata *texti;
 
     if(i==-1){
       if(opaque_texture_index==-1)continue;
-      texti = terrain_textures+opaque_texture_index;
+      texti = global_scase.terrain_texture_coll.terrain_textures+opaque_texture_index;
     }
     else{
       if(i==opaque_texture_index)continue;
-      texti = terrain_textures+i;
+      texti = global_scase.terrain_texture_coll.terrain_textures+i;
     }
     if(texti->loaded==0||texti->display==0)continue;
     count++;
@@ -212,7 +212,7 @@ void DrawTerrainGeom(int option){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
 
   if(option==DRAW_OPAQUE){
 
@@ -559,10 +559,10 @@ void DrawTerrainGeom(int option){
     int ii;
     int opaque_texture_index = -1;
 
-    for(i = 0; i<nterrain_textures; i++){
+    for(i = 0; i<global_scase.terrain_texture_coll.nterrain_textures; i++){
       texturedata *texti;
 
-      texti = terrain_textures+i;
+      texti = global_scase.terrain_texture_coll.terrain_textures+i;
       if(texti->loaded==1&&texti->display==1&&texti->is_transparent==0){
         opaque_texture_index = i;
         break;
@@ -575,18 +575,18 @@ void DrawTerrainGeom(int option){
     int count = 0;
     int is_transparent=0;
     TransparentOff();
-    for(ii = -1; ii<nterrain_textures; ii++){
+    for(ii = -1; ii<global_scase.terrain_texture_coll.nterrain_textures; ii++){
       float dz;
       texturedata *texti;
 
       // draw opaque texture first
       if(ii==-1){
         if(opaque_texture_index==-1)continue;
-        texti = terrain_textures+opaque_texture_index;
+        texti = global_scase.terrain_texture_coll.terrain_textures+opaque_texture_index;
       }
       else{
         if(ii==opaque_texture_index)continue;
-        texti = terrain_textures+ii;
+        texti = global_scase.terrain_texture_coll.terrain_textures+ii;
       }
       if(texti->loaded==0||texti->display==0)continue;
       dz = SCALE2FDS((float)(count)*FDS_OFFSET);
@@ -677,7 +677,7 @@ void DrawTerrainGeom(int option){
 void DrawNorth(void){
   glPushMatrix();
   glTranslatef(northangle_position[0], northangle_position[1], northangle_position[2]);
-  glRotatef(-northangle, 0.0, 0.0, 1.0);
+  glRotatef(-global_scase.northangle, 0.0, 0.0, 1.0);
   glBegin(GL_LINES);
   glColor3fv(foregroundcolor);
   glVertex3f(0.0, 0.0, 0.0);
@@ -706,13 +706,13 @@ void DrawTrees(void){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
-  for(i=0;i<ntreeinfo;i++){
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
+  for(i=0;i<global_scase.ntreeinfo;i++){
     treedata *treei;
     float crown_height;
     int state;
 
-    treei = treeinfo + i;
+    treei = global_scase.treeinfo + i;
 
     state=0;
     if(showtime==1&&global_times!=NULL){
@@ -772,7 +772,7 @@ float GetZCellVal(meshdata *meshi,float xval, float yval, float *zval_offset, in
 
   if(meshi==NULL)meshstart=0;
   if(zval_offset!=NULL)*zval_offset=0.0;
-  for(imesh=meshstart;imesh<nmeshes;imesh++){
+  for(imesh=meshstart;imesh<global_scase.meshescoll.nmeshes;imesh++){
     meshdata *meshj;
     float *xplt, *yplt;
     int ibar, jbar;
@@ -781,7 +781,7 @@ float GetZCellVal(meshdata *meshi,float xval, float yval, float *zval_offset, in
       meshj=meshi;
     }
     else{
-      meshj=meshinfo+imesh;
+      meshj=global_scase.meshescoll.meshinfo+imesh;
       if(meshi==meshj)continue;
     }
     xplt = meshj->xplt_orig;
@@ -827,7 +827,7 @@ float GetZCellValOffset(meshdata *meshi,float xval, float yval, int *loc){
 
   if(meshi==NULL)meshstart=0;
 
-  for(imesh=meshstart;imesh<nmeshes;imesh++){
+  for(imesh=meshstart;imesh<global_scase.meshescoll.nmeshes;imesh++){
     meshdata *meshj;
     float *xplt, *yplt;
     int ibar, jbar;
@@ -836,7 +836,7 @@ float GetZCellValOffset(meshdata *meshi,float xval, float yval, int *loc){
       meshj=meshi;
     }
     else{
-      meshj=meshinfo+imesh;
+      meshj=global_scase.meshescoll.meshinfo+imesh;
       if(meshi==meshj)continue;
     }
 
@@ -910,14 +910,14 @@ float GetZTerrain(float x, float y){
 void ComputeTerrainNormalsManual(void){
   int imesh;
 
-  for(imesh=0;imesh<nmeshes;imesh++){
+  for(imesh=0;imesh<global_scase.meshescoll.nmeshes;imesh++){
     meshdata *meshi;
     terraindata *terri;
     float *znode;
     int j;
     int nycell;
 
-    meshi = meshinfo + imesh;
+    meshi = global_scase.meshescoll.meshinfo + imesh;
     terri = meshi->terrain;
     if(terri==NULL)continue;
     znode = terri->znode;
@@ -986,7 +986,7 @@ void ComputeTerrainNormalsManual(void){
         znormal3[0]/=sum;
         znormal3[1]/=sum;
         znormal3[2]/=sum;
-        *uc_znormal = GetNormalIndex(wui_sphereinfo, znormal3);
+        *uc_znormal = GetNormalIndex(global_scase.wui_sphereinfo, znormal3);
       }
     }
   }
@@ -998,7 +998,7 @@ void ComputeTerrainNormalsAuto(void){
   int imesh;
   float zmin, zmax;
 
-  for(imesh=0;imesh<nmeshes;imesh++){
+  for(imesh=0;imesh<global_scase.meshescoll.nmeshes;imesh++){
     meshdata *meshi;
     terraindata *terri;
     int j;
@@ -1007,7 +1007,7 @@ void ComputeTerrainNormalsAuto(void){
     int nycell;
     unsigned char *uc_znormal;
 
-    meshi = meshinfo + imesh;
+    meshi = global_scase.meshescoll.meshinfo + imesh;
 
     terri = meshi->terrain;
 
@@ -1153,19 +1153,19 @@ void ComputeTerrainNormalsAuto(void){
         znormal3[0]/=sum;
         znormal3[1]/=sum;
         znormal3[2]/=sum;
-        *uc_znormal = GetNormalIndex(wui_sphereinfo, znormal3);
+        *uc_znormal = GetNormalIndex(global_scase.wui_sphereinfo, znormal3);
       }
     }
   }
 
-  zmin = meshinfo->terrain->znode[0];
+  zmin = global_scase.meshescoll.meshinfo->terrain->znode[0];
   zmax = zmin;
-  for(imesh=0;imesh<nmeshes;imesh++){
+  for(imesh=0;imesh<global_scase.meshescoll.nmeshes;imesh++){
     meshdata *meshi;
     terraindata *terri;
     int i;
 
-    meshi = meshinfo + imesh;
+    meshi = global_scase.meshescoll.meshinfo + imesh;
     terri = meshi->terrain;
 
     for(i=0;i<(terri->ibar+1)*(terri->jbar+1);i++){
@@ -1190,7 +1190,7 @@ int GetTerrainData(char *file, terraindata *terri){
   int nvalues, i;
 
 #ifdef _DEBUG
-  printf("reading terrain data mesh: %i\n", (int)(terri-terraininfo));
+  printf("reading terrain data mesh: %i\n", (int)(terri-global_scase.terraininfo));
 #endif
   WUIFILE = fopen(file, "rb");
   if(WUIFILE==NULL)return 1;
@@ -1202,7 +1202,7 @@ int GetTerrainData(char *file, terraindata *terri){
 //    WRITE(LU_TERRAIN(NM)) Z_TERRAIN
 
   FORTWUIREAD(&zmin_cutoff, 1);
-  zmin_cutoff = zbar0;
+  zmin_cutoff = global_scase.zbar0;
   zmin_cutoff -= 0.1;
   terri->zmin_cutoff = zmin_cutoff;
   FORTWUIREAD(ijbar, 2);
@@ -1322,7 +1322,7 @@ void DrawTerrainOBST(terraindata *terri, int flag){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
   ENABLE_LIGHTING;
   glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&terrain_shininess);
@@ -1369,16 +1369,16 @@ void DrawTerrainOBST(terraindata *terri, int flag){
       zval4 += ZOFFSET;
 
       uc_zn1 = uc_znormal+IJ2(i,j);
-      zn1 = GetNormalVectorPtr(wui_sphereinfo, (unsigned int)(*uc_zn1));
+      zn1 = GetNormalVectorPtr(global_scase.wui_sphereinfo, (unsigned int)(*uc_zn1));
 
       uc_zn2 = uc_znormal+IJ2(ip1, j);
-      zn2 = GetNormalVectorPtr(wui_sphereinfo, (unsigned int)(*uc_zn2));
+      zn2 = GetNormalVectorPtr(global_scase.wui_sphereinfo, (unsigned int)(*uc_zn2));
 
       uc_zn3 = uc_znormal+IJ2(ip1, jp1);
-      zn3 = GetNormalVectorPtr(wui_sphereinfo, (unsigned int)(*uc_zn3));
+      zn3 = GetNormalVectorPtr(global_scase.wui_sphereinfo, (unsigned int)(*uc_zn3));
 
       uc_zn4 = uc_znormal+IJ2(i, jp1);
-      zn4 = GetNormalVectorPtr(wui_sphereinfo, (unsigned int)(*uc_zn4));
+      zn4 = GetNormalVectorPtr(global_scase.wui_sphereinfo, (unsigned int)(*uc_zn4));
 
       if(flag==TERRAIN_TOP_SIDE||flag==TERRAIN_BOTH_SIDES){
         if(skip123==0){
@@ -1475,7 +1475,7 @@ void DrawTerrainOBST(terraindata *terri, int flag){
           zval11 = znode[IJ2(i,     j)]+ZOFFSET;
 
           uc_zn = uc_znormal+IJ2(i, j);
-          zn = GetNormalVectorPtr(wui_sphereinfo, (unsigned int)(*uc_zn));
+          zn = GetNormalVectorPtr(global_scase.wui_sphereinfo, (unsigned int)(*uc_zn));
 
           glVertex3f(x[i], y[j], zval11);
           glVertex3f(x[i]  +terrain_normal_length*zn[0],
@@ -1517,7 +1517,7 @@ void DrawTerrainOBSTSides(meshdata *meshi){
 
   glPushMatrix();
   glScalef(SCALE2SMV(mscale[0]), SCALE2SMV(mscale[1]), vertical_factor*SCALE2SMV(mscale[2]));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
 
   ENABLE_LIGHTING;
   glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
@@ -1541,15 +1541,15 @@ void DrawTerrainOBSTSides(meshdata *meshi){
       zij   = znode[IJ2(i, j)];
       zijp1 = znode[IJ2(i, j+1)];
       if(zij>zcutoff){
-        glVertex3f(x[i], y[j],   zbar0);
+        glVertex3f(x[i], y[j],   global_scase.zbar0);
         glVertex3f(x[i], y[j],   zij);
-        glVertex3f(x[i], y[j+1], zbar0);
+        glVertex3f(x[i], y[j+1], global_scase.zbar0);
       }
 
       if(zij<zcutoff&&zijp1<zcutoff)continue;
       if(zij<zcutoff)zij = zijp1;
       if(zijp1<zcutoff)zijp1 = zij;
-      glVertex3f(x[i], y[j+1], zbar0);
+      glVertex3f(x[i], y[j+1], global_scase.zbar0);
       glVertex3f(x[i], y[j],   zij);
       glVertex3f(x[i], y[j+1], zijp1);
     }
@@ -1563,15 +1563,15 @@ void DrawTerrainOBSTSides(meshdata *meshi){
       zijp1 = znode[IJ2(i, j+1)];
 
       if(zijp1>zcutoff){
-        glVertex3f(x[i], y[j],   zbar0);
-        glVertex3f(x[i], y[j+1], zbar0);
+        glVertex3f(x[i], y[j],   global_scase.zbar0);
+        glVertex3f(x[i], y[j+1], global_scase.zbar0);
         glVertex3f(x[i], y[j+1], zijp1);
       }
 
       if(zij<zcutoff&&zijp1<zcutoff)continue;
       if(zij<zcutoff)zij = zijp1;
       if(zijp1<zcutoff)zijp1 = zij;
-      glVertex3f(x[i], y[j],   zbar0);
+      glVertex3f(x[i], y[j],   global_scase.zbar0);
       glVertex3f(x[i], y[j+1], zijp1);
       glVertex3f(x[i], y[j],   zij);
     }
@@ -1584,15 +1584,15 @@ void DrawTerrainOBSTSides(meshdata *meshi){
       zij   = znode[IJ2(i, j)];
       zip1j = znode[IJ2(i+1, j)];
       if(zip1j>zcutoff){
-        glVertex3f(x[i],   y[j], zbar0);
-        glVertex3f(x[i+1], y[j], zbar0);
+        glVertex3f(x[i],   y[j], global_scase.zbar0);
+        glVertex3f(x[i+1], y[j], global_scase.zbar0);
         glVertex3f(x[i+1], y[j], zip1j);
       }
 
       if(zij<zcutoff&&zip1j<zcutoff)continue;
       if(zij<zcutoff)zij = zip1j;
       if(zip1j<zcutoff)zip1j = zij;
-      glVertex3f(x[i],   y[j], zbar0);
+      glVertex3f(x[i],   y[j], global_scase.zbar0);
       glVertex3f(x[i+1], y[j], zip1j);
       glVertex3f(x[i],   y[j], zij);
     }
@@ -1605,15 +1605,15 @@ void DrawTerrainOBSTSides(meshdata *meshi){
       zij   = znode[IJ2(i, j)];
       zip1j = znode[IJ2(i+1, j)];
       if(zip1j>zcutoff){
-        glVertex3f(x[i],   y[j], zbar0);
+        glVertex3f(x[i],   y[j], global_scase.zbar0);
         glVertex3f(x[i+1], y[j], zip1j);
-        glVertex3f(x[i+1], y[j], zbar0);
+        glVertex3f(x[i+1], y[j], global_scase.zbar0);
       }
 
       if(zij<zcutoff&&zip1j<zcutoff)continue;
       if(zij<zcutoff)zij = zip1j;
       if(zip1j<zcutoff)zip1j = zij;
-      glVertex3f(x[i],   y[j], zbar0);
+      glVertex3f(x[i],   y[j], global_scase.zbar0);
       glVertex3f(x[i],   y[j], zij);
       glVertex3f(x[i+1], y[j], zip1j);
     }
@@ -1658,13 +1658,13 @@ void DrawTerrainOBSTTexture(terraindata *terri){
 
   glPushMatrix();
   glScalef(SCALE2SMV(mscale[0]),SCALE2SMV(mscale[1]),vertical_factor*SCALE2SMV(mscale[2]));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
   ENABLE_LIGHTING;
   glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
   glTexEnvf(GL_TEXTURE_ENV,GL_TEXTURE_ENV_MODE,GL_MODULATE);
   glEnable(GL_TEXTURE_2D);
-  glBindTexture(GL_TEXTURE_2D,terrain_textures[iterrain_textures].name);
+  glBindTexture(GL_TEXTURE_2D,global_scase.terrain_texture_coll.terrain_textures[iterrain_textures].name);
 
   glEnable(GL_COLOR_MATERIAL);
   glColor4fv(terrain_color);
@@ -1699,19 +1699,19 @@ void DrawTerrainOBSTTexture(terraindata *terri){
       txp1 = (x[ip1]-xbar0ORIG)/(xbarORIG-xbar0ORIG);
 
       uc_zn1 = uc_znormal+ijnode2(i,j);
-      zn1 = GetNormalVectorPtr(wui_sphereinfo, (unsigned int)(*uc_zn1));
+      zn1 = GetNormalVectorPtr(global_scase.wui_sphereinfo, (unsigned int)(*uc_zn1));
       zval1 = znode[IJ2(i, j)];
 
       uc_zn2 = uc_znormal+ijnode2(ip1, j);
-      zn2 = GetNormalVectorPtr(wui_sphereinfo, (unsigned int)(*uc_zn2));
+      zn2 = GetNormalVectorPtr(global_scase.wui_sphereinfo, (unsigned int)(*uc_zn2));
       zval2 = znode[IJ2(ip1, j)];
 
       uc_zn3 = uc_znormal+ijnode2(ip1, jp1);
-      zn3 = GetNormalVectorPtr(wui_sphereinfo, (unsigned int)(*uc_zn3));
+      zn3 = GetNormalVectorPtr(global_scase.wui_sphereinfo, (unsigned int)(*uc_zn3));
       zval3 = znode[IJ2(ip1, jp1)];
 
       uc_zn4 = uc_znormal+ijnode2(i, jp1);
-      zn4 = GetNormalVectorPtr(wui_sphereinfo, (unsigned int)(*uc_zn4));
+      zn4 = GetNormalVectorPtr(global_scase.wui_sphereinfo, (unsigned int)(*uc_zn4));
       zval4 = znode[IJ2(i, jp1)];
 
       if(zval1<zcut&&zval2<zcut&&zval3<zcut&&zval4<zcut)continue;
@@ -1847,8 +1847,8 @@ int GetTerrainSize(char *file, float *xmin, float *xmax, int *nx, float *ymin, f
 
 float GetTerrainElev(meshdata *meshi, int index){
   for(;;){
-    if(meshi==NULL)return zbar0-2.0;
-    if(meshi->terrain==NULL||meshi->terrain->znode[index]<zbar0){
+    if(meshi==NULL)return global_scase.zbar0-2.0;
+    if(meshi->terrain==NULL||meshi->terrain->znode[index]<global_scase.zbar0){
       meshi = meshi->nabors[MDOWN];
     }
     else{
@@ -1860,34 +1860,34 @@ float GetTerrainElev(meshdata *meshi, int index){
 /* ------------------ UpdateTerrain ------------------------ */
 
 void UpdateTerrain(int allocate_memory){
-  if(auto_terrain==1||manual_terrain==1){
+  if(global_scase.auto_terrain==1||global_scase.manual_terrain==1){
     int i;
 
-    if(manual_terrain==0){
-      nterraininfo = nmeshes;
-      if(allocate_memory==1&&manual_terrain==0){
-        NewMemory((void **)&terraininfo, nterraininfo*sizeof(terraindata));
-        for(i = 0; i<nterraininfo; i++){
+    if(global_scase.manual_terrain==0){
+      global_scase.nterraininfo = global_scase.meshescoll.nmeshes;
+      if(allocate_memory==1&&global_scase.manual_terrain==0){
+        NewMemory((void **)&global_scase.terraininfo, global_scase.nterraininfo*sizeof(terraindata));
+        for(i = 0; i<global_scase.nterraininfo; i++){
           terraindata *terri;
 
-          terri = terraininfo+i;
+          terri = global_scase.terraininfo+i;
           terri->defined = 0;
         }
       }
     }
 
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       terraindata *terri;
       float xmin, xmax, ymin, ymax;
       int nx, ny;
 
-      meshi=meshinfo + i;
-      if(manual_terrain==1){
+      meshi=global_scase.meshescoll.meshinfo + i;
+      if(global_scase.manual_terrain==1){
         terri = meshi->terrain;
       }
       else{
-        terri = terraininfo + i;
+        terri = global_scase.terraininfo + i;
         terri->file = NULL;
       }
 
@@ -1900,21 +1900,21 @@ void UpdateTerrain(int allocate_memory){
 
       InitTerrainZNode(meshi, terri, xmin, xmax, nx, ymin, ymax, ny, allocate_memory);
     }
-    if(manual_terrain==0){ // slow
+    if(global_scase.manual_terrain==0){ // slow
       ComputeTerrainNormalsAuto();
     }
-    if(manual_terrain==1){
+    if(global_scase.manual_terrain==1){
       ComputeTerrainNormalsManual();
     }
   }
   if(allocate_memory==1){
     int i;
 
-    for(i = 0; i<nmeshes; i++){
+    for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
       meshdata *meshi;
       int ii;
 
-      meshi = meshinfo+i;
+      meshi = global_scase.meshescoll.meshinfo+i;
       // compute elevations for terrain in each mesh
       // really only need to do this for one mesh in a column but computation isquick and doesn't take a lot of space
       // so doing it for all meshes keeps code simpler
@@ -1922,16 +1922,16 @@ void UpdateTerrain(int allocate_memory){
         meshi->znodes_complete[ii] = GetTerrainElev(meshi, ii);
       }
     }
-    for(i=0; i<slicecoll.nsliceinfo; i++){
+    for(i=0; i<global_scase.slicecoll.nsliceinfo; i++){
       slicedata *slicei;
       meshdata *meshi;
       float zmin, zmax;
       float agl;
       int ii;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
       if(slicei->slice_filetype!=SLICE_TERRAIN)continue;
-      meshi = meshinfo + slicei->blocknumber;
+      meshi = global_scase.meshescoll.meshinfo + slicei->blocknumber;
       zmin = meshi->zplt_orig[0];
       zmax = meshi->zplt_orig[meshi->kbar];
       agl = slicei->above_ground_level;
@@ -1940,7 +1940,7 @@ void UpdateTerrain(int allocate_memory){
 
         zterrain = meshi->znodes_complete[ii];
         zslice   = zterrain+agl;
-        if(zterrain>=zbar0&&zslice>=zmin&&zslice<=zmax){
+        if(zterrain>=global_scase.zbar0&&zslice>=zmin&&zslice<=zmax){
           slicei->have_agl_data = 1;
           break;
         }
@@ -1948,10 +1948,10 @@ void UpdateTerrain(int allocate_memory){
     }
     CheckMemory;
   }
-  if(nterraininfo>0){
+  if(global_scase.nterraininfo>0){
     int imesh;
 
-    for(imesh=0;imesh<nmeshes;imesh++){
+    for(imesh=0;imesh<global_scase.meshescoll.nmeshes;imesh++){
       meshdata *meshi;
       terraindata *terri;
       float *znode, *znode_scaled;
@@ -1959,7 +1959,7 @@ void UpdateTerrain(int allocate_memory){
       float mesh_zmin, mesh_zmax;
       float t_zmin, t_zmax;
 
-      meshi=meshinfo + imesh;
+      meshi=global_scase.meshescoll.meshinfo + imesh;
       terri = meshi->terrain;
       if(terri==NULL)continue;
       terri->terrain_mesh = meshi;
@@ -2002,10 +2002,10 @@ void UpdateTerrain(int allocate_memory){
 int HaveTerrainSlice(void){
   int i;
 
-  for(i=0;i<slicecoll.nsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
 
     if(slicei->loaded==1&&slicei->slice_filetype==SLICE_TERRAIN)return 1;
 
@@ -2016,7 +2016,7 @@ int HaveTerrainSlice(void){
 /* ------------------ UpdateTerrainOptions ------------------------ */
 
 void UpdateTerrainOptions(void){
-  if(nterraininfo>0||auto_terrain==1){
+  if(global_scase.nterraininfo>0||global_scase.auto_terrain==1){
     visOpenVents=0;
     visDummyVents=0;
     updatemenu=1;

--- a/Source/smokeview/IOzone.c
+++ b/Source/smokeview/IOzone.c
@@ -32,7 +32,7 @@ void GetZoneSizeCSV(int *nzone_times_local, int *nroom, int *nfires_local, int *
    *ntargets_arg = nt;
 
    nr=0;
-   for(i=0;i<ndeviceinfo;i++){
+   for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
      char label[100];
 
      sprintf(label,"ULT_%i",i+1);
@@ -44,7 +44,7 @@ void GetZoneSizeCSV(int *nzone_times_local, int *nroom, int *nfires_local, int *
    *nroom=nr;
 
    nv=0;
-   for(i=0;i<ndeviceinfo;i++){
+   for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
      char label[100];
 
      sprintf(label,"HVENT_%i",i+1);
@@ -55,7 +55,7 @@ void GetZoneSizeCSV(int *nzone_times_local, int *nroom, int *nfires_local, int *
    *nhvents=nv;
 
    nv=0;
-   for(i=0;i<ndeviceinfo;i++){
+   for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
      char label[100];
 
      sprintf(label,"VVENT_%i",i+1);
@@ -66,7 +66,7 @@ void GetZoneSizeCSV(int *nzone_times_local, int *nroom, int *nfires_local, int *
    *nvvents=nv;
 
    nv=0;
-   for(i=0;i<ndeviceinfo;i++){
+   for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
      char label[100];
 
      sprintf(label,"MVENT_%i",i+1);
@@ -77,7 +77,7 @@ void GetZoneSizeCSV(int *nzone_times_local, int *nroom, int *nfires_local, int *
    *nmvents=nv;
 
    nf=0;
-   for(i=0;i<ndeviceinfo;i++){
+   for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
      char label[100];
 
      sprintf(label,"HRR_%i",i+1);
@@ -166,10 +166,10 @@ void GetZoneDataCSV(int nzone_times_local, int nrooms_local, int nfires_local, i
     NewMemory((void **)&zoneodu_devs,  nrooms_local*sizeof(devicedata *));
   }
 
-  if(nzhvents+nzvvents+nzmvents>0){
+  if(global_scase.nzhvents+global_scase.nzvvents+global_scase.nzmvents>0){
     int ntotalvents;
 
-    ntotalvents = nzhvents+nzvvents+nzmvents;
+    ntotalvents = global_scase.nzhvents+global_scase.nzvvents+global_scase.nzmvents;
     NewMemory((void **)&zonevents_devs,   ntotalvents*sizeof(devicedata *));
     NewMemory((void **)&zoneslab_n_devs,  ntotalvents*sizeof(devicedata *));
     NewMemory((void **)&zoneslab_T_devs,  MAX_HSLABS*ntotalvents*sizeof(devicedata *));
@@ -374,21 +374,21 @@ void GetZoneDataCSV(int nzone_times_local, int nrooms_local, int nfires_local, i
     zonefarea_devs[i]->in_zone_csv=1;
   }
 
-  for(i = 0; i < nzhvents+nzvvents+nzmvents; i++){
+  for(i = 0; i < global_scase.nzhvents+global_scase.nzvvents+global_scase.nzmvents; i++){
     char label[100],vent_type[10];
     int vent_index;
 
-    if(i<nzhvents){
+    if(i<global_scase.nzhvents){
       strcpy(vent_type,"HVENT");
       vent_index=i+1;
     }
-    else if(i>=nzhvents&&i<nzhvents+nzvvents){
+    else if(i>=global_scase.nzhvents&&i<global_scase.nzhvents+global_scase.nzvvents){
       strcpy(vent_type,"VVENT");
-      vent_index=i+1-nzhvents;
+      vent_index=i+1-global_scase.nzhvents;
     }
     else{
       strcpy(vent_type,"MVENT");
-      vent_index=i+1-nzhvents-nzvvents;
+      vent_index=i+1-global_scase.nzhvents-global_scase.nzvvents;
     }
     sprintf(label, "%s_%i", vent_type,vent_index);
     zonevents_devs[i] = GetDeviceFromLabel(label, -1);
@@ -402,22 +402,22 @@ void GetZoneDataCSV(int nzone_times_local, int nrooms_local, int nfires_local, i
 
 //  setup devices that describe VENTS
   have_ventslab_flow = 0;
-  for(i = 0; i < nzhvents+nzvvents+nzmvents; i++){
+  for(i = 0; i < global_scase.nzhvents+global_scase.nzvvents+global_scase.nzmvents; i++){
     char label[100], vent_type[10];
     int islab, vent_index, max_slabs;
 
-    if(i<nzhvents){
+    if(i<global_scase.nzhvents){
       vent_index = 1+i;
       strcpy(vent_type, "HSLAB");
       max_slabs = MAX_HSLABS;
     }
-    else if(i>=nzhvents&&i<nzhvents+nzvvents){
-      vent_index = 1+i-nzhvents;
+    else if(i>=global_scase.nzhvents&&i<global_scase.nzhvents+global_scase.nzvvents){
+      vent_index = 1+i-global_scase.nzhvents;
       strcpy(vent_type, "VSLAB");
       max_slabs = MAX_VSLABS;
     }
     else{
-      vent_index = 1+i-nzhvents-nzvvents;
+      vent_index = 1+i-global_scase.nzhvents-global_scase.nzvvents;
       strcpy(vent_type, "MSLAB");
       max_slabs = MAX_MSLABS;
     }
@@ -450,22 +450,22 @@ void GetZoneDataCSV(int nzone_times_local, int nrooms_local, int nfires_local, i
     if(have_ventslab_flow == 1)break;
   }
   if(have_ventslab_flow == 1){
-    for(i = 0; i < nzhvents+nzvvents+nzmvents; i++){
+    for(i = 0; i < global_scase.nzhvents+global_scase.nzvvents+global_scase.nzmvents; i++){
       char label[100], vent_type[10];
       int islab, vent_index, max_slabs;
 
-      if(i<nzhvents){
+      if(i<global_scase.nzhvents){
         vent_index = 1+i;
         strcpy(vent_type, "HSLAB");
         max_slabs = MAX_HSLABS;
       }
-      else if(i>=nzhvents&&i<nzhvents+nzvvents){
-        vent_index = 1+i-nzhvents;
+      else if(i>=global_scase.nzhvents&&i<global_scase.nzhvents+global_scase.nzvvents){
+        vent_index = 1+i-global_scase.nzhvents;
         strcpy(vent_type, "VSLAB");
         max_slabs = MAX_VSLABS;
       }
       else{
-        vent_index = 1+i-nzhvents-nzvvents;
+        vent_index = 1+i-global_scase.nzhvents-global_scase.nzvvents;
         strcpy(vent_type, "MSLAB");
         max_slabs = MAX_MSLABS;
       }
@@ -569,14 +569,14 @@ void GetZoneDataCSV(int nzone_times_local, int nrooms_local, int nfires_local, i
       zonefbase_local[iif]=zonefbase_devs[j]->vals[i];
       iif++;
     }
-    for(ivent=0;ivent<nzhvents+nzvvents+nzmvents;ivent++){
+    for(ivent=0;ivent<global_scase.nzhvents+global_scase.nzvvents+global_scase.nzmvents;ivent++){
       int islab, max_slabs;
 
       zonevents_local[iihv] = zonevents_devs[ivent]->vals[i];
-      if(ivent<nzhvents){
+      if(ivent<global_scase.nzhvents){
         max_slabs = MAX_HSLABS;
       }
-      else if(ivent>=nzhvents&&i<nzhvents+nzvvents){
+      else if(ivent>=global_scase.nzhvents&&i<global_scase.nzhvents+global_scase.nzvvents){
         max_slabs = MAX_VSLABS;
       }
       else{
@@ -626,28 +626,28 @@ void FillZoneData(int izone_index){
   float R = (gamma - 1.0)*CP / gamma;
 
   if(ReadZoneFile == 0)return;
-  pr0 = zonepr + izone_index*nrooms;
-  ylay0 = zoneylay + izone_index*nrooms;
-  tl0 = zonetl + izone_index*nrooms;
-  tu0 = zonetu + izone_index*nrooms;
+  pr0 = zonepr + izone_index*global_scase.nrooms;
+  ylay0 = zoneylay + izone_index*global_scase.nrooms;
+  tl0 = zonetl + izone_index*global_scase.nrooms;
+  tu0 = zonetu + izone_index*global_scase.nrooms;
   if(zone_rho == 1){
-    rhol0 = zonerhol + izone_index*nrooms;
-    rhou0 = zonerhou + izone_index*nrooms;
+    rhol0 = zonerhol + izone_index*global_scase.nrooms;
+    rhou0 = zonerhou + izone_index*global_scase.nrooms;
   }
-  ntotal_vents = nzhvents + nzvvents + nzmvents;
+  ntotal_vents = global_scase.nzhvents + global_scase.nzvvents + global_scase.nzmvents;
   hvent0 = zonevents + izone_index*ntotal_vents;
   zoneslab_n0 = zoneslab_n + izone_index*ntotal_vents;
   zoneslab_T0 = zoneslab_T + izone_index*MAX_HSLABS*ntotal_vents;
   zoneslab_F0 = zoneslab_F + izone_index*MAX_HSLABS*ntotal_vents;
   zoneslab_YB0 = zoneslab_YB + izone_index*MAX_HSLABS*ntotal_vents;
   zoneslab_YT0 = zoneslab_YT + izone_index*MAX_HSLABS*ntotal_vents;
-  if(zoneodl != NULL)odl0 = zoneodl + izone_index*nrooms;
-  if(zoneodu != NULL)odu0 = zoneodu + izone_index*nrooms;
-  for(ivent = 0;ivent < nzhvents + nzvvents + nzmvents;ivent++){
+  if(zoneodl != NULL)odl0 = zoneodl + izone_index*global_scase.nrooms;
+  if(zoneodu != NULL)odu0 = zoneodu + izone_index*global_scase.nrooms;
+  for(ivent = 0;ivent < global_scase.nzhvents + global_scase.nzvvents + global_scase.nzmvents;ivent++){
     zventdata *zventi;
     int islab;
 
-    zventi = zventinfo + ivent;
+    zventi = global_scase.zventinfo + ivent;
     zventi->area_fraction = CLAMP(hvent0[ivent] / zventi->area, 0.0, 1.0);
 
     zventi->nslab = zoneslab_n0[ivent];
@@ -661,8 +661,8 @@ void FillZoneData(int izone_index){
       zventi->slab_temp[islab] = zoneslab_T0[iislab];
     }
   }
-  for(iroom = 0;iroom < nrooms;iroom++){
-    roomi = roominfo + iroom;
+  for(iroom = 0;iroom < global_scase.nrooms;iroom++){
+    roomi = global_scase.roominfo + iroom;
     roomi->pfloor = pr0[iroom];
     roomi->ylay = ylay0[iroom];
     roomi->tl = C2K(tl0[iroom]);
@@ -674,21 +674,21 @@ void FillZoneData(int izone_index){
       roomi->rho_U = rhou0[iroom];
     }
     else{
-      roomi->rho_L = (pref + pr0[iroom]) / R / roomi->tl;
-      roomi->rho_U = (pref + pr0[iroom]) / R / roomi->tu;
+      roomi->rho_L = (global_scase.pref + pr0[iroom]) / R / roomi->tl;
+      roomi->rho_U = (global_scase.pref + pr0[iroom]) / R / roomi->tu;
     }
     if(zoneodl != NULL)roomi->od_L = 1.0 / MAX(odl0[iroom], 0.0001);
     if(zoneodu != NULL)roomi->od_U = 1.0 / MAX(odu0[iroom], 0.0001);
   }
-  roomi = roominfo + nrooms;
+  roomi = global_scase.roominfo + global_scase.nrooms;
   roomi->pfloor = 0.0;
   roomi->ylay = 99999.0;
-  roomi->tl = tamb;
-  roomi->tu = tamb;
-  roomi->itl = GetZoneColor(K2C(tamb), zonemin, zonemax, nrgb_full);
-  roomi->itu = GetZoneColor(K2C(tamb), zonemin, zonemax, nrgb_full);
-  roomi->rho_L = (pref + pamb) / R / roomi->tl;
-  roomi->rho_U = (pref + pamb) / R / roomi->tu;
+  roomi->tl = global_scase.tamb;
+  roomi->tu = global_scase.tamb;
+  roomi->itl = GetZoneColor(K2C(global_scase.tamb), zonemin, zonemax, nrgb_full);
+  roomi->itu = GetZoneColor(K2C(global_scase.tamb), zonemin, zonemax, nrgb_full);
+  roomi->rho_L = (global_scase.pref + global_scase.pamb) / R / roomi->tl;
+  roomi->rho_U = (global_scase.pref + global_scase.pamb) / R / roomi->tu;
   roomi->z0 = 0.0;
   roomi->z1 = 100000.0;
 }
@@ -770,21 +770,21 @@ void GetZoneVentBounds(void){
   int i;
 #define VEL_MAX  100000000.0
 #define VEL_MIN -100000000.0
-  for(i = 0;i < nzvents;i++){
+  for(i = 0;i < global_scase.nzvents;i++){
     zventdata *zvi;
 
-    zvi = zventinfo + i;
+    zvi = global_scase.zventinfo + i;
     zvi->g_vmax = VEL_MIN;
     zvi->g_vmin = VEL_MAX;
   }
   for(izone = 0;izone < nzone_times;izone++){
     FillZoneData(izone);
-    for(i = 0;i < nzvents;i++){
+    for(i = 0;i < global_scase.nzvents;i++){
       int j;
       zventdata *zvi;
       float zelev[NELEV_ZONE];
 
-      zvi = zventinfo + i;
+      zvi = global_scase.zventinfo + i;
       if(zvi->area_fraction < 0.0001)continue;
       if(zvi->vent_type == VFLOW_VENT || zvi->vent_type == MFLOW_VENT)continue;
       for(j = 0;j < NELEV_ZONE;j++){
@@ -796,10 +796,10 @@ void GetZoneVentBounds(void){
     }
   }
   zone_maxventflow = 0.0;
-  for(i = 0;i < nzvents;i++){
+  for(i = 0;i < global_scase.nzvents;i++){
     zventdata *zvi;
 
-    zvi = zventinfo + i;
+    zvi = global_scase.zventinfo + i;
     if(zvi->vent_type == VFLOW_VENT || zvi->vent_type == MFLOW_VENT)continue;
     if(ABS(zvi->g_vmin)<VEL_MAX-1.0)zone_maxventflow = MAX(ABS(zvi->g_vmin), zone_maxventflow);
     if(ABS(zvi->g_vmax)<VEL_MAX-1.0)zone_maxventflow = MAX(ABS(zvi->g_vmax), zone_maxventflow);
@@ -836,23 +836,23 @@ void GetZoneGlobalBounds(const float *pdata, int ndata, float *pglobalmin, float
 void GetSliceTempBounds(void){
   int i;
 
-  for(i=0; i<slicecoll.nsliceinfo; i++){
+  for(i=0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     int framesize, headersize, return_val, error;
     int ntimes_slice_old=0;
     float qmin, qmax;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     if(strcmp(slicei->label.shortlabel, "TEMP")!=0)continue;
     GetSliceSizes(slicei->file, ALL_FRAMES, &slicei->nslicei, &slicei->nslicej, &slicei->nslicek, &slicei->ntimes, tload_step, &error,
-                  use_tload_begin, use_tload_end, tload_begin, tload_end, &headersize, &framesize);
+                  use_tload_begin, use_tload_end, global_scase.tload_begin, global_scase.tload_end, &headersize, &framesize);
     return_val = NewResizeMemory(slicei->qslicedata, sizeof(float)*(slicei->nslicei+1)*(slicei->nslicej+1)*(slicei->nslicek+1)*slicei->ntimes);
     if(return_val!=0)return_val = NewResizeMemory(slicei->times, sizeof(float)*slicei->ntimes);
     qmin = 1.0e30;
     qmax = -1.0e30;
     GetSliceData(slicei, slicei->file, ALL_FRAMES, &slicei->is1, &slicei->is2, &slicei->js1, &slicei->js2, &slicei->ks1, &slicei->ks2, &slicei->idir,
       &qmin, &qmax, slicei->qslicedata, slicei->times, ntimes_slice_old, &slicei->ntimes,
-      tload_step, use_tload_begin, use_tload_end, tload_begin, tload_end
+      tload_step, use_tload_begin, use_tload_end, global_scase.tload_begin, global_scase.tload_end
     );
     slicei->globalmin_slice = qmin;
     slicei->globalmax_slice = qmax;
@@ -874,8 +874,8 @@ void ReadZone(int ifile, int flag, int *errorcode){
 
   *errorcode=0;
 
-  assert(ifile>=0&&ifile<nzoneinfo);
-  zonei = zoneinfo + ifile;
+  assert(ifile>=0&&ifile<global_scase.nzoneinfo);
+  zonei = global_scase.zoneinfo + ifile;
   file = zonei->file;
   if(zonei->loaded==0&&flag==UNLOAD)return;
   FREEMEMORY(zonevents);
@@ -933,28 +933,28 @@ void ReadZone(int ifile, int flag, int *errorcode){
   }
   else{
     getzonesize(file,&nzone_times,&nrooms2,&nfires2,&error);
-    nzhvents2=nzhvents;
-    nzvvents2=nzvvents;
+    nzhvents2=global_scase.nzhvents;
+    nzvvents2=global_scase.nzvvents;
   }
   CheckMemory;
-  if(error!=0||nrooms!=nrooms2||nzone_times==0||nzhvents!=nzhvents2||nzvvents!=nzvvents2||nzmvents!=nzmvents2){
+  if(error!=0||global_scase.nrooms!=nrooms2||nzone_times==0||global_scase.nzhvents!=nzhvents2||global_scase.nzvvents!=nzvvents2||global_scase.nzmvents!=nzmvents2){
     showzone=0;
     UpdateTimes();
     ReadZoneFile=0;
-    if(nrooms!=nrooms2){
-      fprintf(stderr,"*** Error: number of rooms specified in the smv file (%i)\n",nrooms);
+    if(global_scase.nrooms!=nrooms2){
+      fprintf(stderr,"*** Error: number of rooms specified in the smv file (%i)\n",global_scase.nrooms);
       fprintf(stderr,"    not consistent with the number specified in the zone file (%i)\n",nrooms2);
     }
-    if(nzhvents!=nzhvents2){
-      fprintf(stderr,"*** Error: number of horizontal flow vents specified in the smv file (%i)\n",nzhvents);
+    if(global_scase.nzhvents!=nzhvents2){
+      fprintf(stderr,"*** Error: number of horizontal flow vents specified in the smv file (%i)\n",global_scase.nzhvents);
       fprintf(stderr,"    not consistent with the number specified in the data file (%i)\n",nzhvents2);
     }
-    if(nzvvents!=nzvvents2){
-      fprintf(stderr,"*** Error: number of vertical flow vents specified in the smv file (%i)\n",nzvvents);
+    if(global_scase.nzvvents!=nzvvents2){
+      fprintf(stderr,"*** Error: number of vertical flow vents specified in the smv file (%i)\n",global_scase.nzvvents);
       fprintf(stderr,"    not consistent with the number specified in the data file (%i)\n",nzvvents2);
     }
-    if(nzmvents != nzmvents2){
-      fprintf(stderr, "*** Error: number of mechanical vents specified in the smv file (%i)\n", nzmvents);
+    if(global_scase.nzmvents != nzmvents2){
+      fprintf(stderr, "*** Error: number of mechanical vents specified in the smv file (%i)\n", global_scase.nzmvents);
       fprintf(stderr, "    not consistent with the number specified in the data file (%i)\n", nzmvents2);
     }
     if(nzone_times <= 0)fprintf(stderr, "*** Error: The file, %s, contains no data\n", file);
@@ -967,7 +967,7 @@ void ReadZone(int ifile, int flag, int *errorcode){
   if(NewMemory((void **)&zonelonglabels  ,LABELLEN)==0||
      NewMemory((void **)&zoneshortlabels ,LABELLEN)==0||
      NewMemory((void **)&zoneunits       ,LABELLEN)==0||
-     NewMemory((void **)&zonelevels      ,nrgb*sizeof(float))==0){
+     NewMemory((void **)&zonelevels      ,global_scase.nrgb*sizeof(float))==0){
     *errorcode=1;
     return;
   }
@@ -975,7 +975,7 @@ void ReadZone(int ifile, int flag, int *errorcode){
 
   PRINTF("Loading zone data: %s\n",file);
 
-  ntotal_rooms = nrooms*nzone_times;
+  ntotal_rooms = global_scase.nrooms*nzone_times;
   nzonetotal=ntotal_rooms;
 
   if(ntotal_rooms>0){
@@ -1016,10 +1016,10 @@ void ReadZone(int ifile, int flag, int *errorcode){
     FREEMEMORY(zoneslab_F);
     FREEMEMORY(zoneslab_YB);
     FREEMEMORY(zoneslab_YT);
-    if(nzhvents+nzvvents+nzmvents>0){
+    if(global_scase.nzhvents+global_scase.nzvvents+global_scase.nzmvents>0){
       int ntotalvents;
 
-      ntotalvents = nzhvents+nzvvents+nzmvents;
+      ntotalvents = global_scase.nzhvents+global_scase.nzvvents+global_scase.nzmvents;
       NewMemory((void **)&zonevents,   nzone_times*ntotalvents*sizeof(float));
       NewMemory((void **)&zoneslab_n,  nzone_times*ntotalvents*sizeof(int));
       NewMemory((void **)&zoneslab_T,  nzone_times*ntotalvents*MAX_HSLABS*sizeof(float));
@@ -1032,12 +1032,12 @@ void ReadZone(int ifile, int flag, int *errorcode){
     FREEMEMORY(zonefheight);
     FREEMEMORY(zonefdiam);
     FREEMEMORY(zonefbase);
-    if(nfires!=0){
+    if(global_scase.nfires!=0){
       if(
-        NewMemory((void **)&zoneqfire,nfires*nzone_times*sizeof(float))==0||
-        NewMemory((void **)&zonefheight,nfires*nzone_times*sizeof(float))==0||
-        NewMemory((void **)&zonefdiam,nfires*nzone_times*sizeof(float))==0||
-        NewMemory((void **)&zonefbase,nfires*nzone_times*sizeof(float))==0
+        NewMemory((void **)&zoneqfire,global_scase.nfires*nzone_times*sizeof(float))==0||
+        NewMemory((void **)&zonefheight,global_scase.nfires*nzone_times*sizeof(float))==0||
+        NewMemory((void **)&zonefdiam,global_scase.nfires*nzone_times*sizeof(float))==0||
+        NewMemory((void **)&zonefbase,global_scase.nfires*nzone_times*sizeof(float))==0
         ){
         *errorcode=1;
         return;
@@ -1098,7 +1098,7 @@ void ReadZone(int ifile, int flag, int *errorcode){
   }
   CheckMemory;
   if(zonei->csv==1){
-    GetZoneDataCSV(nzone_times,nrooms,  nfires, ntargets_local,
+    GetZoneDataCSV(nzone_times,global_scase.nrooms,  global_scase.nfires, ntargets_local,
                    zone_times,zoneqfire, zonefheight, zonefbase, zonefdiam,
                    zonepr,zoneylay,zonetl,zonetu,zonerhol,zonerhou,&zoneodl,&zoneodu, zonevents,
                    zoneslab_n, zoneslab_T, zoneslab_F, zoneslab_YB, zoneslab_YT,
@@ -1107,14 +1107,14 @@ void ReadZone(int ifile, int flag, int *errorcode){
                    &error);
   }
   else{
-    getzonedata(file,&nzone_times,&nrooms, &nfires, zone_times,zoneqfire,zonepr,zoneylay,zonetl,zonetu,&error);
+    getzonedata(file,&nzone_times,&global_scase.nrooms, &global_scase.nfires, zone_times,zoneqfire,zonepr,zoneylay,zonetl,zonetu,&error);
   }
   CheckMemory;
 
   if(zonei->csv==0){
     ii=0;
     for(i=0;i<nzone_times;i++){
-      for(j=0;j<nrooms;j++){
+      for(j=0;j<global_scase.nrooms;j++){
         zonetu[ii] = K2C(zonetu[ii]);
         zonetl[ii] = K2C(zonetl[ii]);
         ii++;
@@ -1124,7 +1124,7 @@ void ReadZone(int ifile, int flag, int *errorcode){
   CheckMemory;
   ii = 0;
   for(i=0;i<nzone_times;i++){
-    for(j=0;j<nrooms;j++){
+    for(j=0;j<global_scase.nrooms;j++){
       if(zonetu[ii]>=500.0){
         hazardcolor[ii]=RED;
       }
@@ -1163,10 +1163,10 @@ void ReadZone(int ifile, int flag, int *errorcode){
     GetSliceTempBounds();
   }
   if(flag==BOUNDS_ONLY)return;
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     if(strcmp(slicei->label.shortlabel, "TEMP")==0){
       zoneglobalmin = MIN(slicei->valmin_slice, zoneglobalmin);
       zoneglobalmax = MAX(slicei->valmax_slice, zoneglobalmax);
@@ -1178,13 +1178,13 @@ void ReadZone(int ifile, int flag, int *errorcode){
   if(setzonemin==SET_MIN)zonemin = zoneusermin;
   if(setzonemax==SET_MAX)zonemax = zoneusermax;
   GLUIUpdateZoneBounds();
-  GetZoneColors(zonetu, ntotal_rooms, izonetu, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-  GetZoneColors(zonetl, ntotal_rooms, izonetl, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-  if(have_zonefl==1)GetZoneColors(zonefl, ntotal_rooms, izonefl, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-  if(have_zonelw==1)GetZoneColors(zonelw, ntotal_rooms, izonelw, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-  if(have_zoneuw==1)GetZoneColors(zoneuw, ntotal_rooms, izoneuw, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-  if(have_zonecl==1)GetZoneColors(zonecl, ntotal_rooms, izonecl, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-  if(have_target_data==1)GetZoneColors(zonetargets, ntotal_targets, izonetargets, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
+  GetZoneColors(zonetu, ntotal_rooms, izonetu, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+  GetZoneColors(zonetl, ntotal_rooms, izonetl, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+  if(have_zonefl==1)GetZoneColors(zonefl, ntotal_rooms, izonefl, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+  if(have_zonelw==1)GetZoneColors(zonelw, ntotal_rooms, izonelw, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+  if(have_zoneuw==1)GetZoneColors(zoneuw, ntotal_rooms, izoneuw, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+  if(have_zonecl==1)GetZoneColors(zonecl, ntotal_rooms, izonecl, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+  if(have_target_data==1)GetZoneColors(zonetargets, ntotal_targets, izonetargets, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
 
   ReadZoneFile=1;
   visZone=1;
@@ -1194,8 +1194,8 @@ void ReadZone(int ifile, int flag, int *errorcode){
   plotstate=GetPlotState(DYNAMIC_PLOTS);
   UpdateTimes();
   updatemenu=1;
-  activezone = zoneinfo + ifile;
-  if(nzhvents>0||nzvvents>0||nzmvents>0){
+  activezone = global_scase.zoneinfo + ifile;
+  if(global_scase.nzhvents>0||global_scase.nzvvents>0||global_scase.nzmvents>0){
     PRINTF("computing vent bounds\n");
     GetZoneVentBounds();
   }
@@ -1287,24 +1287,24 @@ void DrawZoneRoomGeom(void){
     AntiAliasLine(ON);
     glBegin(GL_LINES);
 
-    for(i = 0; i < nrooms; i++){
+    for(i = 0; i < global_scase.nrooms; i++){
       roomdata *roomi;
       float xroom0, yroom0, zroom0, xroom, yroom, zroom;
 
       if(zone_highlight == 1 && zone_highlight_room == i){
         glEnd();
-        glLineWidth(5.0*linewidth);
+        glLineWidth(5.0*global_scase.linewidth);
         glBegin(GL_LINES);
         glColor3f(1.0, 0.0, 0.0);
       }
       else{
         glEnd();
-        glLineWidth(linewidth);
+        glLineWidth(global_scase.linewidth);
         glBegin(GL_LINES);
         glColor4fv(foregroundcolor);
       }
 
-      roomi = roominfo + i;
+      roomi = global_scase.roominfo + i;
       xroom0 = roomi->x0;
       yroom0 = roomi->y0;
       zroom0 = roomi->z0;
@@ -1354,11 +1354,11 @@ void DrawZoneRoomGeom(void){
   }
 
   if(visVents==1){
-    for(i=0;i<nzvents;i++){
+    for(i=0;i<global_scase.nzvents;i++){
       zventdata *zvi;
       float x1, x2, y1, y2, z1, z2;
 
-      zvi = zventinfo + i;
+      zvi = global_scase.zventinfo + i;
       x1 = zvi->x0;
       x2 = zvi->x1;
       y1 = zvi->y0;
@@ -1377,10 +1377,10 @@ void DrawZoneRoomGeom(void){
           DrawSphere(SCALE2SMV(zone_hvac_diam), hvac_sphere_color);
         }
         glPopMatrix();
-        glLineWidth(2.0*ventlinewidth);
+        glLineWidth(2.0*global_scase.ventlinewidth);
       }
       else{
-        glLineWidth(ventlinewidth);
+        glLineWidth(global_scase.ventlinewidth);
       }
       glColor4fv(zvi->color);
       if(zvi->vent_type==VFLOW_VENT&&zvi->vertical_vent_type==ZONEVENT_CIRCLE){
@@ -1402,7 +1402,7 @@ void DrawZoneRoomGeom(void){
           float x45;
 
           x45 = sqrt(2.0)/2.0;
-          glLineWidth(ventlinewidth);
+          glLineWidth(global_scase.ventlinewidth);
           glBegin(GL_LINES);
           glColor3ubv(uc_color);
           glVertex3f(-x45*SCALE2SMV(zvi->radius), -x45*SCALE2SMV(zvi->radius), 0.0);
@@ -1477,12 +1477,12 @@ void DrawZoneVentDataProfile(void){
 
   if(cullfaces==1)glDisable(GL_CULL_FACE);
 
-  for(i=0;i<nzvents;i++){
+  for(i=0;i<global_scase.nzvents;i++){
     int j;
     zventdata *zvi;
     float zelev[NELEV_ZONE];
 
-    zvi = zventinfo + i;
+    zvi = global_scase.zventinfo + i;
     assert(zvi->z0 <= zvi->z1);
     if(zvi->vent_type==VFLOW_VENT||zvi->vent_type==MFLOW_VENT)continue;
     for(j=0;j<NELEV_ZONE;j++){
@@ -1491,14 +1491,14 @@ void DrawZoneVentDataProfile(void){
     GetZoneVentVel(zelev, NELEV_ZONE, zvi->room1, zvi->room2, zvi->vdata, &zvi->vmin, &zvi->vmax, zvi->itempdata);
   }
   factor = 0.1*zone_ventfactor/zone_maxventflow;
-  for(i=0;i<nzvents;i++){
+  for(i=0;i<global_scase.nzvents;i++){
     zventdata *zvi;
     int j;
     float zelev[NELEV_ZONE];
     float *vcolor1,*vcolor2;
     float xmid, ymid;
 
-    zvi = zventinfo + i;
+    zvi = global_scase.zventinfo + i;
 
     if(zvi->vent_type==VFLOW_VENT||zvi->vent_type==MFLOW_VENT)continue;
     for(j=0;j<NELEV_ZONE;j++){
@@ -1614,12 +1614,12 @@ void DrawZoneVentDataSlab(void){
 
   if(cullfaces==1)glDisable(GL_CULL_FACE);
 
-  for(i = 0; i<nzvents; i++){
+  for(i = 0; i<global_scase.nzvents; i++){
     zventdata *zvi;
     int islab;
     float xmid, ymid;
 
-    zvi = zventinfo+i;
+    zvi = global_scase.zventinfo+i;
 
     if((visVentHFlow==0||visventslab!=1)&&zvi->vent_type==HFLOW_VENT)continue;
     if(visVentVFlow==0&&zvi->vent_type==VFLOW_VENT)continue;
@@ -1702,21 +1702,21 @@ void DrawZoneWallData(void){
 
   FillZoneData(izone);
 
-  cl = izonecl + izone*nrooms;
-  uw = izoneuw + izone*nrooms;
-  lw = izonelw + izone*nrooms;
-  fl = izonefl + izone*nrooms;
+  cl = izonecl + izone*global_scase.nrooms;
+  uw = izoneuw + izone*global_scase.nrooms;
+  lw = izonelw + izone*global_scase.nrooms;
+  fl = izonefl + izone*global_scase.nrooms;
 
 
 /* draw the frame */
 
   glBegin(GL_TRIANGLES);
 
-  for(i = 0; i < nrooms; i++){
+  for(i = 0; i < global_scase.nrooms; i++){
     roomdata *roomi;
     float x0, y0, z0, x1, y1, z1, z;
 
-    roomi = roominfo + i;
+    roomi = global_scase.roominfo + i;
     x0 = roomi->x0;
     y0 = roomi->y0;
     z0 = roomi->z0;
@@ -2252,18 +2252,18 @@ void DrawZoneFireData(void){
   if(zone_times[0]>global_times[itimes])return;
   if(cullfaces==1)glDisable(GL_CULL_FACE);
 
-  zoneqfirebase = zoneqfire + izone*nfires;
-  zonefheightbase = zonefheight + izone*nfires;
-  zonefdiambase = zonefdiam + izone*nfires;
-  zonefbasebase = zonefbase + izone*nfires;
+  zoneqfirebase = zoneqfire + izone*global_scase.nfires;
+  zonefheightbase = zonefheight + izone*global_scase.nfires;
+  zonefdiambase = zonefdiam + izone*global_scase.nfires;
+  zonefbasebase = zonefbase + izone*global_scase.nfires;
 
   if(viszonefire==1){
-    for(i=0;i<nfires;i++){
+    for(i=0;i<global_scase.nfires;i++){
       float qdot;
       float diameter, flameheight, maxheight;
 
       qdot = zoneqfirebase[i]/1000.0f;
-      if(zonecsv==1){
+      if(global_scase.zonecsv==1){
         if(qdot>0.0f){
           firedata *firei;
           roomdata *roomi;
@@ -2271,9 +2271,9 @@ void DrawZoneFireData(void){
           meshdata *meshi;
 
           // radius/plumeheight = .268 = atan(15 degrees)
-          firei = fireinfo + i;
-          roomi = roominfo + firei->roomnumber-1;
-          meshi = meshinfo + firei->roomnumber-1;
+          firei = global_scase.fireinfo + i;
+          roomi = global_scase.roominfo + firei->roomnumber-1;
+          meshi = global_scase.meshescoll.meshinfo + firei->roomnumber-1;
           diameter = SCALE2SMV(zonefdiambase[i]);
           deltaz = SCALE2SMV(zonefbasebase[i]);
           maxheight=roomi->z1-roomi->z0-deltaz;
@@ -2293,9 +2293,9 @@ void DrawZoneFireData(void){
           meshdata *meshi;
 
           // radius/plumeheight = .268 = atan(15 degrees)
-          firei = fireinfo + i;
-          roomi = roominfo + firei->roomnumber-1;
-          meshi = meshinfo + firei->roomnumber-1;
+          firei = global_scase.fireinfo + i;
+          roomi = global_scase.roominfo + firei->roomnumber-1;
+          meshi = global_scase.meshescoll.meshinfo + firei->roomnumber-1;
           maxheight=roomi->z1-firei->absz;
           flameheight = SCALE2SMV((0.23f*pow((double)qdot,(double)0.4)/(1.0f+2.0f*0.268f)));
           diameter = 2.0*flameheight*0.268f;
@@ -2332,10 +2332,10 @@ void DrawZoneRoomData(void){
   if(cullfaces==1)glDisable(GL_CULL_FACE);
   if(use_transparency_data==1)TransparentOn();
 
-  izonetubase = izonetu + izone*nrooms;
-  izonetlbase = izonetl + izone*nrooms;
-  hazardcolorbase = hazardcolor + izone*nrooms;
-  zoneylaybase = zoneylay + izone*nrooms;
+  izonetubase = izonetu + izone*global_scase.nrooms;
+  izonetlbase = izonetl + izone*global_scase.nrooms;
+  hazardcolorbase = hazardcolor + izone*global_scase.nrooms;
+  zoneylaybase = zoneylay + izone*global_scase.nrooms;
 
   if(zonecolortype==ZONEHAZARD_COLOR){
     zonecolorbaseU=hazardcolorbase;
@@ -2350,12 +2350,12 @@ void DrawZoneRoomData(void){
      LoadZoneSmokeShaders();
    }
 #endif
-  for(i=0;i<nrooms;i++){
+  for(i=0;i<global_scase.nrooms;i++){
     roomdata *roomi;
     unsigned char colorU;
     unsigned char colorL;
 
-    roomi = roominfo + i;
+    roomi = global_scase.roominfo + i;
 
     ylay = *(zoneylaybase+i);
     colorU = *(zonecolorbaseU+i);

--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -151,8 +151,8 @@ int Loadsmvall(const char *input_filename) {
   int return_code;
   // fdsprefix and input_filename_ext are global and defined in smokeviewvars.h
   // TODO: move these into the model information namespace
-  ParseSmvFilepath(input_filename, fdsprefix, input_filename_ext);
-  return_code = Loadsmv(fdsprefix, input_filename_ext);
+  ParseSmvFilepath(input_filename, global_scase.fdsprefix, input_filename_ext);
+  return_code = Loadsmv(global_scase.fdsprefix, input_filename_ext);
 #ifdef pp_HIST
   if(return_code == 0 && update_bounds == 1) return_code = Update_Bounds();
 #endif
@@ -280,7 +280,7 @@ int Loadsmv(char *input_filename, char *input_filename_ext_arg) {
   InitTranslate(smv_bindir, tr_name);
   FREEMEMORY(smv_bindir);
 
-  if(tourcoll.ntourinfo == 0) SetupTour();
+  if(global_scase.tourcoll.ntourinfo == 0) SetupTour();
   InitRolloutList();
   GLUIColorbarSetup(mainwindow_id);
   GLUIMotionSetup(mainwindow_id);
@@ -324,39 +324,39 @@ int Loadfile(const char *filename) {
     return 1;
   }
 
-  for(size_t i = 0; i < slicecoll.nsliceinfo; i++) {
+  for(size_t i = 0; i < global_scase.slicecoll.nsliceinfo; i++) {
     slicedata *sd;
 
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     if(strcmp(sd->file, filename) == 0) {
       ReadSlice(sd->file, i, ALL_FRAMES, NULL, LOAD, SET_SLICECOLOR,
                 &errorcode);
       return errorcode;
     }
   }
-  for(size_t i = 0; i < npatchinfo; i++) {
+  for(size_t i = 0; i < global_scase.npatchinfo; i++) {
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(strcmp(patchi->file, filename) == 0) {
       ReadBoundary(i, LOAD, &errorcode);
       return errorcode;
     }
   }
-  for(size_t i = 0; i < npartinfo; i++) {
+  for(size_t i = 0; i < global_scase.npartinfo; i++) {
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     if(strcmp(parti->file, filename) == 0) {
       LoadParticleMenu(i);
       return errorcode;
     }
   }
   CancelUpdateTriangles();
-  for(size_t i = 0; i < nisoinfo; i++) {
+  for(size_t i = 0; i < global_scase.nisoinfo; i++) {
     isodata *isoi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     if(strcmp(isoi->file, filename) == 0) {
       ReadIso(isoi->file, i, LOAD, NULL, &errorcode);
       if(update_readiso_geom_wrapup == UPDATE_ISO_ONE_NOW)
@@ -364,29 +364,29 @@ int Loadfile(const char *filename) {
       return errorcode;
     }
   }
-  for(size_t i = 0; i < smoke3dcoll.nsmoke3dinfo; i++) {
+  for(size_t i = 0; i < global_scase.smoke3dcoll.nsmoke3dinfo; i++) {
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     if(strcmp(smoke3di->file, filename) == 0) {
       smoke3di->finalize = 1;
       ReadSmoke3D(ALL_SMOKE_FRAMES, i, LOAD, FIRST_TIME, &errorcode);
       return errorcode;
     }
   }
-  for(size_t i = 0; i < nzoneinfo; i++) {
+  for(size_t i = 0; i < global_scase.nzoneinfo; i++) {
     zonedata *zonei;
 
-    zonei = zoneinfo + i;
+    zonei = global_scase.zoneinfo + i;
     if(strcmp(zonei->file, filename) == 0) {
       ReadZone(i, LOAD, &errorcode);
       return errorcode;
     }
   }
-  for(size_t i = 0; i < nplot3dinfo; i++) {
+  for(size_t i = 0; i < global_scase.nplot3dinfo; i++) {
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     if(strcmp(plot3di->file, filename) == 0) {
       ReadPlot3D(plot3di->file, i, LOAD, &errorcode);
       UpdateMenu();
@@ -408,12 +408,12 @@ void Loadinifile(const char *filepath) {
 }
 
 int Loadvfile(const char *filepath) {
-  for(size_t i = 0; i < slicecoll.nvsliceinfo; i++) {
+  for(size_t i = 0; i < global_scase.slicecoll.nvsliceinfo; i++) {
     slicedata *val;
     vslicedata *vslicei;
 
-    vslicei = slicecoll.vsliceinfo + i;
-    val = slicecoll.sliceinfo + vslicei->ival;
+    vslicei = global_scase.slicecoll.vsliceinfo + i;
+    val = global_scase.slicecoll.sliceinfo + vslicei->ival;
     if(val == NULL) continue;
     if(strcmp(val->reg_file, filepath) == 0) {
       LoadVSliceMenu(i);
@@ -428,10 +428,10 @@ void Loadboundaryfile(const char *filepath) {
   int errorcode;
   int count = 0;
 
-  for(size_t i = 0; i < npatchinfo; i++) {
+  for(size_t i = 0; i < global_scase.npatchinfo; i++) {
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(strcmp(patchi->label.longlabel, filepath) == 0) {
       THREADcontrol(compress_threads, THREAD_LOCK);
       ReadBoundary(i, LOAD, &errorcode);
@@ -464,9 +464,7 @@ void Renderclip(int flag, int left, int right, int bottom, int top) {
 }
 
 ERROR_CODE CApiRender(const char *filename) {
-  // runluascript=0;
   DisplayCB();
-  // runluascript=1;
   // strcpy(render_file_base,filename);
   return RenderFrameLua(VIEW_CENTER, filename);
 }
@@ -761,7 +759,7 @@ int Settime(float timeval) {
 /// @brief Show slices in blockages.
 /// @param setting Boolean
 void SetSliceInObst(int setting) {
-  show_slice_in_obst = setting;
+  global_scase.show_slice_in_obst = setting;
   // UpdateSliceFilenum();
   // plotstate=GetPlotState(DYNAMIC_PLOTS);
   //
@@ -771,7 +769,7 @@ void SetSliceInObst(int setting) {
 
 /// @brief Check if slices are being shown in obstructions.
 /// @return
-int GetSliceInObst() { return show_slice_in_obst; }
+int GetSliceInObst() { return global_scase.show_slice_in_obst; }
 
 /// @brief Set the colorbar to one named @p name
 /// @param name
@@ -913,7 +911,7 @@ int GetChidVisibility() { return vis_title_CHID; }
 void ToggleChidVisibility() { vis_title_CHID = 1 - vis_title_CHID; }
 
 void BlockagesShowAll() {
-  if(isZoneFireModel) visFrame = 1;
+  if(global_scase.isZoneFireModel) visFrame = 1;
   /*
   visFloor=1;
   visWalls=1;
@@ -929,23 +927,23 @@ void BlockageMenu(int value);
 void BlockagesHideAll() { BlockageMenu(visBLOCKHide); }
 // TODO: clarify behaviour under isZoneFireModel
 void OutlinesHide() {
-  if(isZoneFireModel == 0) visFrame = 1 - visFrame;
+  if(global_scase.isZoneFireModel == 0) visFrame = 0;
 }
 void OutlinesShow() {
-  if(isZoneFireModel == 0) visFrame = 1 - visFrame;
+  if(global_scase.isZoneFireModel == 0) visFrame = 1;
 }
 
 void SurfacesHideAll() {
   visVents = 0;
   visOpenVents = 0;
   visDummyVents = 0;
-  visOtherVents = 0;
+  global_scase.visOtherVents = 0;
   visCircularVents = VENT_HIDE;
 }
 
 void DevicesHideAll() {
-  for(size_t i = 0; i < objectscoll->nobject_defs; i++) {
-    sv_object *objecti = objectscoll->object_defs[i];
+  for(size_t i = 0; i < global_scase.objectscoll.nobject_defs; i++) {
+    sv_object *objecti = global_scase.objectscoll.object_defs[i];
     objecti->visible = 0;
   }
 }
@@ -1173,11 +1171,11 @@ int BlockageOutlineColor(int setting) {
   switch(setting) {
   case 0:
     outline_color_flag = 0;
-    updatefaces = 1;
+    global_scase.updatefaces = 1;
     break;
   case 1:
     outline_color_flag = 1;
-    updatefaces = 1;
+    global_scase.updatefaces = 1;
     break;
   default:
     return 1;
@@ -1231,11 +1229,11 @@ void Loadvolsmoke(int meshnumber) {
     read_vol_mesh = VOL_READALL;
     ReadVolsmokeAllFramesAllMeshes2(NULL);
   }
-  else if(imesh >= 0 && imesh < nmeshes) {
+  else if(imesh >= 0 && imesh < global_scase.meshescoll.nmeshes) {
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo + imesh;
+    meshi = global_scase.meshescoll.meshinfo + imesh;
     vr = meshi->volrenderinfo;
     ReadVolsmokeAllFrames(vr);
   }
@@ -1249,17 +1247,16 @@ void Loadvolsmoke(int meshnumber) {
 void Loadvolsmokeframe(int meshnumber, int framenumber, int flag) {
   int framenum, index;
   int first = 1;
-  int i;
 
   index = meshnumber;
   framenum = framenumber;
-  if(index > nmeshes - 1) index = -1;
-  for(i = 0; i < nmeshes; i++) {
+  if(index > global_scase.meshescoll.nmeshes - 1) index = -1;
+  for(size_t i = 0; i < global_scase.meshescoll.nmeshes; i++) {
     if(index == i || index < 0) {
       meshdata *meshi;
       volrenderdata *vr;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       vr = meshi->volrenderinfo;
       FreeVolsmokeFrame(vr, framenum);
       ReadVolsmokeFrame(vr, framenum, &first);
@@ -1276,7 +1273,7 @@ void Loadvolsmokeframe(int meshnumber, int framenumber, int flag) {
   UpdateTimes();
   force_redisplay = 1;
   UpdateFrameNumber(framenum);
-  i = framenum;
+  int i = framenum;
   itimes = i;
   script_itime = i;
   stept = 1;
@@ -1293,30 +1290,30 @@ void Load3dsmoke(const char *smoke_type) {
   int count = 0;
   int lastsmoke;
 
-  for(size_t i = smoke3dcoll.nsmoke3dinfo - 1; i >= 0; i--) {
+  for(size_t i = global_scase.smoke3dcoll.nsmoke3dinfo - 1; i >= 0; i--) {
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     if(MatchUpper(smoke3di->label.longlabel, smoke_type) == MATCH) {
       lastsmoke = i;
       break;
     }
   }
 
-  for(size_t i = smoke3dcoll.nsmoke3dinfo - 1; i >= 0; i--) {
+  for(size_t i = global_scase.smoke3dcoll.nsmoke3dinfo - 1; i >= 0; i--) {
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     if(MatchUpper(smoke3di->label.longlabel, smoke_type) == MATCH) {
       lastsmoke = i;
       break;
     }
   }
 
-  for(size_t i = 0; i < smoke3dcoll.nsmoke3dinfo; i++) {
+  for(size_t i = 0; i < global_scase.smoke3dcoll.nsmoke3dinfo; i++) {
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     if(MatchUpper(smoke3di->label.longlabel, smoke_type) == MATCH) {
       smoke3di->finalize = 0;
       if(lastsmoke == i) smoke3di->finalize = 1;
@@ -1377,10 +1374,10 @@ int Loadtour(const char *tourname) {
   int count = 0;
   int errorcode = 0;
 
-  for(size_t i = 0; i < tourcoll.ntourinfo; i++) {
+  for(size_t i = 0; i < global_scase.tourcoll.ntourinfo; i++) {
     tourdata *touri;
 
-    touri = tourcoll.tourinfo + i;
+    touri = global_scase.tourcoll.tourinfo + i;
     if(strcmp(touri->label, tourname) == 0) {
       TourMenu(i);
       viewtourfrompath = 0;
@@ -1404,17 +1401,17 @@ void Loadparticles(const char *name) {
   int count = 0;
 
   npartframes_max = GetMinPartFrames(PARTFILE_LOADALL);
-  for(size_t i = 0; i < npartinfo; i++) {
+  for(size_t i = 0; i < global_scase.npartinfo; i++) {
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     ReadPart(parti->file, i, UNLOAD, &errorcode);
     count++;
   }
-  for(size_t i = 0; i < npartinfo; i++) {
+  for(size_t i = 0; i < global_scase.npartinfo; i++) {
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     ReadPart(parti->file, i, LOAD, &errorcode);
     count++;
   }
@@ -1450,11 +1447,11 @@ void Partclasstype(const char *part_type) {
 
     propi = part5propinfo + i;
     if(propi->display == 0) continue;
-    for(j = 0; j < npartclassinfo; j++) {
+    for(j = 0; j < global_scase.npartclassinfo; j++) {
       partclassdata *partclassj;
 
       if(propi->class_present[j] == 0) continue;
-      partclassj = partclassinfo + j;
+      partclassj = global_scase.partclassinfo + j;
       if(strcmp(partclassj->name, part_type) == 0) {
         ParticlePropShowMenu(-10 - j);
         count++;
@@ -1501,8 +1498,8 @@ void Plot3dprops(int variable_index, int showvector, int vector_length_index,
     meshdata *gbsave, *gbi;
 
     gbsave = current_mesh;
-    for(size_t i = 0; i < nmeshes; i++) {
-      gbi = meshinfo + i;
+    for(size_t i = 0; i < global_scase.meshescoll.nmeshes; i++) {
+      gbi = global_scase.meshescoll.meshinfo + i;
       if(gbi->plot3dfilenum == -1) continue;
       UpdateCurrentMesh(gbi);
       UpdatePlotSlice(XDIR);
@@ -1519,9 +1516,9 @@ void ShowPlot3dData(int meshnumber, int plane_orientation, int display,
   int dir;
   float val;
 
-  if(meshnumber < 0 || meshnumber > nmeshes - 1) return;
+  if(meshnumber < 0 || meshnumber > global_scase.meshescoll.nmeshes - 1) return;
 
-  meshi = meshinfo + meshnumber;
+  meshi = global_scase.meshescoll.meshinfo + meshnumber;
   UpdateCurrentMesh(meshi);
 
   dir = CLAMP(plane_orientation, XDIR, ISO);
@@ -1569,10 +1566,10 @@ void Loadplot3d(int meshnumber, float time_local) {
   size_t count = 0;
   int blocknum = meshnumber - 1;
 
-  for(size_t i = 0; i < nplot3dinfo; i++) {
+  for(size_t i = 0; i < global_scase.nplot3dinfo; i++) {
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     if(plot3di->blocknumber == blocknum &&
        ABS(plot3di->time - time_local) < 0.5) {
       count++;
@@ -1590,11 +1587,11 @@ void Loadiso(const char *type) {
   int count = 0;
 
   update_readiso_geom_wrapup = UPDATE_ISO_START_ALL;
-  for(size_t i = 0; i < nisoinfo; i++) {
+  for(size_t i = 0; i < global_scase.nisoinfo; i++) {
     int errorcode;
     isodata *isoi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     if(STRCMP(isoi->surface_label.longlabel, type) == 0) {
       ReadIso(isoi->file, i, LOAD, NULL, &errorcode);
       count++;
@@ -1613,21 +1610,21 @@ void Loadiso(const char *type) {
 }
 
 FILE_SIZE Loadsliceindex(size_t index, int *errorcode) {
-  return ReadSlice(slicecoll.sliceinfo[index].file, (int)index, ALL_FRAMES, NULL, LOAD,
-                   SET_SLICECOLOR, errorcode);
+  return ReadSlice(global_scase.slicecoll.sliceinfo[index].file, (int)index, ALL_FRAMES,
+                   NULL, LOAD, SET_SLICECOLOR, errorcode);
 }
 
 void Loadslice(const char *type, int axis, float distance) {
   int count = 0;
-  for(int i = 0; i < slicecoll.nmultisliceinfo; i++) {
+  for(int i = 0; i < global_scase.slicecoll.nmultisliceinfo; i++) {
     multislicedata *mslicei;
     slicedata *slicei;
     int j;
     float delta_orig;
 
-    mslicei = slicecoll.multisliceinfo + i;
+    mslicei = global_scase.slicecoll.multisliceinfo + i;
     if(mslicei->nslices <= 0) continue;
-    slicei = slicecoll.sliceinfo + mslicei->islices[0];
+    slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[0];
     if(MatchUpper(slicei->label.longlabel, type) == 0) continue;
     if(slicei->idir != axis) continue;
     delta_orig = slicei->position_orig - distance;
@@ -1650,14 +1647,14 @@ void Loadslice(const char *type, int axis, float distance) {
 void Loadvslice(const char *type, int axis, float distance) {
   float delta_orig;
   int count = 0;
-  for(int i = 0; i < slicecoll.nmultivsliceinfo; i++) {
+  for(int i = 0; i < global_scase.slicecoll.nmultivsliceinfo; i++) {
     multivslicedata *mvslicei;
     int j;
     slicedata *slicei;
 
-    mvslicei = slicecoll.multivsliceinfo + i;
+    mvslicei = global_scase.slicecoll.multivsliceinfo + i;
     if(mvslicei->nvslices <= 0) continue;
-    slicei = slicecoll.sliceinfo + mvslicei->ivslices[0];
+    slicei = global_scase.slicecoll.sliceinfo + mvslicei->ivslices[0];
     if(MatchUpper(slicei->label.longlabel, type) == 0) continue;
     if(slicei->idir != axis) continue;
     delta_orig = slicei->position_orig - distance;
@@ -1685,7 +1682,7 @@ void Unloadslice(int value) {
   if(value >= 0) {
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo + value;
+    slicei = global_scase.slicecoll.sliceinfo + value;
 
     if(slicei->slice_filetype == SLICE_GEOM) {
       ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0,
@@ -1701,10 +1698,10 @@ void Unloadslice(int value) {
   }
   else {
     if(value == UNLOAD_ALL) {
-      for(size_t i = 0; i < slicecoll.nsliceinfo; i++) {
+      for(size_t i = 0; i < global_scase.slicecoll.nsliceinfo; i++) {
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         if(slicei->slice_filetype == SLICE_GEOM) {
           ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0,
                        &errorcode);
@@ -1714,10 +1711,10 @@ void Unloadslice(int value) {
                     &errorcode);
         }
       }
-      for(size_t i = 0; i < npatchinfo; i++) {
+      for(size_t i = 0; i < global_scase.npatchinfo; i++) {
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->filetype_label != NULL &&
            strcmp(patchi->filetype_label, "INCLUDE_GEOM") == 0) {
           UnloadBoundaryMenu(i);
@@ -1734,16 +1731,16 @@ int Unloadall() {
   if(scriptoutstream != NULL) {
     fprintf(scriptoutstream, "UNLOADALL\n");
   }
-  if(hrr_csv_filename != NULL) {
+  if(global_scase.paths.hrr_csv_filename != NULL) {
     ReadHRR(UNLOAD);
   }
   if(nvolrenderinfo > 0) {
     LoadVolsmoke3DMenu(UNLOAD_ALL);
   }
-  for(size_t i = 0; i < slicecoll.nsliceinfo; i++) {
+  for(size_t i = 0; i < global_scase.slicecoll.nsliceinfo; i++) {
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     if(slicei->loaded == 1) {
       if(slicei->slice_filetype == SLICE_GEOM) {
         ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0,
@@ -1755,22 +1752,22 @@ int Unloadall() {
       }
     }
   }
-  for(size_t i = 0; i < nplot3dinfo; i++) {
+  for(size_t i = 0; i < global_scase.nplot3dinfo; i++) {
     ReadPlot3D("", i, UNLOAD, &errorcode);
   }
-  for(size_t i = 0; i < npatchinfo; i++) {
+  for(size_t i = 0; i < global_scase.npatchinfo; i++) {
     ReadBoundary(i, UNLOAD, &errorcode);
   }
-  for(size_t i = 0; i < npartinfo; i++) {
+  for(size_t i = 0; i < global_scase.npartinfo; i++) {
     ReadPart("", i, UNLOAD, &errorcode);
   }
-  for(size_t i = 0; i < nisoinfo; i++) {
+  for(size_t i = 0; i < global_scase.nisoinfo; i++) {
     ReadIso("", i, UNLOAD, NULL, &errorcode);
   }
-  for(size_t i = 0; i < nzoneinfo; i++) {
+  for(size_t i = 0; i < global_scase.nzoneinfo; i++) {
     ReadZone(i, UNLOAD, &errorcode);
   }
-  for(size_t i = 0; i < smoke3dcoll.nsmoke3dinfo; i++) {
+  for(size_t i = 0; i < global_scase.smoke3dcoll.nsmoke3dinfo; i++) {
     ReadSmoke3D(ALL_SMOKE_FRAMES, i, UNLOAD, FIRST_TIME, &errorcode);
   }
   if(nvolrenderinfo > 0) {
@@ -1816,6 +1813,7 @@ int Setviewpoint(const char *viewpoint) {
 /// @return
 int SetOrthoPreset(const char *viewpoint) {
   int command;
+  fprintf(stderr, "setting ortho %s\n", viewpoint);
   if(STRCMP(viewpoint, "XMIN") == 0) {
     command = SCRIPT_VIEWXMIN;
   }
@@ -2095,7 +2093,7 @@ float CameraGetElev() { return camera_current->az_elev[1]; }
 
 void MoveScene(int xm, int ym);
 int CameraZoomToFit() {
-  float offset = (zbar - ybar) / 2.0;
+  float offset = (global_scase.zbar - global_scase.ybar) / 2.0;
   camera_current->eye[1] += offset * 2;
   eye_xyz0[1] = camera_current->eye[1];
   in_external = 0;
@@ -2405,7 +2403,7 @@ int SetIsopointsize(float v) {
 } // ISOPOINTSIZE
 
 int SetLinewidth(float v) {
-  linewidth = v;
+  global_scase.linewidth = v;
   return 0;
 } // LINEWIDTH
 
@@ -2489,7 +2487,7 @@ int SetVectorpointsize(float v) {
 } // VECTORPOINTSIZE
 
 int SetVentlinewidth(float v) {
-  ventlinewidth = v;
+  global_scase.ventlinewidth = v;
   return 0;
 } // VENTLINEWIDTH
 
@@ -2670,8 +2668,8 @@ int SetIsotran2(int v) {
 int SetMeshvis(int n, int vals[]) {
   meshdata *meshi;
   for(size_t i = 0; i < n; i++) {
-    if(i > nmeshes - 1) break;
-    meshi = meshinfo + i;
+    if(i > global_scase.meshescoll.nmeshes - 1) break;
+    meshi = global_scase.meshescoll.meshinfo + i;
     meshi->blockvis = vals[i];
     ONEORZERO(meshi->blockvis);
   }
@@ -2679,10 +2677,10 @@ int SetMeshvis(int n, int vals[]) {
 } // MESHVIS
 
 int SetMeshoffset(int meshnum, int value) {
-  if(meshnum >= 0 && meshnum < nmeshes) {
+  if(meshnum >= 0 && meshnum < global_scase.meshescoll.nmeshes) {
     meshdata *meshi;
 
-    meshi = meshinfo + meshnum;
+    meshi = global_scase.meshescoll.meshinfo + meshnum;
     meshi->mesh_offset_ptr = meshi->mesh_offset;
     return 0;
   }
@@ -2857,7 +2855,7 @@ int SetShowopenvents(int a, int b) {
 } // SHOWOPENVENTS
 
 int SetShowothervents(int v) {
-  visOtherVents = v;
+  global_scase.visOtherVents = v;
   return 0;
 } // SHOWOTHERVENTS
 
@@ -2868,7 +2866,7 @@ int SetShowsensors(int a, int b) {
 } // SHOWSENSORS
 
 int SetShowsliceinobst(int v) {
-  show_slice_in_obst = v;
+  global_scase.show_slice_in_obst = v;
   return 0;
 } // SHOWSLICEINOBST
 
@@ -2891,7 +2889,7 @@ int SetShowstreak(int show, int step, int showhead, int index) {
 } // SHOWSTREAK
 
 int SetShowterrain(int v) {
-  visTerrainType = v;
+  global_scase.visTerrainType = v;
   return 0;
 } // SHOWTERRAIN
 
@@ -3316,7 +3314,7 @@ int SetSmokeskip(int v) {
 } // SMOKESKIP
 
 int SetSmokealbedo(float v) {
-  smoke_albedo = v;
+  global_scase.smoke_albedo = v;
   return 0;
 } // SMOKEALBEDO
 
@@ -3438,9 +3436,9 @@ int SetViewalltours(int v) {
 } // VIEWALLTOURS
 
 int SetViewtimes(float start, float stop, int ntimes) {
-  tourcoll.tour_tstart = start;
-  tourcoll.tour_tstop = stop;
-  tourcoll.tour_ntimes = ntimes;
+  global_scase.tourcoll.tour_tstart = start;
+  global_scase.tourcoll.tour_tstop = stop;
+  global_scase.tourcoll.tour_ntimes = ntimes;
   return 0;
 } // VIEWTIMES
 
@@ -3544,10 +3542,10 @@ int SetMsliceauto(int n, int vals[]) {
   for(size_t i = 0; i < n3dsmokes; i++) {
     seq_id = vals[i];
 
-    if(seq_id >= 0 && seq_id < slicecoll.nmultisliceinfo) {
+    if(seq_id >= 0 && seq_id < global_scase.slicecoll.nmultisliceinfo) {
       multislicedata *mslicei;
 
-      mslicei = slicecoll.multisliceinfo + seq_id;
+      mslicei = global_scase.slicecoll.multisliceinfo + seq_id;
       mslicei->autoload = 1;
     }
   }
@@ -3573,7 +3571,7 @@ int SetCompressauto(int v) {
 //     trim_back(buffer);
 //     token = strtok(buffer, " ");
 //     j = 0;
-//     while(token != NULL&&j<npartclassinfo){
+//     while(token != NULL&&j<global_scase.npartclassinfo){
 //       int visval;
 
 //       sscanf(token, "%i", &visval);
@@ -3614,16 +3612,16 @@ int SetPropindex(int nvals, int *vals) {
     int ind, val;
     ind = *(vals + (i * PROPINDEX_STRIDE + 0));
     val = *(vals + (i * PROPINDEX_STRIDE + 1));
-    if(ind < 0 || ind > npropinfo - 1) return 0;
-    propi = propinfo + ind;
+    if(ind < 0 || ind > global_scase.propcoll.npropinfo - 1) return 0;
+    propi = global_scase.propcoll.propinfo + ind;
     if(val < 0 || val > propi->nsmokeview_ids - 1) return 0;
     propi->smokeview_id = propi->smokeview_ids[val];
     propi->smv_object = propi->smv_objects[val];
   }
-  for(size_t i = 0; i < npartclassinfo; i++) {
+  for(size_t i = 0; i < global_scase.npartclassinfo; i++) {
     partclassdata *partclassi;
 
-    partclassi = partclassinfo + i;
+    partclassi = global_scase.partclassinfo + i;
     UpdatePartClassDepend(partclassi);
   }
   return 0;
@@ -3665,13 +3663,13 @@ int SetShowdevices(int ndevices_ini, const char *const *names) {
 
   char tempname[255]; // temporary buffer to convert from const string
 
-  for(size_t i = 0; i < objectscoll->nobject_defs; i++) {
-    obj_typei = objectscoll->object_defs[i];
+  for(size_t i = 0; i < global_scase.objectscoll.nobject_defs; i++) {
+    obj_typei = global_scase.objectscoll.object_defs[i];
     obj_typei->visible = 0;
   }
   for(size_t i = 0; i < ndevices_ini; i++) {
     strncpy(tempname, names[i], 255 - 1); // use temp buffer
-    obj_typei = GetSmvObject(objectscoll, tempname);
+    obj_typei = GetSmvObject(&global_scase.objectscoll, tempname);
     // obj_typei = GetSmvObject(names[i]);
     if(obj_typei != NULL) {
       obj_typei->visible = 1;
@@ -3877,9 +3875,9 @@ int SetPl3dBoundMax(int pl3dValueIndex, int set, float value) {
 int SetTload(int beginFlag, float beginVal, int endFlag, int endVal,
              int skipFlag, int skipVal) {
   use_tload_begin = beginFlag;
-  tload_begin = beginVal;
+  global_scase.tload_begin = beginVal;
   use_tload_end = endFlag;
-  tload_end = endVal;
+  global_scase.tload_end = endVal;
   use_tload_skip = skipFlag;
   tload_skip = skipVal;
   return 0;
@@ -4000,8 +3998,8 @@ int ShowSmoke3dShowall() {
   updatemenu = 1;
   GLUTPOSTREDISPLAY;
   plotstate = DYNAMIC_PLOTS;
-  for(size_t i = 0; i < smoke3dcoll.nsmoke3dinfo; i++) {
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+  for(size_t i = 0; i < global_scase.smoke3dcoll.nsmoke3dinfo; i++) {
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     if(smoke3di->loaded == 1) smoke3di->display = 1;
   }
   GLUTPOSTREDISPLAY;
@@ -4014,8 +4012,8 @@ int ShowSmoke3dHideall() {
 
   updatemenu = 1;
   GLUTPOSTREDISPLAY;
-  for(size_t i = 0; i < smoke3dcoll.nsmoke3dinfo; i++) {
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+  for(size_t i = 0; i < global_scase.smoke3dcoll.nsmoke3dinfo; i++) {
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     if(smoke3di->loaded == 1) smoke3di->display = 0;
   }
   UpdateShow();
@@ -4026,8 +4024,8 @@ int ShowSlicesShowall() {
 
   updatemenu = 1;
   GLUTPOSTREDISPLAY;
-  for(size_t i = 0; i < slicecoll.nsliceinfo; i++) {
-    slicecoll.sliceinfo[i].display = 1;
+  for(size_t i = 0; i < global_scase.slicecoll.nsliceinfo; i++) {
+    global_scase.slicecoll.sliceinfo[i].display = 1;
   }
   showall_slices = 1;
   UpdateSliceFilenum();
@@ -4042,8 +4040,8 @@ int ShowSlicesHideall() {
 
   updatemenu = 1;
   GLUTPOSTREDISPLAY;
-  for(size_t i = 0; i < slicecoll.nsliceinfo; i++) {
-   slicecoll.sliceinfo[i].display = 0;
+  for(size_t i = 0; i < global_scase.slicecoll.nsliceinfo; i++) {
+    global_scase.slicecoll.sliceinfo[i].display = 0;
   }
   showall_slices = 0;
   UpdateSliceFilenum();

--- a/Source/smokeview/callbacks.c
+++ b/Source/smokeview/callbacks.c
@@ -87,33 +87,33 @@ void NextXIndex(int inc,int flag){
     if(iplotx_all>nplotx_all-1)iplotx_all=0;
     if(visGrid!=NOGRID_NOPROBE)return;
     if(plotstate==DYNAMIC_PLOTS){
-      for(i=0;i<slicecoll.nsliceinfo;i++){
+      for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
         slicedata *slicei;
         meshdata *meshi;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         if(slicei->loaded==0||slicei->display==0)continue;
-        meshi = meshinfo + slicei->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + slicei->blocknumber;
         if(meshi->iplotx_all[iplotx_all]!=-1)return;
       }
-      for(i=0;i<slicecoll.nvsliceinfo;i++){
+      for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
         vslicedata *vslicei;
         meshdata *meshi;
 
-        vslicei = slicecoll.vsliceinfo + i;
+        vslicei = global_scase.slicecoll.vsliceinfo + i;
         if(vslicei->loaded==0||vslicei->display==0)continue;
-        meshi = meshinfo + vslicei->val->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + vslicei->val->blocknumber;
         if(meshi->iploty_all[iploty_all]!=-1)return;
       }
     }
     else{
-      for(i=0;i<nplot3dinfo;i++){
+      for(i=0;i<global_scase.nplot3dinfo;i++){
         plot3ddata *plot3di;
         meshdata *meshi;
 
-        plot3di = plot3dinfo + i;
+        plot3di = global_scase.plot3dinfo + i;
         if(plot3di->loaded==0||plot3di->display==0)continue;
-        meshi = meshinfo + plot3di->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + plot3di->blocknumber;
         if(meshi->iplotx_all[iplotx_all]!=-1)return;
       }
     }
@@ -149,33 +149,33 @@ void NextYIndex(int inc,int flag){
     if(iploty_all>nploty_all-1)iploty_all=0;
     if(visGrid!=NOGRID_NOPROBE)return;
     if(plotstate==DYNAMIC_PLOTS){
-      for(i=0;i<slicecoll.nsliceinfo;i++){
+      for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
         slicedata *slicei;
         meshdata *meshi;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         if(slicei->loaded==0||slicei->display==0)continue;
-        meshi = meshinfo + slicei->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + slicei->blocknumber;
         if(meshi->iploty_all[iploty_all]!=-1)return;
       }
-      for(i=0;i<slicecoll.nvsliceinfo;i++){
+      for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
         vslicedata *vslicei;
         meshdata *meshi;
 
-        vslicei = slicecoll.vsliceinfo + i;
+        vslicei = global_scase.slicecoll.vsliceinfo + i;
         if(vslicei->loaded==0||vslicei->display==0)continue;
-        meshi = meshinfo + vslicei->val->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + vslicei->val->blocknumber;
         if(meshi->iploty_all[iploty_all]!=-1)return;
       }
     }
     else{
-      for(i=0;i<nplot3dinfo;i++){
+      for(i=0;i<global_scase.nplot3dinfo;i++){
         plot3ddata *plot3di;
         meshdata *meshi;
 
-        plot3di = plot3dinfo + i;
+        plot3di = global_scase.plot3dinfo + i;
         if(plot3di->loaded==0||plot3di->display==0)continue;
-        meshi = meshinfo + plot3di->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + plot3di->blocknumber;
         if(meshi->iploty_all[iploty_all]!=-1)return;
       }
     }
@@ -211,33 +211,33 @@ void NextZIndex(int inc,int flag){
     if(iplotz_all>nplotz_all-1)iplotz_all=0;
     if(visGrid!=NOGRID_NOPROBE)return;
     if(plotstate==DYNAMIC_PLOTS){
-      for(i=0;i<slicecoll.nsliceinfo;i++){
+      for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
         slicedata *slicei;
         meshdata *meshi;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         if(slicei->loaded==0||slicei->display==0)continue;
-        meshi = meshinfo + slicei->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + slicei->blocknumber;
         if(meshi->iplotz_all[iplotz_all]!=-1)return;
       }
-      for(i=0;i<slicecoll.nvsliceinfo;i++){
+      for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
         vslicedata *vslicei;
         meshdata *meshi;
 
-        vslicei = slicecoll.vsliceinfo + i;
+        vslicei = global_scase.slicecoll.vsliceinfo + i;
         if(vslicei->loaded==0||vslicei->display==0)continue;
-        meshi = meshinfo + vslicei->val->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + vslicei->val->blocknumber;
         if(meshi->iploty_all[iploty_all]!=-1)return;
       }
     }
     else{
-      for(i=0;i<nplot3dinfo;i++){
+      for(i=0;i<global_scase.nplot3dinfo;i++){
         plot3ddata *plot3di;
         meshdata *meshi;
 
-        plot3di = plot3dinfo + i;
+        plot3di = global_scase.plot3dinfo + i;
         if(plot3di->loaded==0||plot3di->display==0)continue;
-        meshi = meshinfo + plot3di->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + plot3di->blocknumber;
         if(meshi->iplotz_all[iplotz_all]!=-1)return;
       }
     }
@@ -390,13 +390,13 @@ void MouseEditBlockage(int x, int y){
     sd = selectfaceinfo + val;
     highlight_block=sd->blockage;
     highlight_mesh=sd->mesh;
-    meshi = meshinfo + highlight_mesh;
+    meshi = global_scase.meshescoll.meshinfo + highlight_mesh;
     UpdateCurrentMesh(meshi);
     bchighlight_old=bchighlight;
     bchighlight = meshi->blockageinfoptrs[highlight_block];
     for(i=0;i<6;i++){
-      surface_indices[i]=inv_sorted_surfidlist[bchighlight->surf_index[i]];
-      surface_indices_bak[i]=inv_sorted_surfidlist[bchighlight->surf_index[i]];
+      surface_indices[i]=global_scase.surfcoll.inv_sorted_surfidlist[bchighlight->surf_index[i]];
+      surface_indices_bak[i]=global_scase.surfcoll.inv_sorted_surfidlist[bchighlight->surf_index[i]];
     }
 
     glShadeModel(GL_SMOOTH);
@@ -467,11 +467,11 @@ void MouseSelectDevice(int x, int y){
 
   val = (r << (nbluebits+ngreenbits)) | (g << nbluebits) | b;
 
-  if(val>0&&val<ndeviceinfo){
+  if(val>0&&val<global_scase.devicecoll.ndeviceinfo){
     devicedata *devicei;
     float *xyz;
 
-    devicei = deviceinfo+val-1;
+    devicei = global_scase.devicecoll.deviceinfo+val-1;
     devicei->selected = 1-devicei->selected;
     xyz = devicei->xyz;
 
@@ -638,23 +638,23 @@ void CheckTimeBound(void){
         current_script_command->exit=1;
       }
     }
-    for(i=0;i<slicecoll.nsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
       slicedata *sd;
 
-      sd=slicecoll.sliceinfo+i;
+      sd=global_scase.slicecoll.sliceinfo+i;
       sd->itime=0;
     }
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
 
-      meshi=meshinfo+i;
+      meshi=global_scase.meshescoll.meshinfo+i;
 
       meshi->patch_itime=0;
     }
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
 
-      meshi=meshinfo+i;
+      meshi=global_scase.meshescoll.meshinfo+i;
       if(meshi->iso_times==NULL)continue;
       meshi->iso_itime=0;
     }
@@ -662,43 +662,43 @@ void CheckTimeBound(void){
   if((timebar_drag==0&&itimes<0)||(timebar_drag==1&&itimes>nglobal_times-1)){
     izone=nzone_times-1;
     itimes=nglobal_times-1;
-    for(i=0;i<npartinfo;i++){
+    for(i=0;i<global_scase.npartinfo;i++){
       partdata *parti;
 
-      parti=partinfo+i;
+      parti=global_scase.partinfo+i;
       parti->itime=parti->ntimes-1;
     }
-    for(i=0;i<slicecoll.nsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
       slicedata *sd;
 
-      sd=slicecoll.sliceinfo+i;
+      sd=global_scase.slicecoll.sliceinfo+i;
       sd->itime=sd->ntimes-1;
       if(sd->volslice==1)sd->itime--;
     }
-    for(i=0;i<npatchinfo;i++){
+    for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
       meshdata *meshi;
 
-      patchi=patchinfo+i;
+      patchi=global_scase.patchinfo+i;
       if(patchi->loaded == 0)continue;
-      meshi = meshinfo + patchi->blocknumber;
+      meshi = global_scase.meshescoll.meshinfo + patchi->blocknumber;
       meshi->patch_itime=patchi->ntimes-1;
     }
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
 
-      meshi=meshinfo+i;
+      meshi=global_scase.meshescoll.meshinfo+i;
       if(meshi->iso_times==NULL)continue;
       meshi->iso_itime=meshi->niso_times-1;
     }
   }
   /* set blockage visibility */
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int j;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     for(j=0;j<meshi->nbptrs;j++){
       blockagedata *bc;
 
@@ -1547,10 +1547,10 @@ void PrintGPUState(void){
 int IsPartLoaded(void){
   int i;
 
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     if(parti->loaded==0||parti->display==0)continue;
     return 1;
   }
@@ -1562,10 +1562,10 @@ int IsPartLoaded(void){
 int IsPlot3DLoaded(void){
   int i;
 
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->loaded==0||plot3di->display==0)continue;
     return 1;
   }
@@ -1583,10 +1583,10 @@ int GetPlot3DTimeList(int inc){
   if(nplot3dtimelist<=1)return 0;
   delta_time = (plot3dtimelist[1]-plot3dtimelist[0])/2.0;
 
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->loaded==1){
       time = plot3di->time;
       have_plot3d = 1;
@@ -1664,16 +1664,16 @@ void Keyboard(unsigned char key, int flag){
 #define DEVYES_HRRNO  2
 #define DEVNO_HRRYES  3
     case 'A':
-      if(hrrptr==NULL&&ndeviceinfo==0)break;
-      if(hrrptr!=NULL&&ndeviceinfo>0){
+      if(hrrptr==NULL&&global_scase.devicecoll.ndeviceinfo==0)break;
+      if(hrrptr!=NULL&&global_scase.devicecoll.ndeviceinfo>0){
         plot_option++;
         if(plot_option>3)plot_option = 0;
       }
       else{
         int plot_option_temp = DEVNO_HRRNO;
 
-        if(ndeviceinfo==0&&hrrptr!=NULL&&plot_option==DEVNO_HRRNO)plot_option_temp = DEVNO_HRRYES;
-        if(ndeviceinfo>0&&hrrptr==NULL&&plot_option==DEVNO_HRRNO)plot_option_temp = DEVYES_HRRNO;
+        if(global_scase.devicecoll.ndeviceinfo==0&&hrrptr!=NULL&&plot_option==DEVNO_HRRNO)plot_option_temp = DEVNO_HRRYES;
+        if(global_scase.devicecoll.ndeviceinfo>0&&hrrptr==NULL&&plot_option==DEVNO_HRRNO)plot_option_temp = DEVYES_HRRNO;
         plot_option = plot_option_temp;
       }
       // 0 - device no, hrr no
@@ -1722,12 +1722,12 @@ void Keyboard(unsigned char key, int flag){
         HandleMoveKeys(256+key2);
         break;
       }
-      if((visVector==1&&nplot3dloaded>0)||showvslice==1||isZoneFireModel==1){
+      if((visVector==1&&nplot3dloaded>0)||showvslice==1||global_scase.isZoneFireModel==1){
       }
       else{
         break;
       }
-      if(isZoneFireModel==1){
+      if(global_scase.isZoneFireModel==1){
         if(keystate==GLUT_ACTIVE_ALT){
           zone_ventfactor /= 1.5;
         }
@@ -1748,8 +1748,8 @@ void Keyboard(unsigned char key, int flag){
       }
       if(visVector==1&&nplot3dloaded>0){
         gbsave=current_mesh;
-        for(i=0;i<nmeshes;i++){
-          gbi = meshinfo + i;
+        for(i=0;i<global_scase.meshescoll.nmeshes;i++){
+          gbi = global_scase.meshescoll.meshinfo + i;
           if(gbi->plot3dfilenum==-1)continue;
           UpdateCurrentMesh(gbi);
           UpdatePlotSlice(XDIR);
@@ -1799,9 +1799,9 @@ void Keyboard(unsigned char key, int flag){
 #endif
       case GLUT_ACTIVE_CTRL:
       default:
-        if(nrooms>0){
+        if(global_scase.nrooms>0){
           zone_highlight_room++;
-          if(zone_highlight_room>=nrooms)zone_highlight_room=0;
+          if(zone_highlight_room>=global_scase.nrooms)zone_highlight_room=0;
           PRINTF("room %i\n",zone_highlight_room+1);
         }
         else{
@@ -1824,7 +1824,7 @@ void Keyboard(unsigned char key, int flag){
 #endif
         case GLUT_ACTIVE_CTRL:
         default:
-          if(nrooms>0){
+          if(global_scase.nrooms>0){
             zone_highlight = 1 - zone_highlight;
             if(zone_highlight==1){
               PRINTF("room %i\n",zone_highlight_room+1);
@@ -1894,7 +1894,7 @@ void Keyboard(unsigned char key, int flag){
 #endif
       case GLUT_ACTIVE_CTRL:
       default:
-        if(ntotal_blockages>0||isZoneFireModel==0||(isZoneFireModel==1&&ntrnx>0)){
+        if(ntotal_blockages>0||global_scase.isZoneFireModel==0||(global_scase.isZoneFireModel==1&&global_scase.ntrnx>0)){
           switch(visGrid){
             case NOGRID_NOPROBE:
               visGrid=GRID_NOPROBE;
@@ -1928,7 +1928,7 @@ void Keyboard(unsigned char key, int flag){
       else{
         usegpu=0;
       }
-      if(smoke3dcoll.nsmoke3dinfo>0){
+      if(global_scase.smoke3dcoll.nsmoke3dinfo>0){
         GLUIUpdateSmoke3dFlags();
       }
       PrintGPUState();
@@ -1953,16 +1953,16 @@ void Keyboard(unsigned char key, int flag){
       {
         int nslice_loaded_local=0, nvslice_loaded_local=0;
 
-        for(i=0;i<slicecoll.nsliceinfo;i++){
+        for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
           slicedata *sd;
 
-          sd = slicecoll.sliceinfo + i;
+          sd = global_scase.slicecoll.sliceinfo + i;
           if(sd->loaded==1)nslice_loaded_local++;
         }
-        for(i=0;i<slicecoll.nvsliceinfo;i++){
+        for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
           vslicedata *vd;
 
-          vd = slicecoll.vsliceinfo + i;
+          vd = global_scase.slicecoll.vsliceinfo + i;
           if(vd->loaded==1)nvslice_loaded_local++;
         }
         stept=1;
@@ -1990,14 +1990,14 @@ void Keyboard(unsigned char key, int flag){
       break;
     case 'i':
       if(keystate==GLUT_ACTIVE_ALT){ // toggle device visibility
-        if(objectscoll->nobject_defs>0){
+        if(global_scase.objectscoll.nobject_defs>0){
           int vis;
 
-          vis = 1-objectscoll->object_defs[0]->visible;
-          for(i = 0; i<objectscoll->nobject_defs; i++){
+          vis = 1-global_scase.objectscoll.object_defs[0]->visible;
+          for(i = 0; i<global_scase.objectscoll.nobject_defs; i++){
             sv_object *objecti;
 
-            objecti = objectscoll->object_defs[i];
+            objecti = global_scase.objectscoll.object_defs[i];
             objecti->visible = vis;
           }
           updatemenu = 1;
@@ -2009,9 +2009,9 @@ void Keyboard(unsigned char key, int flag){
       }
       break;
     case 'I':
-      show_slice_in_obst++;
-      if(show_slice_in_obst>3)show_slice_in_obst = 0;
-      GLUISliceInObstMenu2Dialog(show_slice_in_obst);
+      global_scase.show_slice_in_obst++;
+      if(global_scase.show_slice_in_obst>3)global_scase.show_slice_in_obst = 0;
+      GLUISliceInObstMenu2Dialog(global_scase.show_slice_in_obst);
       updatemenu = 1;
       break;
     case 'j':
@@ -2025,35 +2025,35 @@ void Keyboard(unsigned char key, int flag){
       GLUIUpdateDeviceSize();
       break;
     case '`':
-      if(ndeviceinfo>0){
+      if(global_scase.devicecoll.ndeviceinfo>0){
         int selected;
 
-        selected = 1-deviceinfo[0].selected;
+        selected = 1-global_scase.devicecoll.deviceinfo[0].selected;
         if(selected==1&&select_device==0)select_device = 1;
-        for(i = 0; i<ndeviceinfo; i++){
+        for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
           devicedata *devicei;
 
-          devicei = deviceinfo+i;
+          devicei = global_scase.devicecoll.deviceinfo+i;
           devicei->selected = selected;
         }
       }
-      if(objectscoll->nobject_defs>0){
+      if(global_scase.objectscoll.nobject_defs>0){
         int makevis=1;
 
-        for(i = 0; i<objectscoll->nobject_defs; i++){
+        for(i = 0; i<global_scase.objectscoll.nobject_defs; i++){
           sv_object *objecti;
 
-          objecti = objectscoll->object_defs[i];
+          objecti = global_scase.objectscoll.object_defs[i];
           if(objecti->visible==1){
             makevis = 0;
             break;
           }
         }
         if(makevis==1){
-          for(i = 0; i<objectscoll->nobject_defs; i++){
+          for(i = 0; i<global_scase.objectscoll.nobject_defs; i++){
             sv_object *objecti;
 
-            objecti = objectscoll->object_defs[i];
+            objecti = global_scase.objectscoll.object_defs[i];
             objecti->visible = 1;
           }
         }
@@ -2113,10 +2113,10 @@ void Keyboard(unsigned char key, int flag){
 #endif
       case GLUT_ACTIVE_CTRL:
       default:
-        if(nmeshes>1){
+        if(global_scase.meshescoll.nmeshes>1){
           highlight_mesh++;
-          if(highlight_mesh>nmeshes-1)highlight_mesh=0;
-          UpdateCurrentMesh(meshinfo+highlight_mesh);
+          if(highlight_mesh>global_scase.meshescoll.nmeshes-1)highlight_mesh=0;
+          UpdateCurrentMesh(global_scase.meshescoll.meshinfo+highlight_mesh);
         }
       }
       break;
@@ -2169,7 +2169,7 @@ void Keyboard(unsigned char key, int flag){
       if(force_bound_update == 0)printf("bound updates: only when bound files have changed\n");
       break;
     case 'O':
-    if(ncgeominfo>0){
+    if(global_scase.ngeominfo>0){
       if(show_faces_outline==0&&show_faces_shaded==1){
         show_faces_outline = 1;
         show_faces_shaded = 1;
@@ -2252,8 +2252,8 @@ void Keyboard(unsigned char key, int flag){
           updatemenu = 1;
           glutPostRedisplay();
         }
-        if(highlight_flag>2&&noutlineinfo>0)highlight_flag=0;
-        if(highlight_flag>1&&noutlineinfo==0)highlight_flag=0;
+        if(highlight_flag>2&&global_scase.noutlineinfo>0)highlight_flag=0;
+        if(highlight_flag>1&&global_scase.noutlineinfo==0)highlight_flag=0;
         PRINTF("outline mode=%i\n",highlight_flag);
       }
       break;
@@ -2319,10 +2319,10 @@ void Keyboard(unsigned char key, int flag){
       else{
         blocklocation++;
       }
-      if((NCADGeom(cadgeomcoll)==0&&blocklocation>BLOCKlocation_exact)||blocklocation>BLOCKlocation_cad){
+      if((NCADGeom(&global_scase.cadgeomcoll)==0&&blocklocation>BLOCKlocation_exact)||blocklocation>BLOCKlocation_cad){
         blocklocation=BLOCKlocation_grid;
       }
-      if(ncgeominfo>0){
+      if(global_scase.ncgeominfo>0){
         if(blocklocation==BLOCKlocation_grid){
           use_cfaces = 1;
           printf("cfaces: ");
@@ -2354,10 +2354,10 @@ void Keyboard(unsigned char key, int flag){
       break;
     case 'Q':
       showhide_textures = 1-showhide_textures;
-      for(i = 0; i<ntextureinfo; i++){
+      for(i = 0; i<global_scase.texture_coll.ntextureinfo; i++){
         texturedata *texti;
 
-        texti = textureinfo+i;
+        texti = global_scase.texture_coll.textureinfo+i;
         if(texti->loaded==0||texti->used==0)continue;
         if(texti->display==0){ // if any textures are hidden then show them all
           showhide_textures = 1;
@@ -2413,14 +2413,14 @@ void Keyboard(unsigned char key, int flag){
             fprintf(scriptoutstream,"SETTIMEVAL\n");
             fprintf(scriptoutstream," %f\n",timeval);
             if(nvolrenderinfo>0&&load_at_rendertimes==1){
-              for(i=0;i<nmeshes;i++){
+              for(i=0;i<global_scase.meshescoll.nmeshes;i++){
                 meshdata *meshi;
                 volrenderdata *vr;
                 int j;
                 int framenum;
                 float timediffmin;
 
-                meshi = meshinfo + i;
+                meshi = global_scase.meshescoll.meshinfo + i;
                 vr = meshi->volrenderinfo;
                 if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
                 if(vr->loaded==0||vr->display==0)continue;
@@ -2443,15 +2443,15 @@ void Keyboard(unsigned char key, int flag){
           else{
             int show_plot3dkeywords=0;
 
-            for(i=0;i<nmeshes;i++){
+            for(i=0;i<global_scase.meshescoll.nmeshes;i++){
               meshdata *meshi;
               plot3ddata *plot3di;
               float *xp, *yp, *zp;
 
-              meshi = meshinfo  + i;
+              meshi = global_scase.meshescoll.meshinfo  + i;
               if(meshi->plot3dfilenum==-1)continue;
 
-              plot3di = plot3dinfo + meshi->plot3dfilenum;
+              plot3di = global_scase.plot3dinfo + meshi->plot3dfilenum;
               if(plot3di->display==0)continue;
               show_plot3dkeywords=1;
               xp = meshi->xplt_orig;
@@ -2791,7 +2791,7 @@ void Keyboard(unsigned char key, int flag){
       Quat2Rot(quat_general,quat_rotation);
       break;
     case '=':
-      if(ngeominfo>0){
+      if(global_scase.ngeominfo>0){
         select_geom++;
         if(select_geom==5)select_geom=0;
         if(select_geom==GEOM_PROP_NONE)printf("geometry selection off\n");
@@ -2863,7 +2863,7 @@ void Keyboard(unsigned char key, int flag){
       partfast = 1 - partfast;
 #ifndef pp_PARTFRAME
       if(current_script_command==NULL){
-        if(npartinfo>1){
+        if(global_scase.npartinfo>1){
           use_partload_threads = partfast;
         }
         else{
@@ -2896,7 +2896,7 @@ void Keyboard(unsigned char key, int flag){
         force_alpha_opaque = 1 - force_alpha_opaque;
         if(force_alpha_opaque == 1)printf("force smoke/fire opaqueness: yes\n");
         if(force_alpha_opaque == 0)printf("force smoke/fire opaqueness: no\n");
-        update_smoke_alphas = 1;
+        global_scase.update_smoke_alphas = 1;
         GLUIForceAlphaOpaque();
         GLUTPOSTREDISPLAY;
       }
@@ -2909,7 +2909,7 @@ void Keyboard(unsigned char key, int flag){
       break;
     case '&':
       if(keystate==GLUT_ACTIVE_ALT){
-        if(hvaccoll.nhvacinfo > 0){
+        if(global_scase.hvaccoll.nhvacinfo > 0){
           ToggleMetroMode();
           PRINTF("HVAC metro view mode=%i\n", hvac_metro_view);
         }
@@ -2984,13 +2984,13 @@ void Keyboard(unsigned char key, int flag){
     if(stepclip_xmin==1  )clip_i += skip_global*ClipDir;
     if(stepclip_ymin==1  )clip_j += skip_global*ClipDir;
     if(stepclip_zmin==1  )clip_k += skip_global*ClipDir;
-    if(stepclip_xmax==1  )clip_I += skip_global*ClipDir;
-    if(stepclip_ymax==1  )clip_J += skip_global*ClipDir;
-    if(stepclip_zmax==1  )clip_K += skip_global*ClipDir;
+    if(stepclip_xmax==1  )global_scase.clip_I += skip_global*ClipDir;
+    if(stepclip_ymax==1  )global_scase.clip_J += skip_global*ClipDir;
+    if(stepclip_zmax==1  )global_scase.clip_K += skip_global*ClipDir;
 
-    UpdateClipbounds(clipinfo.clip_xmin,&clip_i,clipinfo.clip_xmax,&clip_I,current_mesh->ibar);
-    UpdateClipbounds(clipinfo.clip_ymin,&clip_j,clipinfo.clip_ymax,&clip_J,current_mesh->jbar);
-    UpdateClipbounds(clipinfo.clip_zmin,&clip_k,clipinfo.clip_zmax,&clip_K,current_mesh->kbar);
+    UpdateClipbounds(clipinfo.clip_xmin,&clip_i,clipinfo.clip_xmax,&global_scase.clip_I,current_mesh->ibar);
+    UpdateClipbounds(clipinfo.clip_ymin,&clip_j,clipinfo.clip_ymax,&global_scase.clip_J,current_mesh->jbar);
+    UpdateClipbounds(clipinfo.clip_zmin,&clip_k,clipinfo.clip_zmax,&global_scase.clip_K,current_mesh->kbar);
     return;
   }
 
@@ -3168,12 +3168,12 @@ void SpecialKeyboardCB(int key, int x, int y){
 float SetClipVal(int flag){
   int i;
 
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     float *xplt, *yplt, *zplt;
     int plotx, ploty, plotz;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
 
     switch(flag){
       case 0:
@@ -3387,7 +3387,7 @@ void HandleMoveKeys(int  key){
 
   glui_move_mode=-1;
 
-  INC_XY=SCALE2SMV(meshinfo->cellsize);
+  INC_XY=SCALE2SMV(global_scase.meshescoll.meshinfo->cellsize);
   INC_Z=INC_XY;
   INC_ANGLE = 5*INC_ANGLE0;
 
@@ -3713,7 +3713,7 @@ void ReshapeCB(int width, int height){
   windowresized=1;
   CopyCamera(camera_current,camera_save);
   // don't update faces after resizing the window
-  updatefaces = 0;
+  global_scase.updatefaces = 0;
   updatefacelists = 0;
   windowsize_pointer_old = -1;
   GLUIUpdateWindowSizeList();
@@ -3743,10 +3743,10 @@ void UpdatePlot3dTitle(void){
   GetBaseTitle("Smokeview ", title_base);
   STRCPY(plot3d_title, title_base);
   meshi = current_mesh;
-  if(meshi == NULL)meshi = meshinfo;
+  if(meshi == NULL)meshi = global_scase.meshescoll.meshinfo;
   filenum = meshi->plot3dfilenum;
   if(filenum != -1){
-    plot3di = plot3dinfo + meshi->plot3dfilenum;
+    plot3di = global_scase.plot3dinfo + meshi->plot3dfilenum;
     STRCAT(plot3d_title, ", ");
     STRCAT(plot3d_title, plot3di->file);
   }
@@ -3980,7 +3980,7 @@ void DoScript(void){
   if(nscriptinfo>0&&current_script_command!=NULL&&(script_step==0||(script_step==1&&script_step_now==1))){
     script_step_now=0;
 #ifndef WIN32
-    if(FILE_EXISTS(stop_filename)==YES){
+    if(FILE_EXISTS(global_scase.paths.stop_filename)==YES){
       fprintf(stderr,"*** Warning: stop file found.  Remove before running smokeview script\n");
       SMV_EXIT(0);
     }

--- a/Source/smokeview/camera.c
+++ b/Source/smokeview/camera.c
@@ -99,12 +99,12 @@ void UpdateCameraYpos(cameradata *ci, int option){
     ci->zcen = FDS2SMV_Z((geom_zmin+geom_zmax)/2.0);
   }
   else{
-    dx = xbar;
-    dy = ybar;
-    dz = zbar;
-    ci->xcen = xbar/2.0;
-    ci->ycen = ybar/2.0;
-    ci->zcen = zbar/2.0;
+    dx = global_scase.xbar;
+    dy = global_scase.ybar;
+    dz = global_scase.zbar;
+    ci->xcen = global_scase.xbar/2.0;
+    ci->ycen = global_scase.ybar/2.0;
+    ci->zcen = global_scase.zbar/2.0;
   }
   switch(option){
     case 1:
@@ -231,13 +231,13 @@ void SetCameraView(cameradata *ca, int option){
 
 void InitCamera(cameradata *ci,char *name){
   strcpy(ci->name,name);
-  ci->rotation_index=nmeshes;
+  ci->rotation_index=global_scase.meshescoll.nmeshes;
   ci->defined=1;
   ci->azimuth=0.0;
   ci->view_angle=0.0;
-  ci->eye[0]=eyexfactor*xbar;
+  ci->eye[0]=eyexfactor*global_scase.xbar;
   UpdateCameraYpos(ci, 2);
-  ci->eye[2]=eyezfactor*zbar;
+  ci->eye[2]=eyezfactor*global_scase.zbar;
   ci->eye_save[0]=ci->eye[0];
   ci->eye_save[1]=ci->eye[1];
   ci->eye_save[2]=ci->eye[2];
@@ -255,9 +255,9 @@ void InitCamera(cameradata *ci,char *name){
   ci->view[0]=0.0;
   ci->view[1]=0.0;
   ci->view[2]=0.0;
-  ci->xcen=xbar/2.0;
-  ci->ycen=ybar/2.0;
-  ci->zcen=zbar/2.0;
+  ci->xcen=global_scase.xbar/2.0;
+  ci->ycen=global_scase.ybar/2.0;
+  ci->zcen=global_scase.zbar/2.0;
   ci->rotation_type=rotation_type;
 
   ci->azimuth=0.0;
@@ -365,13 +365,13 @@ void CopyCamera(cameradata *to, cameradata *from){
 void UpdateCamera(cameradata *ca){
   if(ca==camera_current){
     rotation_type=ca->rotation_type;
-    if(ca->rotation_index>=0&&ca->rotation_index<nmeshes){
-      UpdateCurrentMesh(meshinfo + ca->rotation_index);
+    if(ca->rotation_index>=0&&ca->rotation_index<global_scase.meshescoll.nmeshes){
+      UpdateCurrentMesh(global_scase.meshescoll.meshinfo + ca->rotation_index);
     }
     else{
-      UpdateCurrentMesh(meshinfo);
+      UpdateCurrentMesh(global_scase.meshescoll.meshinfo);
     }
-    highlight_mesh = current_mesh-meshinfo;
+    highlight_mesh = current_mesh-global_scase.meshescoll.meshinfo;
     HandleRotationType(EYE_CENTERED);
     GLUIUpdateMeshList1(ca->rotation_index);
     GLUIUpdateTrainerMoves();

--- a/Source/smokeview/colortimebar.c
+++ b/Source/smokeview/colortimebar.c
@@ -112,7 +112,7 @@ void DrawTimebar(float xleft, float xright, float ybot, float ytop){
   if(xright<=xleft)return;
   DISABLE_LIGHTING;
 
-  glLineWidth(linewidth);
+  glLineWidth(global_scase.linewidth);
   glBegin(GL_LINE_LOOP);
   glColor4fv(timebarcolor);
   glVertex2f(xleft,ybot);
@@ -273,7 +273,7 @@ void DrawColorbarPathRGB(void){
     if(fontindex==SCALED_FONT)ScaleFont3D();
     glPushMatrix();
     glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-    glTranslatef(-xbar0,-ybar0,-zbar0);
+    glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
     int skip = 1;
     if(cbi->nnodes > 16)skip = cbi->nnodes / 16;
     for(i=0;i<cbi->nnodes;i+=skip){
@@ -305,7 +305,7 @@ void DrawColorbarPathRGB(void){
 
       if(have_fire==HRRPUV_index&&smoke_render_option==RENDER_SLICE){
         vval_min=global_hrrpuv_min;
-        vval_cutoff=global_hrrpuv_cutoff;
+        vval_cutoff=global_scase.global_hrrpuv_cutoff;
         vval_max=global_hrrpuv_max;
       }
       else{
@@ -470,7 +470,7 @@ void DrawColorbarPathCIELab(void){
   if(fontindex == SCALED_FONT)ScaleFont3D();
   glPushMatrix();
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
   int skip = 1;
   if(cbi->nnodes > 16)skip = cbi->nnodes / 16;
   for(i = 0;i < cbi->nnodes;i+=skip){
@@ -820,8 +820,8 @@ void UpdateShowColorbar(int *showcfast_arg, int *show_slice_colorbar_arg,
   int showcfast_local = 0;
   int show_slice_colorbar_local = 0;
 
-  if(hvaccoll.hvacductvar_index >= 0)*show_hvacduct_colorbar_arg = 1;
-  if(hvaccoll.hvacnodevar_index >= 0)*show_hvacnode_colorbar_arg = 1;
+  if(global_scase.hvaccoll.hvacductvar_index >= 0)*show_hvacduct_colorbar_arg = 1;
+  if(global_scase.hvaccoll.hvacnodevar_index >= 0)*show_hvacnode_colorbar_arg = 1;
   if(showzone==1&&zonecolortype==ZONETEMP_COLOR)showcfast_local = 1;
   if(showslice==1||(showcfast_local==0&&showvslice==1&&vslicecolorbarflag==1))show_slice_colorbar_local = 1;
   if(show_slice_colorbar_local==1&&showcfast_local==1&&strcmp(slicebounds[slicefile_labelindex].label->shortlabel, "TEMP")==0)show_slice_colorbar_local=0;
@@ -929,17 +929,17 @@ void DrawHorizontalColorbars(void){
     int i;
     float right_hat;
 
-    right_hat = hcolorbar_right_pos*(float)(nrgb - 3) / (float)(nrgb - 2)+hcolorbar_left_pos/(float)(nrgb-2);
+    right_hat = hcolorbar_right_pos*(float)(global_scase.nrgb - 3) / (float)(global_scase.nrgb - 2)+hcolorbar_left_pos/(float)(global_scase.nrgb-2);
 
     glBegin(GL_QUADS);
-    for(i = 0; i < nrgb - 2; i++){
+    for(i = 0; i < global_scase.nrgb - 2; i++){
       float *rgb_plot3d_local;
       float xleft, xright;
 
       rgb_plot3d_local = rgb_plot3d_contour[i];
 
-      xleft = MIX2(i, nrgb - 3, right_hat, hcolorbar_left_pos);
-      xright = MIX2(i + 1, nrgb - 3, right_hat, hcolorbar_left_pos);
+      xleft = MIX2(i, global_scase.nrgb - 3, right_hat, hcolorbar_left_pos);
+      xright = MIX2(i + 1, global_scase.nrgb - 3, right_hat, hcolorbar_left_pos);
 
       if(rgb_plot3d_local[3] != 0.0){
         glColor4fv(rgb_plot3d_local);
@@ -955,11 +955,11 @@ void DrawHorizontalColorbars(void){
       float *rgb_plot3d_local;
       float xleft, xright;
 
-      rgb_plot3d_local = rgb_plot3d_contour[nrgb - 2];
+      rgb_plot3d_local = rgb_plot3d_contour[global_scase.nrgb - 2];
       barmid = (hcolorbar_down_pos + hcolorbar_top_pos) / 2.0;
       i = -1;
-      xright = MIX2(i + 0.5, nrgb - 3, hcolorbar_right_pos, hcolorbar_left_pos);
-      xleft  = MIX2(i + 1, nrgb - 3, hcolorbar_right_pos, hcolorbar_left_pos);
+      xright = MIX2(i + 0.5, global_scase.nrgb - 3, hcolorbar_right_pos, hcolorbar_left_pos);
+      xleft  = MIX2(i + 1, global_scase.nrgb - 3, hcolorbar_right_pos, hcolorbar_left_pos);
 
       if(have_extreme_mindata == 1 || have_extreme_maxdata == 1)glEnable(GL_POLYGON_SMOOTH);
 
@@ -973,11 +973,11 @@ void DrawHorizontalColorbars(void){
         glEnd();
       }
 
-      i = nrgb - 2;
-      xleft = MIX2(i, nrgb - 3, hcolorbar_right_pos, hcolorbar_left_pos);
-      xright = MIX2(i + 0.5, nrgb - 3, hcolorbar_right_pos, hcolorbar_left_pos);
+      i = global_scase.nrgb - 2;
+      xleft = MIX2(i, global_scase.nrgb - 3, hcolorbar_right_pos, hcolorbar_left_pos);
+      xright = MIX2(i + 0.5, global_scase.nrgb - 3, hcolorbar_right_pos, hcolorbar_left_pos);
 
-      rgb_plot3d_local = rgb_plot3d_contour[nrgb - 1];
+      rgb_plot3d_local = rgb_plot3d_contour[global_scase.nrgb - 1];
       if(show_extreme_maxdata == 1 && have_extreme_maxdata == 1 && rgb_plot3d_local[3] != 0.0){
         glBegin(GL_TRIANGLES);
         glColor4fv(rgb_plot3d_local);
@@ -1052,16 +1052,16 @@ void DrawVerticalColorbars(void){
     if(showplot3d==1&&contour_type==STEPPED_CONTOURS){
       float top_hat;
 
-      top_hat = vcolorbar_top_pos*(float)(nrgb - 3) / (float)(nrgb - 2)+vcolorbar_down_pos/(float)(nrgb-2);
+      top_hat = vcolorbar_top_pos*(float)(global_scase.nrgb - 3) / (float)(global_scase.nrgb - 2)+vcolorbar_down_pos/(float)(global_scase.nrgb-2);
 
       glBegin(GL_QUADS);
-      for(i = 0; i < nrgb-2; i++){
+      for(i = 0; i < global_scase.nrgb-2; i++){
         float *rgb_plot3d_local;
         float ybot, ytop;
 
         rgb_plot3d_local = rgb_plot3d_contour[i];
-        ybot = MIX2(  i,nrgb-3,top_hat,vcolorbar_down_pos);
-        ytop = MIX2(i+1,nrgb-3,top_hat,vcolorbar_down_pos);
+        ybot = MIX2(  i,global_scase.nrgb-3,top_hat,vcolorbar_down_pos);
+        ytop = MIX2(i+1,global_scase.nrgb-3,top_hat,vcolorbar_down_pos);
 
         if(rgb_plot3d_local[3]!=0.0){
           glColor4fv(rgb_plot3d_local);
@@ -1078,11 +1078,11 @@ void DrawVerticalColorbars(void){
         float *rgb_plot3d_local;
         float ybot, ytop;
 
-        rgb_plot3d_local = rgb_plot3d_contour[nrgb-2];
+        rgb_plot3d_local = rgb_plot3d_contour[global_scase.nrgb-2];
         barmid = (vcolorbar_left_pos+vcolorbar_right_pos)/2.0;
         i=-1;
-        ytop = MIX2(i+0.5,nrgb-3,vcolorbar_top_pos,vcolorbar_down_pos);
-        ybot = MIX2(i+1,nrgb-3,vcolorbar_top_pos,vcolorbar_down_pos);
+        ytop = MIX2(i+0.5,global_scase.nrgb-3,vcolorbar_top_pos,vcolorbar_down_pos);
+        ybot = MIX2(i+1,global_scase.nrgb-3,vcolorbar_top_pos,vcolorbar_down_pos);
 
         if(have_extreme_mindata==1||have_extreme_maxdata==1)glEnable(GL_POLYGON_SMOOTH);
 
@@ -1096,11 +1096,11 @@ void DrawVerticalColorbars(void){
           glEnd();
         }
 
-        i=nrgb-2;
-        ybot = MIX2(i,nrgb-3,vcolorbar_top_pos,vcolorbar_down_pos);
-        ytop = MIX2(i+0.5,nrgb-3,vcolorbar_top_pos,vcolorbar_down_pos);
+        i=global_scase.nrgb-2;
+        ybot = MIX2(i,global_scase.nrgb-3,vcolorbar_top_pos,vcolorbar_down_pos);
+        ytop = MIX2(i+0.5,global_scase.nrgb-3,vcolorbar_top_pos,vcolorbar_down_pos);
 
-        rgb_plot3d_local = rgb_plot3d_contour[nrgb-1];
+        rgb_plot3d_local = rgb_plot3d_contour[global_scase.nrgb-1];
         if(show_extreme_maxdata==1&&have_extreme_maxdata==1&&rgb_plot3d_local[3]!=0.0){
           glBegin(GL_TRIANGLES);
           glColor4fv(rgb_plot3d_local);
@@ -1288,7 +1288,7 @@ void DrawHorizontalColorbarRegLabels(void){
     patchdata *patchi;
     int patchunitclass, patchunittype;
 
-    patchi = patchinfo + boundarytypes[iboundarytype];
+    patchi = global_scase.patchinfo + global_scase.boundarytypes[iboundarytype];
     strcpy(unitlabel, patchi->label.unit);
     GetUnitInfo(patchi->label.unit, &patchunitclass, &patchunittype);
     if(patchunitclass >= 0 && patchunitclass < nunitclasses){
@@ -1315,7 +1315,7 @@ void DrawHorizontalColorbarRegLabels(void){
     char unitlabel[256];
     int plot3dunitclass, plot3dunittype;
 
-    up3label = plot3dinfo[0].label[plotn - 1].unit;
+    up3label = global_scase.plot3dinfo[0].label[plotn - 1].unit;
     strcpy(unitlabel, up3label);
     GetUnitInfo(up3label, &plot3dunitclass, &plot3dunittype);
     if(plot3dunitclass >= 0 && plot3dunitclass < nunitclasses){
@@ -1325,7 +1325,7 @@ void DrawHorizontalColorbarRegLabels(void){
         strcpy(unitlabel, unitclasses[plot3dunitclass].units[plot3dunittype].unit);
       }
     }
-    p3label = plot3dinfo[0].label[plotn - 1].shortlabel;
+    p3label = global_scase.plot3dinfo[0].label[plotn - 1].shortlabel;
     glPushMatrix();
     glTranslatef(type_label_left, type_label_down, 0.0);
     OutputBarText(0.0, 3 * (VP_vcolorbar.text_height + v_space), foreground_color, "Plot3D");
@@ -1392,20 +1392,20 @@ void DrawHorizontalColorbarRegLabels(void){
       ScaleFloat2String(tttval, isocolorlabel, isofactor);
       isocolorlabel_ptr = isocolorlabel;
       horiz_position = MIX2(global_colorbar_index, 255, hcolorbar_right_pos, hcolorbar_left_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(horiz_position, 0.0, red_color, isocolorlabel_ptr);
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float horiz_position;
       char isocolorlabel[256];
       char *isocolorlabel_ptr = NULL;
       float val;
 
-      horiz_position = MIX2(i, nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
+      horiz_position = MIX2(i, global_scase.nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
       if(iposition == i)continue;
       isocolorlabel_ptr = &(sb->colorlabels[i + 1][0]);
 
-      val = tttmin + i*isorange / (nrgb - 2);
+      val = tttmin + i*isorange / (global_scase.nrgb - 2);
       ScaleFloat2String(val, isocolorlabel, isofactor);
       isocolorlabel_ptr = isocolorlabel;
       OutputBarText(horiz_position, 0.0, foreground_color, isocolorlabel_ptr);
@@ -1442,15 +1442,15 @@ void DrawHorizontalColorbarRegLabels(void){
         partcolorlabel_ptr = partcolorlabel;
       }
       horiz_position = MIX2(global_colorbar_index, 255, hcolorbar_right_pos, hcolorbar_left_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(horiz_position, 0.0, red_color, partcolorlabel_ptr);
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float horiz_position;
       char partcolorlabel[256];
       char *partcolorlabel_ptr = NULL;
 
-      horiz_position = MIX2(i, nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
+      horiz_position = MIX2(i, global_scase.nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
       if(iposition == i)continue;
       if(global_prop_index>= 0 &&global_prop_index < npart5prop){
         float val;
@@ -1471,7 +1471,7 @@ void DrawHorizontalColorbarRegLabels(void){
         float val;
 
         partcolorlabel_ptr = partcolorlabel;
-        val = tttmin + i*partrange / (nrgb - 2);
+        val = tttmin + i*partrange / (global_scase.nrgb - 2);
         val = ScaleFloat2Float(val, partfactor);
         Float2String(partcolorlabel_ptr, val, ncolorlabel_digits, force_fixedpoint);
       }
@@ -1507,22 +1507,22 @@ void DrawHorizontalColorbarRegLabels(void){
         slicecolorlabel_ptr = slicecolorlabel;
       }
       horiz_position = MIX2(global_colorbar_index, 255, hcolorbar_right_pos, hcolorbar_left_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(horiz_position, 0.0, red_color, slicecolorlabel_ptr);
     }
     {
-      for(i = 0; i < nrgb - 1; i++){
+      for(i = 0; i < global_scase.nrgb - 1; i++){
         float horiz_position;
         char slicecolorlabel[256];
         char *slicecolorlabel_ptr = NULL;
 
-        horiz_position = MIX2(i, nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
+        horiz_position = MIX2(i, global_scase.nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
         if(iposition == i)continue;
         slicecolorlabel_ptr = &(sb->colorlabels[i + 1][0]);
         if(sliceflag == 1){
           float val;
 
-          val = tttmin + i*slicerange / (nrgb - 2);
+          val = tttmin + i*slicerange / (global_scase.nrgb - 2);
           ScaleFloat2String(val, slicecolorlabel, slicefactor);
           slicecolorlabel_ptr = slicecolorlabel;
           Float2String(slicecolorlabel_ptr, val, ncolorlabel_digits, force_fixedpoint);
@@ -1561,20 +1561,20 @@ void DrawHorizontalColorbarRegLabels(void){
         boundary_colorlabel_ptr = boundary_colorlabel;
       }
       horiz_position = MIX2(global_colorbar_index, 255, hcolorbar_right_pos, hcolorbar_left_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(0.0,horiz_position, red_color, boundary_colorlabel_ptr);
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       char boundary_colorlabel[256];
       char *boundary_colorlabel_ptr = NULL;
       float horiz_position;
       float val;
 
-      horiz_position = MIX2(i, nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
+      horiz_position = MIX2(i, global_scase.nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
 
       if(iposition == i)continue;
       if(patchflag == 1){
-        val = tttmin + i*patchrange / (nrgb - 2);
+        val = tttmin + i*patchrange / (global_scase.nrgb - 2);
       }
       else{
         val = colorvaluespatch[i+1];
@@ -1610,21 +1610,21 @@ void DrawHorizontalColorbarRegLabels(void){
         zonecolorlabel_ptr = zonecolorlabel;
       }
       horiz_position = MIX2(global_colorbar_index, 255, hcolorbar_right_pos, hcolorbar_left_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(horiz_position, 0.0, red_color, zonecolorlabel_ptr);
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float horiz_position;
       char zonecolorlabel[256];
       char *zonecolorlabel_ptr = NULL;
 
-      horiz_position = MIX2(i, nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
+      horiz_position = MIX2(i, global_scase.nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
       if(iposition == i)continue;
-      zonecolorlabel_ptr = &colorlabelzone[i + 1][0];
+      zonecolorlabel_ptr = &global_scase.colorlabelzone[i + 1][0];
       if(zoneflag == 1){
         float val;
 
-        val = tttmin + (i - 1)*zonerange / (nrgb - 2);
+        val = tttmin + (i - 1)*zonerange / (global_scase.nrgb - 2);
         ScaleFloat2String(val, zonecolorlabel, zonefactor);
         zonecolorlabel_ptr = zonecolorlabel;
       }
@@ -1659,21 +1659,21 @@ void DrawHorizontalColorbarRegLabels(void){
         plot3dcolorlabel_ptr = plot3dcolorlabel;
       }
       horiz_position = MIX2(global_colorbar_index, 255, hcolorbar_right_pos, hcolorbar_left_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(horiz_position, 0.0, red_color, plot3dcolorlabel_ptr);
     }
     if(visiso == 0){
       float horiz_position;
 
-      for(i = 0; i < nrgb - 1; i++){
+      for(i = 0; i < global_scase.nrgb - 1; i++){
         char plot3dcolorlabel[256];
         char *plot3dcolorlabel_ptr = NULL;
         float val;
 
-        horiz_position = MIX2(i, nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
+        horiz_position = MIX2(i, global_scase.nrgb - 2, hcolorbar_right_pos, hcolorbar_left_pos);
         if(iposition == i)continue;
         if(plot3dflag == 1){
-          val = tttmin + i*plot3drange / (nrgb - 2);
+          val = tttmin + i*plot3drange / (global_scase.nrgb - 2);
         }
         else{
           val = colorvaluesp3[plotn - 1][i];
@@ -1688,19 +1688,19 @@ void DrawHorizontalColorbarRegLabels(void){
       float horiz_position;
       float right_hat;
 
-      right_hat = hcolorbar_right_pos*(float)(nrgb - 3) / (float)(nrgb - 2)+hcolorbar_left_pos/(float)(nrgb-2);
-      for(i = 0; i < nrgb - 2; i++){
+      right_hat = hcolorbar_right_pos*(float)(global_scase.nrgb - 3) / (float)(global_scase.nrgb - 2)+hcolorbar_left_pos/(float)(global_scase.nrgb-2);
+      for(i = 0; i < global_scase.nrgb - 2; i++){
         char plot3dcolorlabel[256];
         char *plot3dcolorlabel_ptr = NULL;
 
-        horiz_position = MIX2(i, nrgb - 2, right_hat, hcolorbar_left_pos);
+        horiz_position = MIX2(i, global_scase.nrgb - 2, right_hat, hcolorbar_left_pos);
 
         if(iposition == i)continue;
         plot3dcolorlabel_ptr = &colorlabeliso[plotn - 1][i][0];
         if(plot3dflag == 1){
           float val;
 
-          val = tttmin + (i - 1)*plot3drange / (nrgb - 2);
+          val = tttmin + (i - 1)*plot3drange / (global_scase.nrgb - 2);
           ScaleFloat2String(val, plot3dcolorlabel, plot3dfactor);
           plot3dcolorlabel_ptr = plot3dcolorlabel;
         }
@@ -1817,20 +1817,20 @@ void DrawVerticalColorbarRegLabels(void){
       ScaleFloat2String(tttval, isocolorlabel, isofactor);
       isocolorlabel_ptr = isocolorlabel;
       vert_position = MIX2(global_colorbar_index, 255, vcolorbar_top_pos, vcolorbar_down_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(0.0, vert_position, red_color, isocolorlabel_ptr);
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float vert_position;
       char isocolorlabel[256];
       char *isocolorlabel_ptr = NULL;
       float val;
 
-      vert_position = MIX2(i, nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
+      vert_position = MIX2(i, global_scase.nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
       if(iposition == i)continue;
       isocolorlabel_ptr = &(sb->colorlabels[i + 1][0]);
 
-      val = tttmin + i*isorange / (nrgb - 2);
+      val = tttmin + i*isorange / (global_scase.nrgb - 2);
       ScaleFloat2String(val, isocolorlabel, isofactor);
       isocolorlabel_ptr = isocolorlabel;
       OutputBarText(0.0, vert_position, foreground_color, isocolorlabel_ptr);
@@ -1893,10 +1893,10 @@ void DrawVerticalColorbarRegLabels(void){
         partcolorlabel_ptr = partcolorlabel;
       }
       vert_position = MIX2(global_colorbar_index, 255, vcolorbar_top_pos, vcolorbar_down_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(0.0, vert_position, red_color, partcolorlabel_ptr);
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float val;
 
       if(iposition == i)continue;
@@ -1904,12 +1904,12 @@ void DrawVerticalColorbarRegLabels(void){
       val = ScaleFloat2Float(val, partfactor);
       colorbar_vals[i] = val;
     }
-    Floats2Strings(colorbar_labels, colorbar_vals, nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
+    Floats2Strings(colorbar_labels, colorbar_vals, global_scase.nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
     max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(exp_factor_label));
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float vert_position;
 
-      vert_position = MIX2(i, nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
+      vert_position = MIX2(i, global_scase.nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
       if(iposition == i)continue;
       OutputBarText(0.0, vert_position, foreground_color, colorbar_labels[i]);
       max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(colorbar_labels[i]));
@@ -2011,7 +2011,7 @@ void DrawVerticalColorbarRegLabels(void){
         slicecolorlabel_ptr = slicecolorlabel;
       }
       vert_position = MIX2(shifted_colorbar_index, 255, vcolorbar_top_pos, vcolorbar_down_pos);
-      iposition = MIX2(shifted_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(shifted_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(0.0, vert_position, red_color, slicecolorlabel_ptr);
     }
     {
@@ -2030,18 +2030,18 @@ void DrawVerticalColorbarRegLabels(void){
         valmax = tttmax;
       }
       else{
-        valmax = sb->colorvalues[nrgb-1];
+        valmax = sb->colorvalues[global_scase.nrgb-1];
       }
       valmax = ScaleFloat2Float(valmax, slicefactor);
       colorbar_max = MAX(ABS(valmax), ABS(valmin));
       colorbar_max = MAX(colorbar_max, colorbar_eps);
 
-      for(i = 0; i<nrgb-1; i++){
+      for(i = 0; i<global_scase.nrgb-1; i++){
         float val;
 
         if(iposition==i)continue;
         if(sliceflag==1){
-          val = tttmin+i*slicerange/(nrgb-2);
+          val = tttmin+i*slicerange/(global_scase.nrgb-2);
         }
         else{
           val = sb->colorvalues[i+1];
@@ -2052,12 +2052,12 @@ void DrawVerticalColorbarRegLabels(void){
         }
         colorbar_vals[i] = val;
       }
-      Floats2Strings(colorbar_labels, colorbar_vals, nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
+      Floats2Strings(colorbar_labels, colorbar_vals, global_scase.nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
       max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(exp_factor_label));
-      for(i = 0; i < nrgb - 1; i++){
+      for(i = 0; i < global_scase.nrgb - 1; i++){
         float vert_position;
 
-        vert_position = MIX2(i, nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
+        vert_position = MIX2(i, global_scase.nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
         if(iposition == i)continue;
         OutputBarText(0.0, vert_position, foreground_color, colorbar_labels[i]);
         max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(colorbar_labels[i]));
@@ -2103,12 +2103,12 @@ void DrawVerticalColorbarRegLabels(void){
 
   // -------------- HVAC node left labels ------------
 
-  if(show_hvacnode_colorbar_local==1 && hvaccoll.hvacnodevar_index>=0){
+  if(show_hvacnode_colorbar_local==1 && global_scase.hvaccoll.hvacnodevar_index>=0){
     hvacvaldata *hi;
     float tttval, tttmin, tttmax;
     float hvacrange;
 
-    hi = hvaccoll.hvacnodevalsinfo->node_vars + hvaccoll.hvacnodevar_index;
+    hi = global_scase.hvaccoll.hvacnodevalsinfo->node_vars + global_scase.hvaccoll.hvacnodevar_index;
     iposition = -1;
     tttmin = hi->levels256[0];
     tttmax = hi->levels256[255];
@@ -2125,23 +2125,23 @@ void DrawVerticalColorbarRegLabels(void){
       Num2String(hvaclabel, tttval);
       hvac_colorlabel_ptr = &(hvaclabel[0]);
       vert_position = MIX2(global_colorbar_index, 255, vcolorbar_top_pos, vcolorbar_down_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(0.0, vert_position, red_color, hvac_colorlabel_ptr);
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float val;
 
       if(iposition == i)continue;
-      val = tttmin + i * hvacrange / (nrgb - 2);
+      val = tttmin + i * hvacrange / (global_scase.nrgb - 2);
       colorbar_vals[i] = val;
       GetMantissaExponent(ABS(val), colorbar_exponents + i);
     }
-    Floats2Strings(colorbar_labels, colorbar_vals, nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
+    Floats2Strings(colorbar_labels, colorbar_vals, global_scase.nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
     max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(exp_factor_label));
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float vert_position;
 
-      vert_position = MIX2(i, nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
+      vert_position = MIX2(i, global_scase.nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
 
       if(iposition == i)continue;
       OutputBarText(0.0, vert_position, foreground_color, colorbar_labels[i]);
@@ -2152,12 +2152,12 @@ void DrawVerticalColorbarRegLabels(void){
 
   // -------------- HVAC duct left labels ------------
 
-  if(show_hvacduct_colorbar_local==1 && hvaccoll.hvacductvar_index>=0){
+  if(show_hvacduct_colorbar_local==1 && global_scase.hvaccoll.hvacductvar_index>=0){
     hvacvaldata *hi;
     float tttval, tttmin, tttmax;
     float hvacrange;
 
-    hi = hvaccoll.hvacductvalsinfo->duct_vars + hvaccoll.hvacductvar_index;
+    hi = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + global_scase.hvaccoll.hvacductvar_index;
     iposition = -1;
     tttmin = hi->levels256[0];
     tttmax = hi->levels256[255];
@@ -2174,23 +2174,23 @@ void DrawVerticalColorbarRegLabels(void){
       Num2String(hvaclabel, tttval);
       hvac_colorlabel_ptr = &(hvaclabel[0]);
       vert_position = MIX2(global_colorbar_index, 255, vcolorbar_top_pos, vcolorbar_down_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(0.0, vert_position, red_color, hvac_colorlabel_ptr);
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float val;
 
       if(iposition == i)continue;
-      val = tttmin + i * hvacrange / (nrgb - 2);
+      val = tttmin + i * hvacrange / (global_scase.nrgb - 2);
       colorbar_vals[i] = val;
       GetMantissaExponent(ABS(val), colorbar_exponents + i);
     }
-    Floats2Strings(colorbar_labels, colorbar_vals, nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
+    Floats2Strings(colorbar_labels, colorbar_vals, global_scase.nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
     max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(exp_factor_label));
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float vert_position;
 
-      vert_position = MIX2(i, nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
+      vert_position = MIX2(i, global_scase.nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
 
       if(iposition == i)continue;
       OutputBarText(0.0, vert_position, foreground_color, colorbar_labels[i]);
@@ -2201,11 +2201,11 @@ void DrawVerticalColorbarRegLabels(void){
 
   // -------------- HVAC file node top labels ------------
 
-  if(show_hvacnode_colorbar_local==1 && hvaccoll.hvacnodevar_index>=0){
+  if(show_hvacnode_colorbar_local==1 && global_scase.hvaccoll.hvacnodevar_index>=0){
     char *slabel, *unitlabel;
     hvacvaldata *hi;
 
-    hi = hvaccoll.hvacnodevalsinfo->node_vars + hvaccoll.hvacnodevar_index;
+    hi = global_scase.hvaccoll.hvacnodevalsinfo->node_vars + global_scase.hvaccoll.hvacnodevar_index;
     slabel = hi->label.shortlabel;
     unitlabel = hi->label.unit;
 
@@ -2225,11 +2225,11 @@ void DrawVerticalColorbarRegLabels(void){
 
   // -------------- HVAC file duct top labels ------------
 
-  if(show_hvacduct_colorbar_local==1 && hvaccoll.hvacductvar_index >=0){
+  if(show_hvacduct_colorbar_local==1 && global_scase.hvaccoll.hvacductvar_index >=0){
     char *slabel, *unitlabel;
     hvacvaldata *hi;
 
-    hi = hvaccoll.hvacductvalsinfo->duct_vars + hvaccoll.hvacductvar_index;
+    hi = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + global_scase.hvaccoll.hvacductvar_index;
     slabel = hi->label.shortlabel;
     unitlabel = hi->label.unit;
 
@@ -2256,7 +2256,7 @@ void DrawVerticalColorbarRegLabels(void){
     patchdata *patchi;
     int patchunitclass, patchunittype;
 
-    patchi = patchinfo + boundarytypes[iboundarytype];
+    patchi = global_scase.patchinfo + global_scase.boundarytypes[iboundarytype];
     strcpy(unitlabel, patchi->label.unit);
     GetUnitInfo(patchi->label.unit, &patchunitclass, &patchunittype);
     if(patchunitclass >= 0 && patchunitclass < nunitclasses){
@@ -2288,15 +2288,15 @@ void DrawVerticalColorbarRegLabels(void){
         boundary_colorlabel_ptr = boundary_colorlabel;
       }
       vert_position = MIX2(global_colorbar_index, 255, vcolorbar_top_pos, vcolorbar_down_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(0.0, vert_position, red_color, boundary_colorlabel_ptr);
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float val;
 
       if(iposition == i)continue;
       if(patchflag==1){
-        val = tttmin+i*patchrange/(nrgb-2);
+        val = tttmin+i*patchrange/(global_scase.nrgb-2);
       }
       else{
         val = colorvaluespatch[i+1];
@@ -2305,12 +2305,12 @@ void DrawVerticalColorbarRegLabels(void){
       colorbar_vals[i] = val;
       GetMantissaExponent(ABS(val), colorbar_exponents + i);
     }
-    Floats2Strings(colorbar_labels, colorbar_vals, nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
+    Floats2Strings(colorbar_labels, colorbar_vals, global_scase.nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
     max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(exp_factor_label));
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float vert_position;
 
-      vert_position = MIX2(i, nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
+      vert_position = MIX2(i, global_scase.nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
 
       if(iposition == i)continue;
       OutputBarText(0.0, vert_position, foreground_color, colorbar_labels[i]);
@@ -2326,7 +2326,7 @@ void DrawVerticalColorbarRegLabels(void){
     patchdata *patchi;
     int patchunitclass, patchunittype;
 
-    patchi = patchinfo + boundarytypes[iboundarytype];
+    patchi = global_scase.patchinfo + global_scase.boundarytypes[iboundarytype];
     strcpy(unitlabel, patchi->label.unit);
     GetUnitInfo(patchi->label.unit, &patchunitclass, &patchunittype);
     if(patchunitclass >= 0 && patchunitclass < nunitclasses){
@@ -2388,20 +2388,20 @@ void DrawVerticalColorbarRegLabels(void){
         zonecolorlabel_ptr = zonecolorlabel;
       }
       vert_position = MIX2(global_colorbar_index, 255, vcolorbar_top_pos, vcolorbar_down_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(0.0, vert_position, red_color, zonecolorlabel_ptr);
       max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(zonecolorlabel_ptr));
     }
-    for(i = 0; i < nrgb - 1; i++){
+    for(i = 0; i < global_scase.nrgb - 1; i++){
       float vert_position;
       char zonecolorlabel[256];
       char *zonecolorlabel_ptr = NULL;
       float val;
 
-      vert_position = MIX2(i, nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
+      vert_position = MIX2(i, global_scase.nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
       if(iposition == i)continue;
       if(zoneflag == 1){
-        val = tttmin + i*zonerange / (nrgb - 2);
+        val = tttmin + i*zonerange / (global_scase.nrgb - 2);
       }
       else{
         val = colorvalueszone[i+1];
@@ -2453,7 +2453,7 @@ void DrawVerticalColorbarRegLabels(void){
     char unitlabel[256];
     int plot3dunitclass, plot3dunittype;
 
-    up3label = plot3dinfo[0].label[plotn-1].unit;
+    up3label = global_scase.plot3dinfo[0].label[plotn-1].unit;
     strcpy(unitlabel, up3label);
     GetUnitInfo(up3label, &plot3dunitclass, &plot3dunittype);
     if(plot3dunitclass>=0&&plot3dunitclass<nunitclasses){
@@ -2483,16 +2483,16 @@ void DrawVerticalColorbarRegLabels(void){
         plot3dcolorlabel_ptr = plot3dcolorlabel;
       }
       vert_position = MIX2(global_colorbar_index, 255, vcolorbar_top_pos, vcolorbar_down_pos);
-      iposition = MIX2(global_colorbar_index, 255, nrgb - 1, 0);
+      iposition = MIX2(global_colorbar_index, 255, global_scase.nrgb - 1, 0);
       OutputBarText(0.0, vert_position, red_color, plot3dcolorlabel_ptr);
     }
     if(visiso == 0){
-      for(i = 0; i < nrgb - 1; i++){
+      for(i = 0; i < global_scase.nrgb - 1; i++){
         float val;
 
         if(iposition == i)continue;
         if(plot3dflag == 1){
-          val = tttmin + i*plot3drange / (nrgb - 2);
+          val = tttmin + i*plot3drange / (global_scase.nrgb - 2);
         }
         else{
           val = colorvaluesp3[plotn - 1][i];
@@ -2501,12 +2501,12 @@ void DrawVerticalColorbarRegLabels(void){
         colorbar_vals[i] = val;
         GetMantissaExponent(ABS(val), colorbar_exponents + i);
       }
-      Floats2Strings(colorbar_labels, colorbar_vals, nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
+      Floats2Strings(colorbar_labels, colorbar_vals, global_scase.nrgb-1, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
       max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(exp_factor_label));
-      for(i = 0; i < nrgb - 1; i++){
+      for(i = 0; i < global_scase.nrgb - 1; i++){
         float vert_position;
 
-        vert_position = MIX2(i, nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
+        vert_position = MIX2(i, global_scase.nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
 
         if(iposition == i)continue;
         OutputBarText(0.0, vert_position, foreground_color, colorbar_labels[i]);
@@ -2516,16 +2516,16 @@ void DrawVerticalColorbarRegLabels(void){
     else{
       float vert_position;
 
-      for(i = 0; i < nrgb - 2; i++){
+      for(i = 0; i < global_scase.nrgb - 2; i++){
         float val;
 
-        val = tttmin + (float)(i +0.5)*plot3drange / (nrgb - 2);
+        val = tttmin + (float)(i +0.5)*plot3drange / (global_scase.nrgb - 2);
         colorbar_vals[i] = val;
       }
-      Floats2Strings(colorbar_labels, colorbar_vals, nrgb-2, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
+      Floats2Strings(colorbar_labels, colorbar_vals, global_scase.nrgb-2, ncolorlabel_digits, force_fixedpoint, force_exponential, force_decimal, force_zero_pad, exp_factor_label);
       max_colorbar_label_width = MAX(max_colorbar_label_width, GetStringWidth(exp_factor_label));
-      for(i = 0; i < nrgb - 2; i++){
-        vert_position = MIX2(i+0.5, nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
+      for(i = 0; i < global_scase.nrgb - 2; i++){
+        vert_position = MIX2(i+0.5, global_scase.nrgb - 2, vcolorbar_top_pos, vcolorbar_down_pos);
         if(iposition == i)continue;
         if(isolevelindex == i || isolevelindex2 == i){
           OutputBarText(0.0, vert_position, red_color, colorbar_labels[i]);
@@ -2545,7 +2545,7 @@ void DrawVerticalColorbarRegLabels(void){
     char unitlabel[256];
     int plot3dunitclass, plot3dunittype;
 
-    up3label = plot3dinfo[0].label[plotn - 1].unit;
+    up3label = global_scase.plot3dinfo[0].label[plotn - 1].unit;
     strcpy(unitlabel, up3label);
     GetUnitInfo(up3label, &plot3dunitclass, &plot3dunittype);
     if(plot3dunitclass >= 0 && plot3dunitclass < nunitclasses){
@@ -2555,7 +2555,7 @@ void DrawVerticalColorbarRegLabels(void){
         strcpy(unitlabel, unitclasses[plot3dunitclass].units[plot3dunittype].unit);
       }
     }
-    p3label = plot3dinfo[0].label[plotn - 1].shortlabel;
+    p3label = global_scase.plot3dinfo[0].label[plotn - 1].shortlabel;
     glPushMatrix();
     glTranslatef(
       vcolorbar_left_pos - colorbar_label_width,

--- a/Source/smokeview/drawGeometry.c
+++ b/Source/smokeview/drawGeometry.c
@@ -9,6 +9,8 @@
 #include "smokeviewvars.h"
 #include "IOobjects.h"
 #include "readimage.h"
+#include "readcad.h"
+#include "readobject.h"
 
 cadgeomdata *current_cadgeom;
 
@@ -21,13 +23,13 @@ void DrawCircVentsApproxSolid(int option){
   assert(option==VENT_CIRCLE||option==VENT_RECTANGLE);
 
   glBegin(GL_TRIANGLES);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
     meshdata *meshi;
     float *xplt, *yplt, *zplt;
     float dx, dy, dz, dxyz;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     xplt = meshi->xplt;
     yplt = meshi->yplt;
     zplt = meshi->zplt;
@@ -173,13 +175,13 @@ void DrawCircVentsApproxOutline(int option){
   assert(option==VENT_CIRCLE||option==VENT_RECTANGLE);
 
   glBegin(GL_LINES);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
     meshdata *meshi;
     float *xplt, *yplt, *zplt;
     float dx, dy, dz, dxyz;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     xplt = meshi->xplt;
     yplt = meshi->yplt;
     zplt = meshi->zplt;
@@ -356,11 +358,11 @@ void DrawCircVentsExactSolid(int option){
 
   if(option==VENT_HIDE)return;
   assert(option==VENT_CIRCLE||option==VENT_RECTANGLE);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j=0;j<meshi->ncvents;j++){
       cventdata *cvi;
       float x0, yy0, z0;
@@ -393,7 +395,7 @@ void DrawCircVentsExactSolid(int option){
       vcolor[2]=color[2]*255;
       glPushMatrix();
       glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-      glTranslatef(-xbar0,-ybar0,-zbar0);
+      glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
       if(option==VENT_CIRCLE){
         clipdata circleclip;
         float *ventmin, *ventmax;
@@ -466,11 +468,11 @@ void DrawCircVentsExactOutline(int option){
 
   if(option==VENT_HIDE)return;
   assert(option==VENT_CIRCLE||option==VENT_RECTANGLE);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j=0;j<meshi->ncvents;j++){
       cventdata *cvi;
       float x0, yy0, z0;
@@ -503,7 +505,7 @@ void DrawCircVentsExactOutline(int option){
       vcolor[2]=color[2]*255;
       glPushMatrix();
       glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-      glTranslatef(-xbar0,-ybar0,-zbar0);
+      glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
       if(option==VENT_CIRCLE){
         clipdata circleclip;
         float *ventmin, *ventmax;
@@ -589,15 +591,15 @@ void UpdateIndexColors(void){
   int j;
   float s_color[4];
 
-  updateindexcolors=0;
+  global_scase.updateindexcolors=0;
 
   if(strcmp(surfacedefault->surfacelabel,"INERT")==0){
     surfacedefault->color=block_ambient2;
   }
-  for(i=0;i<nsurfinfo;i++){
+  for(i=0;i<global_scase.surfcoll.nsurfinfo;i++){
     surfdata *surfi;
 
-    surfi = surfinfo + i;
+    surfi = global_scase.surfcoll.surfinfo + i;
     if(strcmp(surfi->surfacelabel,"INERT")==0){
       surfi->color=block_ambient2;
     }
@@ -606,10 +608,10 @@ void UpdateIndexColors(void){
     }
   }
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j=0;j<meshi->nbptrs;j++){
       blockagedata *bc;
 
@@ -617,7 +619,7 @@ void UpdateIndexColors(void){
       if(bc->usecolorindex==1){
         colorindex=bc->colorindex;
         if(colorindex>=0){
-          bc->color = GetColorPtr(rgb[nrgb+colorindex]);
+          bc->color = GetColorPtr(global_scase.rgb[global_scase.nrgb+colorindex]);
         }
       }
     }
@@ -628,15 +630,15 @@ void UpdateIndexColors(void){
       if(vi->usecolorindex==1){
         colorindex=vi->colorindex;
 
-        s_color[0]=rgb[nrgb+colorindex][0];
-        s_color[1]=rgb[nrgb+colorindex][1];
-        s_color[2]=rgb[nrgb+colorindex][2];
+        s_color[0]=global_scase.rgb[global_scase.nrgb+colorindex][0];
+        s_color[1]=global_scase.rgb[global_scase.nrgb+colorindex][1];
+        s_color[2]=global_scase.rgb[global_scase.nrgb+colorindex][2];
         s_color[3]=1.0;
         vi->color = GetColorPtr(s_color);
       }
     }
   }
-  updatefaces=1;
+  global_scase.updatefaces=1;
 }
 
 
@@ -647,18 +649,18 @@ void DrawObstOutlines(void){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
   AntiAliasLine(ON);
-  glLineWidth(linewidth);
+  glLineWidth(global_scase.linewidth);
   glBegin(GL_LINES);
-  for(n = 0; n < nmeshes; n++){
+  for(n = 0; n < global_scase.meshescoll.nmeshes; n++){
     int i;
     float xmin, xmax, ymin, ymax, zmin, zmax;
     meshdata *meshi;
     float *color, *oldcolor=NULL;
     float *xplt, *yplt, *zplt;
 
-    meshi = meshinfo + n;
+    meshi = global_scase.meshescoll.meshinfo + n;
     xplt = meshi->xplt_orig;
     yplt = meshi->yplt_orig;
     zplt = meshi->zplt_orig;
@@ -720,16 +722,16 @@ void DrawOrigObstOutlines(void){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
   AntiAliasLine(ON);
-  glLineWidth(linewidth);
+  glLineWidth(global_scase.linewidth);
   glBegin(GL_LINES);
-  for(i=0; i<nobstinfo; i++){
+  for(i=0; i<global_scase.obstcoll.nobstinfo; i++){
     xbdata *obi;
     float *xyz;
     float xmin, xmax, ymin, ymax, zmin, zmax;
 
-    obi = obstinfo + i;
+    obi = global_scase.obstcoll.obstinfo + i;
     color = foregroundcolor;
     if(obi->bc!=NULL&&obi->bc->showtimelist!=NULL&&obi->bc->showtimelist[itimes]==0)continue;
     if(obi->color!=NULL)color = obi->color;
@@ -782,18 +784,18 @@ void DrawOrigObstOutlines(void){
 void DrawOutlines(void){
   int i;
 
-  if(noutlineinfo<=0)return;
+  if(global_scase.noutlineinfo<=0)return;
   AntiAliasLine(ON);
-  glLineWidth(linewidth);
+  glLineWidth(global_scase.linewidth);
   glBegin(GL_LINES);
   glColor3fv(foregroundcolor);
-  for(i=0;i<noutlineinfo;i++){
+  for(i=0;i<global_scase.noutlineinfo;i++){
     outlinedata *outlinei;
     float *xx1, *yy1, *zz1;
     float *xx2, *yy2, *zz2;
     int j;
 
-    outlinei = outlineinfo + i;
+    outlinei = global_scase.outlineinfo + i;
     xx1 = outlinei->x1;
     xx2 = outlinei->x2;
     yy1 = outlinei->y1;
@@ -914,10 +916,10 @@ void GetBlockVals(  float *xmin, float *xmax,
 int HaveCircularVents(void){
   int i;
 
-  for(i = 0; i < nmeshes; i++){
+  for(i = 0; i < global_scase.meshescoll.nmeshes; i++){
     meshdata* meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
 
     if(meshi->ncvents > 0)return 1;
   }
@@ -929,13 +931,13 @@ void SetCVentDirs(void){
   int ii;
 
   InitCircle(90,&cvent_circ);
-  for(ii=0;ii<nmeshes;ii++){
+  for(ii=0;ii<global_scase.meshescoll.nmeshes;ii++){
     meshdata *meshi;
     int ibar, jbar;
     char *c_iblank;
     int iv;
 
-    meshi=meshinfo+ii;
+    meshi=global_scase.meshescoll.meshinfo+ii;
 
     ibar = meshi->ibar;
     jbar = meshi->jbar;
@@ -992,7 +994,7 @@ void SetCVentDirs(void){
             for(k=cvi->kmin;k<=cvi->kmax;k++){
               int state1, state2;
 
-              if(use_iblank==1&&c_iblank!=NULL){
+              if(global_scase.use_iblank==1&&c_iblank!=NULL){
                 state1=c_iblank[IJKCELL(i-1,j,k)];
                 state2=c_iblank[IJKCELL(i,j,k)];
               }
@@ -1039,7 +1041,7 @@ void SetCVentDirs(void){
             for(k=cvi->kmin;k<=cvi->kmax;k++){
               int state1, state2;
 
-              if(use_iblank==1&&c_iblank!=NULL){
+              if(global_scase.use_iblank==1&&c_iblank!=NULL){
                 state1=c_iblank[IJKCELL(i,j-1,k)];
                 state2=c_iblank[IJKCELL(i,j,k)];
               }
@@ -1086,7 +1088,7 @@ void SetCVentDirs(void){
             for(j=cvi->jmin;j<=cvi->jmax;j++){
               int state1, state2;
 
-              if(use_iblank==1&&c_iblank!=NULL){
+              if(global_scase.use_iblank==1&&c_iblank!=NULL){
                 state1=c_iblank[IJKCELL(i,j,k-1)];
                 state2=c_iblank[IJKCELL(i,j,k)];
               }
@@ -1122,13 +1124,13 @@ void SetCVentDirs(void){
 
   // set up blanking arrays for circular vents
 
-  for(ii=0;ii<nmeshes;ii++){
+  for(ii=0;ii<global_scase.meshescoll.nmeshes;ii++){
     meshdata *meshi;
     int iv,i,j,k;
     unsigned char *blank;
     float *xplt, *yplt, *zplt;
 
-    meshi=meshinfo+ii;
+    meshi=global_scase.meshescoll.meshinfo+ii;
 
     xplt = meshi->xplt_cen;
     yplt = meshi->yplt_cen;
@@ -1244,11 +1246,11 @@ void SetCVentDirs(void){
     }
   }
 
-  for(ii = 0; ii < nmeshes; ii++){
+  for(ii = 0; ii < global_scase.meshescoll.nmeshes; ii++){
     meshdata *meshi;
     int iv;
 
-    meshi = meshinfo + ii;
+    meshi = global_scase.meshescoll.meshinfo + ii;
     for(iv = 0; iv < meshi->ncvents; iv++){
       cventdata *cvi;
 
@@ -1287,7 +1289,7 @@ void SetVentDirs(void){
   INIT_PRINT_TIMER(vent_setup_timer);
   n_mirrorvents = 0;
   n_openvents = 0;
-  for(ii=0;ii<nmeshes;ii++){
+  for(ii=0;ii<global_scase.meshescoll.nmeshes;ii++){
     meshdata *meshi;
     float *xplttemp;
     float *yplttemp;
@@ -1302,7 +1304,7 @@ void SetVentDirs(void){
     int ventdir;
     float voffset, offset;
 
-    meshi=meshinfo+ii;
+    meshi=global_scase.meshescoll.meshinfo+ii;
 
     ibar = meshi->ibar;
     jbar = meshi->jbar;
@@ -1344,7 +1346,7 @@ void SetVentDirs(void){
             for(k=vi->kmin;k<=MIN(vi->kmax,kbar-1);k++){
               int state1, state2;
 
-              if(use_iblank==1&&c_iblank!=NULL){
+              if(global_scase.use_iblank==1&&c_iblank!=NULL){
                 state1=c_iblank[IJKCELL(i-1,j,k)];
                 state2=c_iblank[IJKCELL(i,j,k)];
               }
@@ -1397,7 +1399,7 @@ void SetVentDirs(void){
             for(k=vi->kmin;k<=MIN(vi->kmax,kbar-1);k++){
               int state1, state2;
 
-              if(use_iblank==1&&c_iblank!=NULL){
+              if(global_scase.use_iblank==1&&c_iblank!=NULL){
                 state1=c_iblank[IJKCELL(i,j-1,k)];
                 state2=c_iblank[IJKCELL(i,j,k)];
               }
@@ -1450,7 +1452,7 @@ void SetVentDirs(void){
             for(j=vi->jmin;j<=MIN(vi->jmax,jbar-1);j++){
               int state1, state2;
 
-              if(use_iblank==1&&c_iblank!=NULL){
+              if(global_scase.use_iblank==1&&c_iblank!=NULL){
                 state1=c_iblank[IJKCELL(i,j,k-1)];
                 state2=c_iblank[IJKCELL(i,j,k)];
               }
@@ -1525,10 +1527,10 @@ int InBlockage(const meshdata *meshi,float x, float y, float z){
 int InAnyBlockage(float *xyz){
   int i;
 
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     if(InBlockage(meshi, xyz[0], xyz[1], xyz[2])==1)return 1;
   }
   return 0;
@@ -1539,11 +1541,11 @@ int InAnyBlockage(float *xyz){
 void SetInteriorBlockages(void){
   int i;
 
-  for(i=0; i<nmeshes; i++){
+  for(i=0; i<global_scase.meshescoll.nmeshes; i++){
     int j;
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j=0; j<meshi->nbptrs; j++){
       blockagedata *bc;
       int k;
@@ -1585,11 +1587,11 @@ void SetInteriorBlockages(void){
       xyzDELTA[2] = bc->zmax+meshi->boxeps[2];
     }
   }
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     int j;
     meshdata *meshi;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     for(j = 0; j<meshi->nbptrs; j++){
       blockagedata *bc;
       int k;
@@ -1983,7 +1985,7 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
   }
 
   for(j=0;j<jend;j++){
-    faceptr->meshindex=meshi-meshinfo;
+    faceptr->meshindex=meshi-global_scase.meshescoll.meshinfo;
     faceptr->type2=facetype;
     faceptr->show_bothsides=0;
     faceptr->bc=NULL;
@@ -1997,7 +1999,7 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
         faceptr->linewidth=&solidlinewidth;
       }
       else{
-        faceptr->linewidth=&linewidth;
+        faceptr->linewidth=&global_scase.linewidth;
       }
       faceptr->showtimelist_handle=&bc->showtimelist;
       faceptr->surfinfo=bc->surf[j];
@@ -2010,10 +2012,10 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
       faceptr->texture_origin=vi->texture_origin;
       faceptr->transparent=vi->transparent;
       if(faceptr->type2==OUTLINE_FRAME_face){
-        faceptr->linewidth=&linewidth;
+        faceptr->linewidth=&global_scase.linewidth;
       }
       else{
-        faceptr->linewidth=&ventlinewidth;
+        faceptr->linewidth=&global_scase.ventlinewidth;
       }
       faceptr->showtimelist_handle=&vi->showtimelist;
       faceptr->surfinfo=vi->surf[j];
@@ -2143,8 +2145,8 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
        ytex = zz;
        xtex2 = xx2;
        ytex2 = zz2;
-       xstart = &xbar0;
-       ystart = &zbar0;
+       xstart = &global_scase.xbar0;
+       ystart = &global_scase.zbar0;
        if(bc!=NULL)faceptr->interior = bc->interior[2];
        break;
      case UP_X:
@@ -2155,8 +2157,8 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
        ytex = zz;
        xtex2 = yy2;
        ytex2 = zz2;
-       xstart = &ybar0;
-       ystart = &zbar0;
+       xstart = &global_scase.ybar0;
+       ystart = &global_scase.zbar0;
        if(bc!=NULL)faceptr->interior = bc->interior[1];
        break;
      case UP_Y:
@@ -2167,8 +2169,8 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
        ytex = zz;
        xtex2 = xx2;
        ytex2 = zz2;
-       xstart = &xbar0;
-       ystart = &zbar0;
+       xstart = &global_scase.xbar0;
+       ystart = &global_scase.zbar0;
        if(bc!=NULL)faceptr->interior = bc->interior[3];
        break;
      case DOWN_X:
@@ -2179,8 +2181,8 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
        ytex2 = zz2;
        faceptr->normal[0]=(float)-1.0;
        faceptr->imax=faceptr->imin;
-       xstart = &ybar0;
-       ystart = &zbar0;
+       xstart = &global_scase.ybar0;
+       ystart = &global_scase.zbar0;
        if(bc!=NULL)faceptr->interior = bc->interior[0];
        break;
      case DOWN_Z:
@@ -2191,8 +2193,8 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
        ytex2 = yy2;
        faceptr->normal[2]=(float)-1.0;
        faceptr->kmax=faceptr->kmin;
-       xstart = &xbar0;
-       ystart = &ybar0;
+       xstart = &global_scase.xbar0;
+       ystart = &global_scase.ybar0;
        if(bc!=NULL)faceptr->interior = bc->interior[4];
        break;
      case UP_Z:
@@ -2203,8 +2205,8 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
        ytex2 = yy2;
        faceptr->normal[2]=(float)1.0;
        faceptr->kmin=faceptr->kmax;
-       xstart = &xbar0;
-       ystart = &ybar0;
+       xstart = &global_scase.xbar0;
+       ystart = &global_scase.ybar0;
        if(bc!=NULL)faceptr->interior = bc->interior[5];
        break;
      default:
@@ -2339,22 +2341,22 @@ void UpdateFacesWorker(void){
   INIT_PRINT_TIMER(timer_allocate_faces);
   AllocateFaces();
   PRINT_TIMER(timer_allocate_faces, "AllocateFaces");
-  updatefaces=0;
+  global_scase.updatefaces=0;
   have_vents_int=0;
 
   INIT_PRINT_TIMER(timer_update_faces_1);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     facedata *faceptr;
     int j;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     faceptr = meshi->faceinfo;
     for(j=0;j<meshi->nbptrs;j++){
       blockagedata *bc;
 
       bc = meshi->blockageinfoptrs[j];
-      if(visTerrainType!=TERRAIN_HIDDEN&&bc->is_wuiblock==1)continue;
+      if(global_scase.visTerrainType!=TERRAIN_HIDDEN&&bc->is_wuiblock==1)continue;
       ObstOrVent2Faces(meshi,bc,NULL,faceptr,BLOCK_face);
       faceptr += 6;
     }
@@ -2428,11 +2430,11 @@ void SetCullVis(void){
     InitCullGeom(cullgeom);
     UpdateFaceLists();
   }
-  for(imesh=0;imesh<nmeshes;imesh++){
+  for(imesh=0;imesh<global_scase.meshescoll.nmeshes;imesh++){
     int iport;
     meshdata *meshi;
 
-    meshi = meshinfo + imesh;
+    meshi = global_scase.meshescoll.meshinfo + imesh;
     meshi->in_frustum = MeshInFrustum(meshi);
     for(iport=0;iport<meshi->ncullgeominfo;iport++){
       culldata *culli;
@@ -2679,14 +2681,14 @@ void UpdateFaceListsWorker(void){
   show = GetInternalFaceShow();
 
   // if we are not showing boundary files then don't try to hide blockages
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int patchfilenum;
     int j;
     patchdata *patchi;
     int vent_offset, outline_offset, exteriorsurface_offset;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j=0;j<meshi->nfaces;j++){
       facedata *facej;
 
@@ -2696,7 +2698,7 @@ void UpdateFaceListsWorker(void){
 
     patchfilenum=meshi->patchfilenum;
     patchi=NULL;
-    if(showplot3d == 0 && patchfilenum>=0 && patchfilenum<npatchinfo)patchi = patchinfo + patchfilenum;
+    if(showplot3d == 0 && patchfilenum>=0 && patchfilenum<global_scase.npatchinfo)patchi = global_scase.patchinfo + patchfilenum;
     ShowHideInternalFaces(meshi, show);
 
     n_normals_single=0;
@@ -2735,7 +2737,7 @@ void UpdateFaceListsWorker(void){
       if(j>=vent_offset&&j<vent_offset+meshi->nvents){
         if(visOpenVents==0&&vi->isOpenvent==1)continue;
         if(visDummyVents==0&&vi->dummy==1)continue;
-        if(visOtherVents==0&&vi->isOpenvent==0&&vi->dummy==0)continue;
+        if(global_scase.visOtherVents==0&&vi->isOpenvent==0&&vi->dummy==0)continue;
         if(
            patchi!=NULL
            &&patchi->loaded==1
@@ -2786,7 +2788,7 @@ void UpdateFaceListsWorker(void){
          (facej->type==BLOCK_outline&&visBlocks==visBLOCKAsInput)||
          ((j>=vent_offset&&j<vent_offset+meshi->nvents)&&vi->isOpenvent==1&&visOpenVentsAsOutline==1)
         ){
-        if(nobstinfo==0||(nobstinfo>0&&blocklocation==BLOCKlocation_grid))meshi->face_outlines[n_outlines++]=facej;
+        if(global_scase.obstcoll.nobstinfo==0||(global_scase.obstcoll.nobstinfo>0&&blocklocation==BLOCKlocation_grid))meshi->face_outlines[n_outlines++]=facej;
         if(visBlocks!=visBLOCKSolidOutline&&visBlocks!=visBLOCKAsInputOutline)continue;
       }
       if(j<vent_offset){
@@ -2976,10 +2978,10 @@ void UpdateFaceListsWorker(void){
     }
   }
   n_geom_triangles=0;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo  + i;
+    meshi = global_scase.meshescoll.meshinfo  + i;
     n_geom_triangles += meshi->nface_textures+meshi->nface_normals_single+meshi->nface_normals_double;
   }
 }
@@ -3000,11 +3002,11 @@ void DrawSelectFaces(){
 
   DISABLE_LIGHTING;
   glBegin(GL_QUADS);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
     meshdata *meshi;
 
-    meshi=meshinfo + i;
+    meshi=global_scase.meshescoll.meshinfo + i;
     for(j=0;j<meshi->nbptrs;j++){
       int k;
 
@@ -3078,7 +3080,7 @@ void DrawObstsDebug(void){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
   if(light_faces == 1){
     ENABLE_LIGHTING;
     glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
@@ -3086,15 +3088,15 @@ void DrawObstsDebug(void){
     glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, block_specular2);
     glEnable(GL_COLOR_MATERIAL);
   }
-  for(i = 1; i <= nmeshes; i++){
+  for(i = 1; i <= global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     int j;
     int jmin, jmax;
 
-    meshi = meshinfo + i - 1;
+    meshi = global_scase.meshescoll.meshinfo + i - 1;
     jmin = 0;
     jmax = meshi->nbptrs-1;
-    if(mesh_index_debug >= 1 && mesh_index_debug <= nmeshes){
+    if(mesh_index_debug >= 1 && mesh_index_debug <= global_scase.meshescoll.nmeshes){
       int max_blockage_index_debug;
       if(mesh_index_debug!=i)continue;
       max_blockage_index_debug = min_blockage_index_debug + n_blockages_debug - 1;
@@ -3143,11 +3145,11 @@ void DrawFacesOLD(){
       glEnable(GL_COLOR_MATERIAL);
     }
     glBegin(GL_TRIANGLES);
-    for(j = 0; j < nmeshes; j++){
+    for(j = 0; j < global_scase.meshescoll.nmeshes; j++){
       meshdata *meshi;
       int i;
 
-      meshi = meshinfo + j;
+      meshi = global_scase.meshescoll.meshinfo + j;
       if(meshi->blockvis == 0)continue;
       for(i = 0; i < meshi->nface_normals_single; i++){
         facedata *facei;
@@ -3223,11 +3225,11 @@ void DrawFacesOLD(){
     if(cullfaces == 1)glDisable(GL_CULL_FACE);
     AntiAliasLine(ON);
     glBegin(GL_QUADS);
-    for(j = 0; j < nmeshes; j++){
+    for(j = 0; j < global_scase.meshescoll.nmeshes; j++){
       meshdata *meshi;
       int i;
 
-      meshi = meshinfo + j;
+      meshi = global_scase.meshescoll.meshinfo + j;
       for(i = 0; i < meshi->nface_normals_double; i++){
         facedata *facei;
         float *vertices;
@@ -3294,13 +3296,13 @@ void DrawFacesOLD(){
 
     DISABLE_LIGHTING;
     AntiAliasLine(ON);
-    glLineWidth(linewidth);
+    glLineWidth(global_scase.linewidth);
     glBegin(GL_LINES);
-    for(j = 0; j < nmeshes; j++){
+    for(j = 0; j < global_scase.meshescoll.nmeshes; j++){
       meshdata *meshi;
       int i;
 
-      meshi = meshinfo + j;
+      meshi = global_scase.meshescoll.meshinfo + j;
       if(meshi->blockvis == 0)continue;
       for(i = 0; i < meshi->nface_outlines; i++){
         facedata *facei;
@@ -3319,7 +3321,7 @@ void DrawFacesOLD(){
         }
         if(facei->type2 != OUTLINE_FRAME_face || highlight_flag == 1){
           glEnd();
-          if(nmeshes > 1 && facei->type2 == OUTLINE_FRAME_face &&
+          if(global_scase.meshescoll.nmeshes > 1 && facei->type2 == OUTLINE_FRAME_face &&
             highlight_mesh == facei->meshindex && highlight_flag == 1){
             glLineWidth(highlight_linewidth);
           }
@@ -3364,11 +3366,11 @@ void DrawFacesOLD(){
     }
     glEnable(GL_TEXTURE_2D);
     glColor4ub(255, 255, 255, 255);
-    for(j = 0; j < nmeshes; j++){
+    for(j = 0; j < global_scase.meshescoll.nmeshes; j++){
       meshdata *meshi;
       int i;
 
-      meshi = meshinfo + j;
+      meshi = global_scase.meshescoll.meshinfo + j;
       if(meshi->blockvis == 0)continue;
       for(i = 0; i < meshi->nface_textures; i++){
         facedata *facei;
@@ -3442,12 +3444,12 @@ void DrawFaces(){
     glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,block_specular2);
     glEnable(GL_COLOR_MATERIAL);
     glBegin(GL_TRIANGLES);
-    for(j=0;j<nmeshes;j++){
+    for(j=0;j<global_scase.meshescoll.nmeshes;j++){
       facedata **face_START;
       meshdata *meshi;
       int i;
 
-      meshi=meshinfo + j;
+      meshi=global_scase.meshescoll.meshinfo + j;
       if(meshi->blockvis==0)continue;
 
       // DOWN_X faces
@@ -3512,11 +3514,11 @@ void DrawFaces(){
     glEnable(GL_COLOR_MATERIAL);
     if(cullfaces==1)glDisable(GL_CULL_FACE);
     glBegin(GL_QUADS);
-    for(j=0;j<nmeshes;j++){
+    for(j=0;j<global_scase.meshescoll.nmeshes;j++){
       meshdata *meshi;
       int i;
 
-      meshi=meshinfo + j;
+      meshi=global_scase.meshescoll.meshinfo + j;
       for(i=0;i<meshi->nface_normals_double;i++){
         facedata *facei;
         float *vertices;
@@ -3579,13 +3581,13 @@ void DrawFaces(){
 
     DISABLE_LIGHTING;
     AntiAliasLine(ON);
-    glLineWidth(linewidth);
+    glLineWidth(global_scase.linewidth);
     glBegin(GL_LINES);
-    for(j=0;j<nmeshes;j++){
+    for(j=0;j<global_scase.meshescoll.nmeshes;j++){
       meshdata *meshi;
       int i;
 
-      meshi = meshinfo + j;
+      meshi = global_scase.meshescoll.meshinfo + j;
       if(meshi->blockvis==0)continue;
       for(i=0;i<meshi->nface_outlines;i++){
         facedata *facei;
@@ -3603,7 +3605,7 @@ void DrawFaces(){
         }
         if(facei->type2!=OUTLINE_FRAME_face||highlight_flag==1){
           glEnd();
-          if(nmeshes>1&&facei->type2==OUTLINE_FRAME_face&&
+          if(global_scase.meshescoll.nmeshes>1&&facei->type2==OUTLINE_FRAME_face&&
             highlight_mesh==facei->meshindex&&highlight_flag==1){
             glLineWidth(highlight_linewidth);
           }
@@ -3641,11 +3643,11 @@ void DrawFaces(){
     glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,block_specular2);
     glEnable(GL_TEXTURE_2D);
     glColor4ub(255, 255, 255, 255);
-    for(j=0;j<nmeshes;j++){
+    for(j=0;j<global_scase.meshescoll.nmeshes;j++){
       meshdata *meshi;
       int i;
 
-      meshi = meshinfo + j;
+      meshi = global_scase.meshescoll.meshinfo + j;
       if(meshi->blockvis==0)continue;
       for(i=0;i<meshi->nface_textures;i++){
         facedata *facei;
@@ -3744,7 +3746,7 @@ void DrawTransparentFaces(){
   float highlight_color[4]={1.0,0.0,0.0,1.0};
   int drawing_transparent, drawing_blockage_transparent, drawing_vent_transparent;
 
-  if(blocklocation==BLOCKlocation_cad||(NCADGeom(cadgeomcoll)!=0&&show_cad_and_grid==1))return;
+  if(blocklocation==BLOCKlocation_cad||(NCADGeom(&global_scase.cadgeomcoll)!=0&&show_cad_and_grid==1))return;
 
   GetDrawingParms(&drawing_transparent, &drawing_blockage_transparent, &drawing_vent_transparent);
 
@@ -3835,11 +3837,11 @@ void DrawTransparentFaces(){
     glEnable(GL_COLOR_MATERIAL);
     if(cullfaces==1)glDisable(GL_CULL_FACE);
     glBegin(GL_QUADS);
-    for(j=0;j<nmeshes;j++){
+    for(j=0;j<global_scase.meshescoll.nmeshes;j++){
       meshdata *meshi;
       int i;
 
-      meshi=meshinfo + j;
+      meshi=global_scase.meshescoll.meshinfo + j;
       for(i=0;i<meshi->nface_transparent_double;i++){
         facedata *facei;
         float *vertices;
@@ -3979,11 +3981,11 @@ void AllocateFaces(){
   int abortflag=0;
 
   FREEMEMORY(face_transparent);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int ntotal;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     ntotal = 6*meshi->nbptrs + meshi->nvents+12;
     ntotal2 += ntotal;
 
@@ -4021,11 +4023,11 @@ void AllocateFaces(){
     mem_sum=0;
     nfaces_temp=0;
     ntotal2=0;
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       int ntotal;
       meshdata *meshi;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
 
       ntotal = 6*meshi->nbptrs + meshi->nvents+12;
       nfaces_temp+=(6*meshi->nbptrs);
@@ -4080,10 +4082,10 @@ void UpdateSelectBlocks(void){
   int ntotal=0;
   int local_count=0;
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     ntotal += meshi->nbptrs;
   }
   if(ntotal==0)return;
@@ -4096,11 +4098,11 @@ void UpdateSelectBlocks(void){
   for(i=0;i<ntotal;i++){
     sortedblocklist[i]=i;
   }
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int j;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j=0;j<meshi->nbptrs;j++){
       blockagedata *bc;
 
@@ -4124,10 +4126,10 @@ void UpdateSelectFaces(void){
   FREEMEMORY(selectfaceinfo);
 
   ntotalfaces=0;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi=meshinfo + i;
+    meshi=global_scase.meshescoll.meshinfo + i;
     ntotalfaces += 6*meshi->nbptrs;
   }
   if(ntotalfaces==0)return;
@@ -4142,11 +4144,11 @@ void UpdateSelectFaces(void){
      up z */
   ntotalfaces=0;
   sd = selectfaceinfo;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int j;
 
-    meshi=meshinfo + i;
+    meshi=global_scase.meshescoll.meshinfo + i;
     for(j=0;j<meshi->nbptrs;j++){
       int k;
 
@@ -4417,10 +4419,10 @@ void InitUserTicks(void){
   user_tick_max[1]=-1000000000.0;
   user_tick_max[2]=-1000000000.0;
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     user_tick_min[0]=MIN(meshi->boxmin[0],user_tick_min[0]);
     user_tick_min[1]=MIN(meshi->boxmin[1],user_tick_min[1]);
     user_tick_min[2]=MIN(meshi->boxmin[2],user_tick_min[2]);
@@ -4634,7 +4636,7 @@ void DrawUserTicks(void){
   }
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
  //*** x axis tick/labels
 
@@ -4935,34 +4937,34 @@ void DrawUserTicks(void){
 /* ------------------ DrawGravityAxis ------------------------ */
 
 void DrawGravityAxis(void){
-  glLineWidth(linewidth);
+  glLineWidth(global_scase.linewidth);
   glBegin(GL_LINES);
 
   // x axis
   glColor3f(0.0,0.0,1.0);
-  glVertex3f(xbar/2.0,ybar/2.0,zbar/2.0);
-  glVertex3f(xbar/2.0,ybar/2.0,zbar/2.0+0.5);
+  glVertex3f(global_scase.xbar/2.0,global_scase.ybar/2.0,global_scase.zbar/2.0);
+  glVertex3f(global_scase.xbar/2.0,global_scase.ybar/2.0,global_scase.zbar/2.0+0.5);
 
   // y axis
   glColor3f(0.0,1.0,0.0);
-  glVertex3f(xbar/2.0,ybar/2.0,zbar/2.0);
-  glVertex3f(xbar/2.0,ybar/2.0+0.5,zbar/2.0);
+  glVertex3f(global_scase.xbar/2.0,global_scase.ybar/2.0,global_scase.zbar/2.0);
+  glVertex3f(global_scase.xbar/2.0,global_scase.ybar/2.0+0.5,global_scase.zbar/2.0);
 
   // z axis
   glColor3f(1.0,0.0,0.0);
-  glVertex3f(xbar/2.0,ybar/2.0,zbar/2.0);
-  glVertex3f(xbar/2.0+0.5,ybar/2.0,zbar/2.0);
+  glVertex3f(global_scase.xbar/2.0,global_scase.ybar/2.0,global_scase.zbar/2.0);
+  glVertex3f(global_scase.xbar/2.0+0.5,global_scase.ybar/2.0,global_scase.zbar/2.0);
 
   // gravity vector
   glColor3fv(foregroundcolor);
-  glVertex3f(xbar/2.0,ybar/2.0,zbar/2.0);
-  glVertex3f(xbar/2.0+gvecunit[0],ybar/2.0+gvecunit[1],zbar/2.0+gvecunit[2]);
+  glVertex3f(global_scase.xbar/2.0,global_scase.ybar/2.0,global_scase.zbar/2.0);
+  glVertex3f(global_scase.xbar/2.0+global_scase.gvecunit[0],global_scase.ybar/2.0+global_scase.gvecunit[1],global_scase.zbar/2.0+global_scase.gvecunit[2]);
 
   glEnd();
-  Output3Text(foregroundcolor, xbar / 2.0, ybar / 2.0, zbar / 2.0 + 0.5, "z");
-  Output3Text(foregroundcolor, xbar / 2.0, ybar / 2.0 + 0.5, zbar / 2.0, "y");
-  Output3Text(foregroundcolor, xbar / 2.0 + 0.5, ybar / 2.0, zbar / 2.0, "x");
-  Output3Text(foregroundcolor, xbar / 2.0 + gvecunit[0], ybar / 2.0 + gvecunit[1], zbar / 2.0 + gvecunit[2], "g");
+  Output3Text(foregroundcolor, global_scase.xbar / 2.0, global_scase.ybar / 2.0, global_scase.zbar / 2.0 + 0.5, "z");
+  Output3Text(foregroundcolor, global_scase.xbar / 2.0, global_scase.ybar / 2.0 + 0.5, global_scase.zbar / 2.0, "y");
+  Output3Text(foregroundcolor, global_scase.xbar / 2.0 + 0.5, global_scase.ybar / 2.0, global_scase.zbar / 2.0, "x");
+  Output3Text(foregroundcolor, global_scase.xbar / 2.0 + global_scase.gvecunit[0], global_scase.ybar / 2.0 + global_scase.gvecunit[1], global_scase.zbar / 2.0 + global_scase.gvecunit[2], "g");
 }
 
 /* ------------------ DrawTicks ------------------------ */
@@ -4972,8 +4974,8 @@ void DrawTicks(void){
   tickdata *ticki;
   float *dxyz,xyz[3],xyz2[3],*begt,*endt,dbar[3];
 
-  for(i=0;i<ntickinfo;i++){
-    ticki = tickinfo + i;
+  for(i=0;i<global_scase.ntickinfo;i++){
+    ticki = global_scase.tickinfo + i;
     begt = ticki->begin;
     endt = ticki->end;
 
@@ -5053,11 +5055,11 @@ void DrawBlockages(int mode, int trans_flag){
     }
   }
 
-  if(blocklocation==BLOCKlocation_cad||(NCADGeom(cadgeomcoll)!=0&&show_cad_and_grid==1)){
+  if(blocklocation==BLOCKlocation_cad||(NCADGeom(&global_scase.cadgeomcoll)!=0&&show_cad_and_grid==1)){
     int ntriangles=0;
 
-    for(i=0;i<NCADGeom(cadgeomcoll);i++){
-      cd=cadgeomcoll->cadgeominfo+i;
+    for(i=0;i<NCADGeom(&global_scase.cadgeomcoll);i++){
+      cd=global_scase.cadgeomcoll.cadgeominfo+i;
       if(cd->version==1){
         if(trans_flag==DRAW_TRANSPARENT)continue;
         if(clip_mode==CLIP_BLOCKAGES)SetClipPlanes(&clipinfo,CLIP_ON);
@@ -5183,7 +5185,7 @@ void InitCullGeom(int cullgeomflag){
 
   update_initcullgeom=0;
   updatefacelists=1;
-  for(imesh=0;imesh<nmeshes;imesh++){
+  for(imesh=0;imesh<global_scase.meshescoll.nmeshes;imesh++){
     meshdata *meshi;
     int iskip, jskip, kskip;
     int ibeg, iend, jbeg, jend, kbeg, kend;
@@ -5192,7 +5194,7 @@ void InitCullGeom(int cullgeomflag){
     int nx, ny, nz;
     int *nxyzgeomcull, *nxyzskipgeomcull;
 
-    meshi=meshinfo+imesh;
+    meshi=global_scase.meshescoll.meshinfo+imesh;
 
     GetCullSkips(meshi,cullgeomflag,cullgeom_portsize,&iskip,&jskip,&kskip);
     nx = (meshi->ibar-1)/iskip + 1;
@@ -5371,10 +5373,10 @@ int CompareBlockage(const void *arg1, const void *arg2){
 void RemoveDupBlockages(void){
   int i;
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
 
     if(meshi->nbptrs>1){
       blockagedata **bclist;
@@ -5470,11 +5472,11 @@ void GetObstLabels(const char *filein){
   }
   fclose(stream_in);
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int j;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j=0;j<meshi->nbptrs;j++){
       blockagedata *bc;
       int id;

--- a/Source/smokeview/getdatabounds.c
+++ b/Source/smokeview/getdatabounds.c
@@ -76,13 +76,13 @@ int GetGlobalPartBounds(int flag){
   int nloaded_files = 0;
 
 
-  if(part_bound_buffer == NULL && npartinfo > 0 && npart5prop>0){
-    NewMemory((void **)&part_bound_buffer, 2*npartinfo*npart5prop*sizeof(float));
-    for(i = 0; i < npartinfo; i++){
+  if(part_bound_buffer == NULL && global_scase.npartinfo > 0 && npart5prop>0){
+    NewMemory((void **)&part_bound_buffer, 2*global_scase.npartinfo*npart5prop*sizeof(float));
+    for(i = 0; i < global_scase.npartinfo; i++){
       partdata *parti;
       int j;
 
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
       if(parti->loaded == 1)nloaded_files++;
       parti->valmin_part = part_bound_buffer;
       part_bound_buffer += npart5prop;
@@ -103,12 +103,12 @@ int GetGlobalPartBounds(int flag){
     partmins[i] = 1.0;
     partmaxs[i] = 0.0;
   }
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
     int j;
     float *valmin_part, *valmax_part;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     if(flag==LOADED_FILES&&parti->loaded==0)continue;
     valmin_part = parti->valmin_part;
     valmax_part = parti->valmax_part;
@@ -348,13 +348,13 @@ int GetNinfo(int file_type){
 
   ASSERT_BOUND_TYPE;
   if(file_type == BOUND_SLICE){
-    ninfo = slicecoll.nsliceinfo;
+    ninfo = global_scase.slicecoll.nsliceinfo;
   }
   else if(file_type == BOUND_PATCH){
-    ninfo = npatchinfo;
+    ninfo = global_scase.npatchinfo;
   }
   else if(file_type == BOUND_PLOT3D){
-    ninfo = nplot3dinfo;
+    ninfo = global_scase.nplot3dinfo;
   }
   return ninfo;
 }
@@ -402,13 +402,13 @@ char *GetRegFile(int file_type, int i){
 
   ASSERT_BOUND_TYPE;
   if(file_type == BOUND_SLICE){
-    reg_file = slicecoll.sliceinfo[i].reg_file;
+    reg_file = global_scase.slicecoll.sliceinfo[i].reg_file;
   }
   else if(file_type == BOUND_PATCH){
-    reg_file = patchinfo[i].reg_file;
+    reg_file = global_scase.patchinfo[i].reg_file;
   }
   else if(file_type == BOUND_PLOT3D){
-    reg_file = plot3dinfo[i].reg_file;
+    reg_file = global_scase.plot3dinfo[i].reg_file;
   }
   return reg_file;
 }
@@ -477,22 +477,22 @@ void BoundsUpdateDoit(int file_type){
     plot3ddata *plot3di;
 
     if(file_type == BOUND_SLICE){
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
       if(slicei->loaded == 0)continue;
     }
     else if(file_type == BOUND_PATCH){
-      patchi = patchinfo + i;
+      patchi = global_scase.patchinfo + i;
       if(patchi->loaded == 0)continue;
     }
     else if(file_type == BOUND_PLOT3D){
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
       if(plot3di->loaded == 0)continue;
     }
     reg_file = GetRegFile(file_type, i);
     key_index = ( char ** )bsearch(( char * )&reg_file, sorted_filenames, ninfo, sizeof(char *), CompareBoundFileName);
     if(key_index == NULL)continue;
     index = ( int )(key_index - sorted_filenames);
-    if(index<0 || index>slicecoll.nsliceinfo - 1)continue;
+    if(index<0 || index>global_scase.slicecoll.nsliceinfo - 1)continue;
     fi = globalboundsinfo + index;
     if(fi->defined == 1 && is_fds_running == 0)continue;
     valmin = 0.0;
@@ -544,7 +544,7 @@ void BoundsUpdateDoit(int file_type){
           float *vals;
           int j;
 
-          meshi = meshinfo + patchi->blocknumber;
+          meshi = global_scase.meshescoll.meshinfo + patchi->blocknumber;
           if(meshi->boundary_mask == NULL && patchi->patch_filetype == PATCH_STRUCTURED_CELL_CENTER){
             MakeBoundaryMask(patchi);
           }
@@ -593,7 +593,7 @@ void BoundsUpdateDoit(int file_type){
       int ii, jj, kk, nn;
       float valmins[MAXPLOT3DVARS], valmaxs[MAXPLOT3DVARS];
 
-      meshi = meshinfo + plot3di->blocknumber;
+      meshi = global_scase.meshescoll.meshinfo + plot3di->blocknumber;
       nx = meshi->ibar + 1;
       ny = meshi->jbar + 1;
       nz = meshi->kbar + 1;
@@ -619,7 +619,7 @@ void BoundsUpdateDoit(int file_type){
       }
       fi->defined = 1;
       fi->nbounds = 5;
-      if(plot3dinfo != NULL)fi->nbounds = plot3di->nplot3dvars;
+      if(global_scase.plot3dinfo != NULL)fi->nbounds = plot3di->nplot3dvars;
     }
   }
 }
@@ -662,8 +662,8 @@ int GetNBounds(int file_type){
     nbounds = 1;
   }
   else if(file_type == BOUND_PLOT3D){
-    if(plot3dinfo != NULL){
-      nbounds = plot3dinfo->nplot3dvars;
+    if(global_scase.plot3dinfo != NULL){
+      nbounds = global_scase.plot3dinfo->nplot3dvars;
     }
     else{
       nbounds = 5;
@@ -679,13 +679,13 @@ char *GetShortLabel(int file_type, int i, int ilabel){
 
   ASSERT_BOUND_TYPE;
   if(file_type == BOUND_SLICE){
-    shortlabel = slicecoll.sliceinfo[i].label.shortlabel;
+    shortlabel = global_scase.slicecoll.sliceinfo[i].label.shortlabel;
   }
   else if(file_type == BOUND_PATCH){
-    shortlabel = patchinfo[i].label.shortlabel;
+    shortlabel = global_scase.patchinfo[i].label.shortlabel;
   }
   else if(file_type == BOUND_PLOT3D){
-    shortlabel = plot3dinfo[i].label[ilabel].shortlabel;
+    shortlabel = global_scase.plot3dinfo[i].label[ilabel].shortlabel;
   }
   return shortlabel;
 }
@@ -806,27 +806,27 @@ void BoundsUpdateWrapup(int file_type){
     key_index = ( char ** )bsearch(( char * )&reg_file, sorted_filenames, ninfo, sizeof(char *), CompareBoundFileName);
     if(key_index == NULL)continue;
     index = ( int )(key_index - sorted_filenames);
-    if(index<0 || index>slicecoll.nsliceinfo - 1)continue;
+    if(index<0 || index>global_scase.slicecoll.nsliceinfo - 1)continue;
     fi = globalboundsinfo + index;
     if(fi->defined == 0)continue;
     if(file_type == BOUND_SLICE){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
       slicei->valmin_slice = fi->valmins[0];
       slicei->valmax_slice = fi->valmaxs[0];
     }
     else if(file_type == BOUND_PATCH){
       patchdata *patchi;
 
-      patchi = patchinfo + i;
+      patchi = global_scase.patchinfo + i;
       patchi->valmin_patch = fi->valmins[0];
       patchi->valmax_patch = fi->valmaxs[0];
     }
     else if(file_type == BOUND_PLOT3D){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
       memcpy(plot3di->valmin_plot3d, fi->valmins, plot3di->nplot3dvars * sizeof(float));
       memcpy(plot3di->valmax_plot3d, fi->valmaxs, plot3di->nplot3dvars * sizeof(float));
     }
@@ -869,22 +869,22 @@ void DefineGbndFilename(int file_type){
   ASSERT_BOUND_TYPE;
   if(file_type == BOUND_SLICE){
     if(slice_gbnd_filename == NULL){
-      NewMemory(( void ** )&slice_gbnd_filename, strlen(fdsprefix) + strlen(".sf.gbnd") + 1);
-      strcpy(slice_gbnd_filename, fdsprefix);
+      NewMemory(( void ** )&slice_gbnd_filename, strlen(global_scase.fdsprefix) + strlen(".sf.gbnd") + 1);
+      strcpy(slice_gbnd_filename, global_scase.fdsprefix);
       strcat(slice_gbnd_filename, ".sf.gbnd");
     }
   }
   else if(file_type == BOUND_PATCH){
     if(patch_gbnd_filename == NULL){
-      NewMemory(( void ** )&patch_gbnd_filename, strlen(fdsprefix) + strlen(".bf.gbnd") + 1);
-      strcpy(patch_gbnd_filename, fdsprefix);
+      NewMemory(( void ** )&patch_gbnd_filename, strlen(global_scase.fdsprefix) + strlen(".bf.gbnd") + 1);
+      strcpy(patch_gbnd_filename, global_scase.fdsprefix);
       strcat(patch_gbnd_filename, ".bf.gbnd");
     }
   }
   else if(file_type == BOUND_PLOT3D){
     if(plot3d_gbnd_filename == NULL){
-      NewMemory(( void ** )&plot3d_gbnd_filename, strlen(fdsprefix) + strlen(".q.gbnd") + 1);
-      strcpy(plot3d_gbnd_filename, fdsprefix);
+      NewMemory(( void ** )&plot3d_gbnd_filename, strlen(global_scase.fdsprefix) + strlen(".q.gbnd") + 1);
+      strcpy(plot3d_gbnd_filename, global_scase.fdsprefix);
       strcat(plot3d_gbnd_filename, ".q.gbnd");
     }
   }
@@ -897,13 +897,13 @@ char *GetBoundFile(int file_type, int i){
 
   ASSERT_BOUND_TYPE;
   if(file_type == BOUND_SLICE){
-    bound_file = slicecoll.sliceinfo[i].bound_file;
+    bound_file = global_scase.slicecoll.sliceinfo[i].bound_file;
   }
   else if(file_type == BOUND_PATCH){
-    bound_file = patchinfo[i].bound_file;
+    bound_file = global_scase.patchinfo[i].bound_file;
   }
   else if(file_type == BOUND_PLOT3D){
-    bound_file = plot3dinfo[i].bound_file;
+    bound_file = global_scase.plot3dinfo[i].bound_file;
   }
   return bound_file;
 }
@@ -1014,7 +1014,7 @@ void BoundsUpdateSetup(int file_type){
         fi->nbounds = 1;
         if(file_type == BOUND_PLOT3D){
           fi->nbounds = 5;
-          if(plot3dinfo != NULL)fi->nbounds = plot3dinfo->nplot3dvars;
+          if(global_scase.plot3dinfo != NULL)fi->nbounds = global_scase.plot3dinfo->nplot3dvars;
         }
         memcpy(fi->valmins, valmins, fi->nbounds * sizeof(float));
         memcpy(fi->valmaxs, valmaxs, fi->nbounds * sizeof(float));
@@ -1080,7 +1080,7 @@ void BoundsUpdate(int file_type){
 void GetGlobalPatchBounds(int flag, int set_flag){
   int i;
 
-  if(npatchinfo==0)return;
+  if(global_scase.npatchinfo==0)return;
   if(no_bounds == 1 && force_bounds==0)flag = 0;
   for(i = 0; i < npatchbounds; i++){
     boundsdata *boundi;
@@ -1090,13 +1090,13 @@ void GetGlobalPatchBounds(int flag, int set_flag){
     boundi->dlg_global_valmax = 0.0;
   }
   if(flag==1)BoundsUpdate(BOUND_PATCH);
-  for(i = 0; i < npatchinfo; i++){
+  for(i = 0; i < global_scase.npatchinfo; i++){
     patchdata *patchi;
     float valmin, valmax;
     boundsdata *boundi;
     int doit;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
 
     doit = 0;
     if(patchi->valmin_patch > patchi->valmax_patch ||
@@ -1114,10 +1114,10 @@ void GetGlobalPatchBounds(int flag, int set_flag){
         valmax = patchi->frameinfo->valmax;
       }
       else{
-        BoundsGet(patchi->reg_file, patchglobalboundsinfo, sorted_patch_filenames, npatchinfo, 1, &valmin, &valmax);
+        BoundsGet(patchi->reg_file, patchglobalboundsinfo, sorted_patch_filenames, global_scase.npatchinfo, 1, &valmin, &valmax);
       }
 #else
-      BoundsGet(patchi->reg_file, patchglobalboundsinfo, sorted_patch_filenames, npatchinfo, 1, &valmin, &valmax);
+      BoundsGet(patchi->reg_file, patchglobalboundsinfo, sorted_patch_filenames, global_scase.npatchinfo, 1, &valmin, &valmax);
 #endif
       if(valmin > valmax)continue;
       patchi->valmin_patch = valmin;
@@ -1146,10 +1146,10 @@ void GetGlobalPatchBounds(int flag, int set_flag){
     boundi = patchbounds + i;
     boundi->dlg_valmin = boundi->dlg_global_valmin;
     boundi->dlg_valmax = boundi->dlg_global_valmax;
-    for(j = 0; j < npatchinfo; j++){
+    for(j = 0; j < global_scase.npatchinfo; j++){
       patchdata *patchj;
 
-      patchj = patchinfo + j;
+      patchj = global_scase.patchinfo + j;
       if(strcmp(patchj->label.shortlabel, boundi->shortlabel) == 0){
         patchj->valmin_glui = boundi->dlg_global_valmin;
         patchj->valmax_glui = boundi->dlg_global_valmax;
@@ -1247,24 +1247,24 @@ int GetPlot3DFileBounds(char *file, float *valmin, float *valmax){
 void GetGlobalPlot3DBounds(void){
   int i;
 
-  if(nplot3dinfo <= 0)return;
+  if(global_scase.nplot3dinfo <= 0)return;
   if(no_bounds==0 || force_bounds==1)BoundsUpdate(BOUND_PLOT3D);
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+i;
-    plot3di->have_bound_file = BoundsGet(plot3di->reg_file, plot3dglobalboundsinfo, sorted_plot3d_filenames, nplot3dinfo, plot3di->nplot3dvars, plot3di->valmin_plot3d, plot3di->valmax_plot3d);
+    plot3di = global_scase.plot3dinfo+i;
+    plot3di->have_bound_file = BoundsGet(plot3di->reg_file, plot3dglobalboundsinfo, sorted_plot3d_filenames, global_scase.nplot3dinfo, plot3di->nplot3dvars, plot3di->valmin_plot3d, plot3di->valmax_plot3d);
   }
   for(i = 0; i<MAXPLOT3DVARS; i++){
     p3min_all[i] = 1.0;
     p3max_all[i] = 0.0;
   }
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
     int j;
     float *valmin_fds, *valmax_fds;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->have_bound_file == 0)continue;
     valmin_fds = plot3di->valmin_plot3d;
     valmax_fds = plot3di->valmax_plot3d;
@@ -1287,15 +1287,15 @@ void GetGlobalPlot3DBounds(void){
   }
 
   nplot3dbounds_cpp = 0;
-  if(nplot3dinfo>0&&plot3dbounds_cpp==NULL){ // only initialize once
-    nplot3dbounds_cpp = plot3dinfo[0].nplot3dvars;
+  if(global_scase.nplot3dinfo>0&&plot3dbounds_cpp==NULL){ // only initialize once
+    nplot3dbounds_cpp = global_scase.plot3dinfo[0].nplot3dvars;
     NewMemory((void **)&plot3dbounds_cpp, nplot3dbounds_cpp*sizeof(cpp_boundsdata));
     for(i = 0; i<nplot3dbounds_cpp; i++){
       cpp_boundsdata *boundscppi;
 
       boundscppi = plot3dbounds_cpp+i;
-      strcpy(boundscppi->label, plot3dinfo->label[i].shortlabel);
-      strcpy(boundscppi->unit, plot3dinfo->label[i].unit);
+      strcpy(boundscppi->label, global_scase.plot3dinfo->label[i].shortlabel);
+      strcpy(boundscppi->unit, global_scase.plot3dinfo->label[i].unit);
 
       boundscppi->cache = cache_plot3d_data;
       boundscppi->set_valtype = 0;
@@ -1318,7 +1318,7 @@ void GetGlobalPlot3DBounds(void){
       boundscppi->chopmax = p3max_global[0];
     }
   }
-  GLUISetGlobalMinMaxAll(BOUND_PLOT3D, p3min_global, p3max_global, plot3dinfo->nplot3dvars);
+  GLUISetGlobalMinMaxAll(BOUND_PLOT3D, p3min_global, p3max_global, global_scase.plot3dinfo->nplot3dvars);
 }
 
 /* ------------------ GetLoadedPlot3dBounds ------------------------ */
@@ -1328,10 +1328,10 @@ void GetLoadedPlot3dBounds(int *compute_loaded, float *loaded_min, float *loaded
   int plot3d_loaded = 0;
 
 #define BOUNDS_LOADED 1
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->loaded==0)continue;
     plot3d_loaded = 1;
     break;
@@ -1349,11 +1349,11 @@ void GetLoadedPlot3dBounds(int *compute_loaded, float *loaded_min, float *loaded
     loaded_min[i] = 1.0;
     loaded_max[i] = 0.0;
   }
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
     int j;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->loaded==0)continue;
     for(j = 0; j< MAXPLOT3DVARS; j++){
       if(compute_loaded!=NULL&&compute_loaded[j]!=BOUNDS_LOADED)continue;
@@ -1423,7 +1423,7 @@ void GetGlobalSliceBounds(int flag, int set_flag){
   int i;
 
   if(no_bounds == 1 && force_bounds==0)flag = 0;
-  if(slicecoll.nsliceinfo==0)return;
+  if(global_scase.slicecoll.nsliceinfo==0)return;
   for(i = 0;i<nslicebounds;i++){
     boundsdata *boundi;
 
@@ -1433,13 +1433,13 @@ void GetGlobalSliceBounds(int flag, int set_flag){
   }
   if(no_bounds==0 || force_bounds==1)BoundsUpdate(BOUND_SLICE);
   INIT_PRINT_TIMER(slicebounds_timer);
-  for(i = 0;i<slicecoll.nsliceinfo;i++){
+  for(i = 0;i<global_scase.slicecoll.nsliceinfo;i++){
     slicedata *slicei;
     float valmin, valmax;
     boundsdata *boundi;
     int doit;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     if(slicei->valmin_slice>slicei->valmax_slice ||
        current_script_command==NULL || NOT_LOADRENDER)doit=1;
     if(flag==0){
@@ -1447,10 +1447,10 @@ void GetGlobalSliceBounds(int flag, int set_flag){
        slicei->valmin_slice = 0.0;
        slicei->valmax_slice = 1.0;
     }
-    if(force_bound_update == 1||nzoneinfo>0)doit = 1;
+    if(force_bound_update == 1||global_scase.nzoneinfo>0)doit = 1;
 
     if(doit==1){
-      BoundsGet(slicei->reg_file, sliceglobalboundsinfo, sorted_slice_filenames, slicecoll.nsliceinfo, 1, &valmin, &valmax);
+      BoundsGet(slicei->reg_file, sliceglobalboundsinfo, sorted_slice_filenames, global_scase.slicecoll.nsliceinfo, 1, &valmin, &valmax);
       if(valmin>valmax)continue;
       slicei->valmin_slice = valmin;
       slicei->valmax_slice = valmax;
@@ -1544,10 +1544,10 @@ void GetHVACDuctBounds(char *shortlabel, float *valminptr, float *valmaxptr){
 
   *valminptr = 1.0;
   *valmaxptr = 0.0;
-  for(i=0;i< hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
+  for(i=0;i< global_scase.hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
     hvacvaldata *hi;
 
-    hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
+    hi = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + i;
     if(strcmp(shortlabel, hi->label.shortlabel)!=0)continue;
     if(valmin<valmax){
       valmin = MIN(valmin,hi->valmin);
@@ -1570,10 +1570,10 @@ void GetHVACNodeBounds(char *shortlabel, float *valminptr, float *valmaxptr){
 
   *valminptr = 1.0;
   *valmaxptr = 0.0;
-  for(i = 0;i < hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
+  for(i = 0;i < global_scase.hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
     hvacvaldata *hi;
 
-    hi = hvaccoll.hvacnodevalsinfo->node_vars + i;
+    hi = global_scase.hvaccoll.hvacnodevalsinfo->node_vars + i;
     if(strcmp(shortlabel, hi->label.shortlabel) != 0)continue;
     if(valmin < valmax){
       valmin = MIN(valmin, hi->valmin);
@@ -1595,7 +1595,7 @@ void GetGlobalHVACDuctBounds(int flag){
 
   if(no_bounds == 1 && force_bounds==0)flag = 0;
   int nhvacboundsmax = 0;
-  if(hvaccoll.hvacductvalsinfo != NULL)nhvacboundsmax = hvaccoll.hvacductvalsinfo->n_duct_vars;
+  if(global_scase.hvaccoll.hvacductvalsinfo != NULL)nhvacboundsmax = global_scase.hvaccoll.hvacductvalsinfo->n_duct_vars;
   if(nhvacboundsmax == 0)return;
   if(flag==0)ReadHVACData(BOUNDS_ONLY);
   for(i = 0;i < nhvacductbounds;i++){
@@ -1656,7 +1656,7 @@ void GetGlobalHVACNodeBounds(int flag){
 
   if(no_bounds == 1 && force_bounds==0)flag = 0;
   int nhvacboundsmax = 0;
-  if(hvaccoll.hvacnodevalsinfo != NULL)nhvacboundsmax = hvaccoll.hvacnodevalsinfo->n_duct_vars + hvaccoll.hvacnodevalsinfo->n_node_vars;
+  if(global_scase.hvaccoll.hvacnodevalsinfo != NULL)nhvacboundsmax = global_scase.hvaccoll.hvacnodevalsinfo->n_duct_vars + global_scase.hvaccoll.hvacnodevalsinfo->n_node_vars;
   if(nhvacboundsmax == 0)return;
   if(flag == 0)ReadHVACData(BOUNDS_ONLY);
   for(i = 0;i < nhvacnodebounds;i++){
@@ -1858,11 +1858,11 @@ void MergeAllPartBounds(void){
 
   // find min/max over all particle files
 
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
     int j;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     if(parti->bounds_set==0)continue;
     for(j = 0; j<npart5prop; j++){
       partpropdata *propj;
@@ -1879,7 +1879,7 @@ void MergeAllPartBounds(void){
     stream = FOPEN_2DIR(part_globalbound_filename, "w");
     if(stream!=NULL){
       global_have_global_bound_file = 1;
-      global_part_boundsize = GetFileSizeSMV(partinfo->bound_file);
+      global_part_boundsize = GetFileSizeSMV(global_scase.partinfo->bound_file);
       fprintf(stream,"%i %i\n",npart5prop,(int)global_part_boundsize);
       for(i=0;i<npart5prop;i++){
         partpropdata *propi;
@@ -1906,10 +1906,10 @@ void PrintPartLoadSummary(int option_arg,int type_arg){
   int j;
 
   nsize_local = 0;
-  for(j = 0; j<npartinfo; j++){
+  for(j = 0; j<global_scase.npartinfo; j++){
     partdata *partj;
 
-    partj = partinfo+j;
+    partj = global_scase.partinfo+j;
     if(type_arg==PART_SIZING&&partj->boundstatus==PART_BOUND_COMPUTING)nsize_local++;
     if(type_arg==PART_LOADING&&partj->loadstatus==FILE_LOADING)nsize_local++;
   }
@@ -1918,11 +1918,11 @@ void PrintPartLoadSummary(int option_arg,int type_arg){
 
     if(type_arg==PART_LOADING)printf("loading: ");
     isize_local = 0;
-    for(j = 0; j<npartinfo; j++){
+    for(j = 0; j<global_scase.npartinfo; j++){
       partdata *partj;
       int doit;
 
-      partj = partinfo+j;
+      partj = global_scase.partinfo+j;
       doit = 0;
       if(type_arg==PART_LOADING&&partj->loadstatus==FILE_LOADING)doit = 1;
       if(doit==1){
@@ -1951,7 +1951,7 @@ void GetAllPartBounds(void){
 
   // find min/max for each particle file
 
-  if(global_part_boundsize==0)global_part_boundsize = GetFileSizeSMV(partinfo->bound_file);
+  if(global_part_boundsize==0)global_part_boundsize = GetFileSizeSMV(global_scase.partinfo->bound_file);
 
   stream = FOPEN_2DIR(part_globalbound_filename, "r");
   if(stream!=NULL){
@@ -1973,9 +1973,9 @@ void GetAllPartBounds(void){
         propi->dlg_global_valmax = valmax;
       }
       fclose(stream);
-      for(i = 0; i<npartinfo; i++){
+      for(i = 0; i<global_scase.npartinfo; i++){
         partdata *parti;
-        parti              = partinfo+i;
+        parti              = global_scase.partinfo+i;
         parti->boundstatus = PART_BOUND_DEFINED;
         parti->bounds_set  = 1;
       }
@@ -1993,10 +1993,10 @@ void GetAllPartBounds(void){
   }
   THREADcontrol(partload_threads, THREAD_UNLOCK);
 
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     THREADcontrol(partload_threads, THREAD_LOCK);
     if(parti->boundstatus!=PART_BOUND_UNDEFINED){
       THREADcontrol(partload_threads, THREAD_UNLOCK);

--- a/Source/smokeview/getdatacolors.c
+++ b/Source/smokeview/getdatacolors.c
@@ -112,19 +112,19 @@ void WriteBoundIni(void){
 
   if(fullfilename == NULL)return;
 
-  for(i = 0; i < npatchinfo; i++){
+  for(i = 0; i < global_scase.npatchinfo; i++){
     bounddata *boundi;
     patchdata *patchi;
     int skipi;
     int j;
 
     skipi = 0;
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->bounds.defined == 0)continue;
     for(j = 0; j < i - 1; j++){
       patchdata *patchj;
 
-      patchj = patchinfo + j;
+      patchj = global_scase.patchinfo + j;
       if(patchi->shortlabel_index == patchj->shortlabel_index&&patchi->patch_filetype == patchj->patch_filetype){
         skipi = 1;
         break;
@@ -220,19 +220,19 @@ void GetBoundaryColors3(patchdata *patchi, float *t, int start, int nt, unsigned
 void UpdateAllBoundaryColors(int flag){
   int i, *list = NULL, nlist = 0;
 
-  if(npatchinfo==0)return;
-  NewMemory((void **)&list, npatchinfo*sizeof(int));
+  if(global_scase.npatchinfo==0)return;
+  NewMemory((void **)&list, global_scase.npatchinfo*sizeof(int));
   nlist = 0;
-  for(i = 0; i<npatchinfo; i++){
+  for(i = 0; i<global_scase.npatchinfo; i++){
     meshdata *meshi;
     patchdata *patchi;
 
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==0)continue;
     switch(patchi->patch_filetype){
       case PATCH_STRUCTURED_NODE_CENTER:
       case PATCH_STRUCTURED_CELL_CENTER:
-        meshi = meshinfo+patchi->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo+patchi->blocknumber;
         if(meshi->patchval==NULL||meshi->cpatchval==NULL)continue;
         list[nlist++] = i;
         break;
@@ -252,7 +252,7 @@ void UpdateAllBoundaryColors(int flag){
     for(i = 0; i<nlist; i++){
       patchdata *patchi;
 
-      patchi = patchinfo+list[i];
+      patchi = global_scase.patchinfo+list[i];
       if(patchi->loaded==1){
         int set_valmin, set_valmax;
         float valmin, valmax;
@@ -267,11 +267,11 @@ void UpdateAllBoundaryColors(int flag){
               meshdata *meshi;
               int npatchvals;
 
-              meshi = meshinfo+patchi->blocknumber;
+              meshi = global_scase.meshescoll.meshinfo+patchi->blocknumber;
               npatchvals = patchi->ntimes*meshi->npatchsize;
               GetBoundaryColors3(patchi, meshi->patchval, 0, npatchvals, meshi->cpatchval,
                                  &glui_patchmin, &glui_patchmax,
-                                 nrgb, colorlabelpatch, colorvaluespatch, boundarylevels256,
+                                 global_scase.nrgb, colorlabelpatch, colorvaluespatch, boundarylevels256,
                                  &patchi->extreme_min, &patchi->extreme_max, flag);
             }
             break;
@@ -279,7 +279,7 @@ void UpdateAllBoundaryColors(int flag){
           case PATCH_GEOMETRY_SLICE:
             GetBoundaryColors3(patchi, patchi->geom_vals, 0, patchi->geom_nvals, patchi->geom_ivals,
                                &valmin, &valmax,
-                               nrgb, colorlabelpatch, colorvaluespatch, boundarylevels256,
+                               global_scase.nrgb, colorlabelpatch, colorvaluespatch, boundarylevels256,
                                &patchi->extreme_min, &patchi->extreme_max, flag);
             break;
           default:
@@ -643,10 +643,10 @@ void GetPlot3DColors(int plot3dvar, float *ttmin, float *ttmax,
       factor = 0.0f;
     }
 
-    for(i = 0; i<nplot3dinfo; i++){
-      p = plot3dinfo+i;
+    for(i = 0; i<global_scase.nplot3dinfo; i++){
+      p = global_scase.plot3dinfo+i;
       if(p->loaded==0||p->display==0)continue;
-      meshi = meshinfo+p->blocknumber;
+      meshi = global_scase.meshescoll.meshinfo+p->blocknumber;
       ntotal = (meshi->ibar+1)*(meshi->jbar+1)*(meshi->kbar+1);
 
       if(meshi->qdata!=NULL){
@@ -696,10 +696,10 @@ void GetPlot3DColors(int plot3dvar, float *ttmin, float *ttmax,
   }
 
   if(flag==1){
-    for(i = 0; i<nplot3dinfo; i++){
-      p = plot3dinfo+i;
+    for(i = 0; i<global_scase.nplot3dinfo; i++){
+      p = global_scase.plot3dinfo+i;
       if(p->loaded==0||p->display==0)continue;
-      meshi = meshinfo+p->blocknumber;
+      meshi = global_scase.meshescoll.meshinfo+p->blocknumber;
       ntotal = (meshi->ibar+1)*(meshi->jbar+1)*(meshi->kbar+1);
 
       if(meshi->qdata==NULL){
@@ -724,11 +724,11 @@ void GetPlot3DColors(int plot3dvar, float *ttmin, float *ttmax,
 void UpdateAllPlot3DColors(int flag){
   int i, updated=0;
 
-  for(i = 0; i < nplot3dinfo; i++){
+  for(i = 0; i < global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
     int errorcode;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     if(plot3di->loaded == 1){
       UpdatePlot3DColors(plot3di, flag, &errorcode);
       updated = 1;
@@ -769,7 +769,7 @@ void UpdateSliceColors(int last_slice){
     slicedata *sd;
 
     i = slice_loaded_list[ii];
-    sd = slicecoll.sliceinfo+i;
+    sd = global_scase.slicecoll.sliceinfo+i;
     if(sd->vloaded==0&&sd->display==0)continue;
     if(sd->slicefile_labelindex==slicefile_labelindex){
       int set_slicecolor;
@@ -796,7 +796,7 @@ void UpdateSliceBounds2(void){
     float qmin, qmax;
 
     i = slice_loaded_list[ii];
-    sd = slicecoll.sliceinfo+i;
+    sd = global_scase.slicecoll.sliceinfo+i;
     if(sd->display==0)continue;
     GLUIGetMinMax(BOUND_SLICE, sd->label.shortlabel, &set_valmin, &qmin, &set_valmax, &qmax);
     sd->valmin_slice      = qmin;
@@ -805,15 +805,15 @@ void UpdateSliceBounds2(void){
     sd->globalmax_slice   = qmax;
     SetSliceColors(qmin, qmax, sd, 0, &error);
   }
-  for(ii = 0; ii<slicecoll.nvsliceinfo; ii++){
+  for(ii = 0; ii<global_scase.slicecoll.nvsliceinfo; ii++){
     vslicedata *vd;
     slicedata *sd;
     int set_valmin, set_valmax;
     float qmin, qmax;
 
-    vd = slicecoll.vsliceinfo+ii;
+    vd = global_scase.slicecoll.vsliceinfo+ii;
     if(vd->loaded==0||vd->display==0||vd->ival==-1)continue;
-    sd = slicecoll.sliceinfo+vd->ival;
+    sd = global_scase.slicecoll.sliceinfo+vd->ival;
     GLUIGetMinMax(BOUND_SLICE, sd->label.shortlabel, &set_valmin, &qmin, &set_valmax, &qmax);
     sd->valmin_slice    = qmin;
     sd->valmax_slice    = qmax;
@@ -906,14 +906,14 @@ void InitCadColors(void){
   switch(setbw){
    case 0:
     for(n=0;n<nrgb_cad;n++){
-      xx = (float)n/(float)nrgb_cad * (float)(nrgb-1);
+      xx = (float)n/(float)nrgb_cad * (float)(global_scase.nrgb-1);
       i1 = (int)xx;
       i2 = (int)(xx+1);
       f2 = xx - (float)i1;
       f1 = 1.0f - f2;
       sum=0.0;
       for(i=0;i<3;i++){
-        rgb_cad[n][i] = f1*rgb[i1][i] + f2*rgb[i2][i];
+        rgb_cad[n][i] = f1*global_scase.rgb[i1][i] + f2*global_scase.rgb[i2][i];
         sum += rgb_cad[n][i]*rgb_cad[n][i];
       }
       sum=sqrt((double)sum);
@@ -1005,30 +1005,30 @@ void InitRGB(void){
   if(setbw==0){
     ConvertColor(TO_COLOR);
     if(nrgb_ini > 0){
-      nrgb = nrgb_ini;
+      global_scase.nrgb = nrgb_ini;
       for(n=0;n<nrgb_ini;n++){
-        rgb[n][0] = rgb_ini[n*3];
-        rgb[n][1] = rgb_ini[n*3+1];
-        rgb[n][2] = rgb_ini[n*3+2];
-        rgb[n][3] = transparent_level_local;
+        global_scase.rgb[n][0] = rgb_ini[n*3];
+        global_scase.rgb[n][1] = rgb_ini[n*3+1];
+        global_scase.rgb[n][2] = rgb_ini[n*3+2];
+        global_scase.rgb[n][3] = transparent_level_local;
       }
     }
     else{
-      for(n=0;n<nrgb;n++){
-        rgb[n][0] = rgb_base[n][0];
-        rgb[n][1] = rgb_base[n][1];
-        rgb[n][2] = rgb_base[n][2];
-        rgb[n][3] = transparent_level_local;
+      for(n=0;n<global_scase.nrgb;n++){
+        global_scase.rgb[n][0] = rgb_base[n][0];
+        global_scase.rgb[n][1] = rgb_base[n][1];
+        global_scase.rgb[n][2] = rgb_base[n][2];
+        global_scase.rgb[n][3] = transparent_level_local;
       }
     }
   }
   else{
     ConvertColor(TO_BW);
-    for(n=0;n<nrgb;n++){
-      rgb[n][0] = bw_base[n][0];
-      rgb[n][1] = bw_base[n][1];
-      rgb[n][2] = bw_base[n][2];
-      rgb[n][3] = transparent_level_local;
+    for(n=0;n<global_scase.nrgb;n++){
+      global_scase.rgb[n][0] = bw_base[n][0];
+      global_scase.rgb[n][1] = bw_base[n][1];
+      global_scase.rgb[n][2] = bw_base[n][2];
+      global_scase.rgb[n][3] = transparent_level_local;
     }
   }
 }
@@ -1082,7 +1082,7 @@ void UpdateSmokeColormap(int option){
 
   if(have_fire==HRRPUV_index&&option==RENDER_SLICE){
     valmin=global_hrrpuv_min;
-    valcut=global_hrrpuv_cutoff;
+    valcut=global_scase.global_hrrpuv_cutoff;
     valmax=global_hrrpuv_max;
     rgb_colormap = rgb_slicesmokecolormap_01;
   }
@@ -1349,53 +1349,53 @@ void UpdateRGBColors(int colorbar_index){
     rgb2ptr=&(rgb2[0][0]);
   }
   if(colorbar_index!=0){
-    for(n=0;n<nrgb;n++){
-      nn=n*(nrgb_full-1)/(nrgb-1);
-      rgb[n][0] = rgb_full[nn][0];
-      rgb[n][1] = rgb_full[nn][1];
-      rgb[n][2] = rgb_full[nn][2];
-      rgb[n][3] = transparent_level_local;
+    for(n=0;n<global_scase.nrgb;n++){
+      nn=n*(nrgb_full-1)/(global_scase.nrgb-1);
+      global_scase.rgb[n][0] = rgb_full[nn][0];
+      global_scase.rgb[n][1] = rgb_full[nn][1];
+      global_scase.rgb[n][2] = rgb_full[nn][2];
+      global_scase.rgb[n][3] = transparent_level_local;
     }
   }
-  for(n=nrgb;n<nrgb+nrgb2;n++){
-    rgb[n][0]=rgb2ptr[3*(n-nrgb)];
-    rgb[n][1]=rgb2ptr[3*(n-nrgb)+1];
-    rgb[n][2]=rgb2ptr[3*(n-nrgb)+2];
-    rgb[n][3]=transparent_level_local;
+  for(n=global_scase.nrgb;n<global_scase.nrgb+global_scase.nrgb2;n++){
+    global_scase.rgb[n][0]=rgb2ptr[3*(n-global_scase.nrgb)];
+    global_scase.rgb[n][1]=rgb2ptr[3*(n-global_scase.nrgb)+1];
+    global_scase.rgb[n][2]=rgb2ptr[3*(n-global_scase.nrgb)+2];
+    global_scase.rgb[n][3]=transparent_level_local;
   }
-  rgb_white=nrgb;
-  rgb_yellow=nrgb+1;
-  rgb_blue=nrgb+2;
-  rgb_red=nrgb+3;
+  rgb_white=global_scase.nrgb;
+  rgb_yellow=global_scase.nrgb+1;
+  rgb_blue=global_scase.nrgb+2;
+  rgb_red=global_scase.nrgb+3;
 
   if(background_flip==0){
     for(i=0;i<3;i++){
       foregroundcolor[i]=foregroundbasecolor[i];
       backgroundcolor[i]=backgroundbasecolor[i];
     }
-    rgb[rgb_white][0]=1.0;
-    rgb[rgb_white][1]=1.0;
-    rgb[rgb_white][2]=1.0;
-    rgb[rgb_black][0]=0.0;
-    rgb[rgb_black][1]=0.0;
-    rgb[rgb_black][2]=0.0;
+    global_scase.rgb[rgb_white][0]=1.0;
+    global_scase.rgb[rgb_white][1]=1.0;
+    global_scase.rgb[rgb_white][2]=1.0;
+    global_scase.rgb[rgb_black][0]=0.0;
+    global_scase.rgb[rgb_black][1]=0.0;
+    global_scase.rgb[rgb_black][2]=0.0;
   }
   else{
     for(i=0;i<3;i++){
       foregroundcolor[i]=backgroundbasecolor[i];
       backgroundcolor[i]=foregroundbasecolor[i];
     }
-    rgb[rgb_white][0]=0.0;  //xxx fix or take out
-    rgb[rgb_white][1]=0.0;
-    rgb[rgb_white][2]=0.0;
-    rgb[rgb_black][0]=1.0;
-    rgb[rgb_black][1]=1.0;
-    rgb[rgb_black][2]=1.0;
+    global_scase.rgb[rgb_white][0]=0.0;  //xxx fix or take out
+    global_scase.rgb[rgb_white][1]=0.0;
+    global_scase.rgb[rgb_white][2]=0.0;
+    global_scase.rgb[rgb_black][0]=1.0;
+    global_scase.rgb[rgb_black][1]=1.0;
+    global_scase.rgb[rgb_black][2]=1.0;
   }
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
 
-    meshi=meshinfo + i;
+    meshi=global_scase.meshescoll.meshinfo + i;
     vent_offset = 6*meshi->nbptrs;
     outline_offset = vent_offset + meshi->nvents;
     if(meshi->faceinfo == NULL)continue;
@@ -1553,10 +1553,10 @@ void UpdateChopColors(void){
   if(showall_3dslices==1){
     int slice3d_loaded = 0;
 
-    for(i=0;i<slicecoll.nsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
       if(slicei->volslice==1&&slicei->loaded==1&&slicei->display==1){
         slice3d_loaded = 1;
         break;
@@ -1708,18 +1708,18 @@ void UpdateChopColors(void){
         if(ii>NCHOP-1)continue;
         rgb_plot3d[4*i+3]=transparent_level_local*(float)ii/(float)(NCHOP-1);
       }
-      for(i = 0; i<nrgb-2; i++){
+      for(i = 0; i<global_scase.nrgb-2; i++){
         int ii;
         float factor;
 
-        factor = 256.0/(float)(nrgb-2);
+        factor = 256.0/(float)(global_scase.nrgb-2);
 
         ii = factor*((float)i+0.5);
         if(ii>255)ii = 255;
         rgb_plot3d_contour[i] = rgb_plot3d + 4*ii;
       }
-      rgb_plot3d_contour[nrgb-2] = rgb_plot3d;
-      rgb_plot3d_contour[nrgb-1] = rgb_plot3d + 4*255;
+      rgb_plot3d_contour[global_scase.nrgb-2] = rgb_plot3d;
+      rgb_plot3d_contour[global_scase.nrgb-1] = rgb_plot3d + 4*255;
     }
     if(setp3chopmax_temp_local==1){
       ichopmax=nrgb_full*(p3chopmax_temp_local - glui_p3min_local)/(glui_p3max_local - glui_p3min_local);
@@ -1739,10 +1739,10 @@ void UpdateChopColors(void){
       }
     }
   }
-  for(i=0;i<npartinfo;i++){
+  for(i=0;i<global_scase.npartinfo;i++){
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     if(parti->loaded==0)continue;
     AdjustPart5Chops(); // only needs to be called once
     break;
@@ -1767,6 +1767,7 @@ void GetRGB(unsigned int val, unsigned char *rr, unsigned char *gg, unsigned cha
   b = b << nblueshift;
   *rr=r; *gg=g; *bb=b;
 }
+
 
 /* ------------------ GetColorPtr ------------------------ */
 
@@ -1828,18 +1829,17 @@ float *GetColorTranPtr(float *color, float transparency){
 
 void ConvertColor(int flag){
   colordata *colorptr;
-  extern colordata *firstcolor;
 
   switch(flag){
    case TO_BW:
-    for(colorptr=firstcolor;colorptr!=NULL;colorptr=colorptr->nextcolor){
+    for(colorptr=global_scase.firstcolor;colorptr!=NULL;colorptr=colorptr->nextcolor){
       colorptr->color[0]=colorptr->bw_color[0];
       colorptr->color[1]=colorptr->bw_color[1];
       colorptr->color[2]=colorptr->bw_color[2];
     }
     break;
    case TO_COLOR:
-    for(colorptr=firstcolor;colorptr!=NULL;colorptr=colorptr->nextcolor){
+    for(colorptr=global_scase.firstcolor;colorptr!=NULL;colorptr=colorptr->nextcolor){
       colorptr->color[0]=colorptr->full_color[0];
       colorptr->color[1]=colorptr->full_color[1];
       colorptr->color[2]=colorptr->full_color[2];

--- a/Source/smokeview/glui_bounds.cpp
+++ b/Source/smokeview/glui_bounds.cpp
@@ -7,6 +7,7 @@
 #include GLUT_H
 #include <math.h>
 
+#include "smokeviewdefs.h"
 #include "smokeviewvars.h"
 #include "IOscript.h"
 #include "dmalloc.h"
@@ -1062,10 +1063,10 @@ extern "C" void GLUISliceBoundsSetupNoGraphics(void){
 /* ------------------ SetResearchMode ------------------------ */
 
 void SetResearchMode(int flag){
-  if(npatchinfo>0)patchboundsCPP.set_research_mode(flag);
-  if(slicecoll.nsliceinfo>0)sliceboundsCPP.set_research_mode(flag);
-  if(npartinfo>0)partboundsCPP.set_research_mode(flag);
-  if(nplot3dinfo>0)plot3dboundsCPP.set_research_mode(flag);
+  if(global_scase.npatchinfo>0)patchboundsCPP.set_research_mode(flag);
+  if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.set_research_mode(flag);
+  if(global_scase.npartinfo>0)partboundsCPP.set_research_mode(flag);
+  if(global_scase.nplot3dinfo>0)plot3dboundsCPP.set_research_mode(flag);
   if(nhvacductbounds>0)hvacductboundsCPP.set_research_mode(flag);
   if(nhvacnodebounds > 0)hvacnodeboundsCPP.set_research_mode(flag);
 }
@@ -1073,19 +1074,19 @@ void SetResearchMode(int flag){
 /* ------------------ GLUISetColorbarDigitsCPP ------------------------ */
 
 extern "C" void GLUISetColorbarDigitsCPP(int ndigits){
-  if(npatchinfo>0)patchboundsCPP.set_colorbar_digits(ndigits);
-  if(slicecoll.nsliceinfo>0)sliceboundsCPP.set_colorbar_digits(ndigits);
-  if(npartinfo>0)partboundsCPP.set_colorbar_digits(ndigits);
-  if(nplot3dinfo>0)plot3dboundsCPP.set_colorbar_digits(ndigits);
+  if(global_scase.npatchinfo>0)patchboundsCPP.set_colorbar_digits(ndigits);
+  if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.set_colorbar_digits(ndigits);
+  if(global_scase.npartinfo>0)partboundsCPP.set_colorbar_digits(ndigits);
+  if(global_scase.nplot3dinfo>0)plot3dboundsCPP.set_colorbar_digits(ndigits);
 }
 
   /* ------------------ InResearchMode ------------------------ */
 
 int InResearchMode(void){
-  if(npatchinfo>0&&patchboundsCPP.in_research_mode()==0)return 0;
-  if(npartinfo>0&&partboundsCPP.in_research_mode()==0)return 0;
-  if(nplot3dinfo>0&&plot3dboundsCPP.in_research_mode()==0)return 0;
-  if(slicecoll.nsliceinfo>0&&sliceboundsCPP.in_research_mode()==0)return 0;
+  if(global_scase.npatchinfo>0&&patchboundsCPP.in_research_mode()==0)return 0;
+  if(global_scase.npartinfo>0&&partboundsCPP.in_research_mode()==0)return 0;
+  if(global_scase.nplot3dinfo>0&&plot3dboundsCPP.in_research_mode()==0)return 0;
+  if(global_scase.slicecoll.nsliceinfo>0&&sliceboundsCPP.in_research_mode()==0)return 0;
   if(nhvacductbounds>0&&hvacductboundsCPP.in_research_mode()==0)return 0;
   if(nhvacnodebounds > 0 && hvacnodeboundsCPP.in_research_mode() == 0)return 0;
   return 1;
@@ -1102,16 +1103,16 @@ extern "C" cpp_boundsdata *GLUIGetBoundsData(int type){
       if(nhvacnodebounds > 0)return hvacnodeboundsCPP.get_bounds_data();
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0)return patchboundsCPP.get_bounds_data();
+      if(global_scase.npatchinfo>0)return patchboundsCPP.get_bounds_data();
       break;
     case BOUND_PART:
-      if(npartinfo>0)return partboundsCPP.get_bounds_data();
+      if(global_scase.npartinfo>0)return partboundsCPP.get_bounds_data();
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0)return plot3dboundsCPP.get_bounds_data();
+      if(global_scase.nplot3dinfo>0)return plot3dboundsCPP.get_bounds_data();
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0)return sliceboundsCPP.get_bounds_data();
+      if(global_scase.slicecoll.nsliceinfo>0)return sliceboundsCPP.get_bounds_data();
       break;
     default:
       assert(FFALSE);
@@ -1131,16 +1132,16 @@ extern "C" void GLUIGetGlobalBoundsMinMax(int type, char *label, float *valmin, 
       if(nhvacnodebounds > 0)hvacnodeboundsCPP.get_global_minmax(label, valmin, valmax);
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0)patchboundsCPP.get_global_minmax(label, valmin, valmax);
+      if(global_scase.npatchinfo>0)patchboundsCPP.get_global_minmax(label, valmin, valmax);
       break;
     case BOUND_PART:
-      if(npartinfo>0)partboundsCPP.get_global_minmax(label, valmin, valmax);
+      if(global_scase.npartinfo>0)partboundsCPP.get_global_minmax(label, valmin, valmax);
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0)plot3dboundsCPP.get_global_minmax(label, valmin, valmax);
+      if(global_scase.nplot3dinfo>0)plot3dboundsCPP.get_global_minmax(label, valmin, valmax);
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0)sliceboundsCPP.get_global_minmax(label, valmin, valmax);
+      if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.get_global_minmax(label, valmin, valmax);
       break;
     default:
       assert(FFALSE);
@@ -1159,16 +1160,16 @@ extern "C" void GLUISetCacheFlag(int type, int cache_flag){
       if(nhvacnodebounds > 0)hvacnodeboundsCPP.set_cache_flag(cache_flag);
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0)patchboundsCPP.set_cache_flag(cache_flag);
+      if(global_scase.npatchinfo>0)patchboundsCPP.set_cache_flag(cache_flag);
       break;
     case BOUND_PART:
-      if(npartinfo>0)partboundsCPP.set_cache_flag(cache_flag);
+      if(global_scase.npartinfo>0)partboundsCPP.set_cache_flag(cache_flag);
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0)plot3dboundsCPP.set_cache_flag(cache_flag);
+      if(global_scase.nplot3dinfo>0)plot3dboundsCPP.set_cache_flag(cache_flag);
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0)sliceboundsCPP.set_cache_flag(cache_flag);
+      if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.set_cache_flag(cache_flag);
       break;
     default:
       assert(FFALSE);
@@ -1187,16 +1188,16 @@ int GetCacheFlag(int type){
       if(nhvacnodebounds > 0)return hvacnodeboundsCPP.get_cache_flag();
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0)return patchboundsCPP.get_cache_flag();
+      if(global_scase.npatchinfo>0)return patchboundsCPP.get_cache_flag();
       break;
     case BOUND_PART:
-      if(npartinfo>0)return partboundsCPP.get_cache_flag();
+      if(global_scase.npartinfo>0)return partboundsCPP.get_cache_flag();
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0)return plot3dboundsCPP.get_cache_flag();
+      if(global_scase.nplot3dinfo>0)return plot3dboundsCPP.get_cache_flag();
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0)return sliceboundsCPP.get_cache_flag();
+      if(global_scase.slicecoll.nsliceinfo>0)return sliceboundsCPP.get_cache_flag();
       break;
     default:
       assert(FFALSE);
@@ -1214,25 +1215,25 @@ extern "C" void GLUIUpdateBounds(void){
   if(nhvacnodebounds > 0){
     hvacnodeboundsCPP.CB(BOUND_VAL_TYPE);
   }
-  if(npatchinfo>0){
+  if(global_scase.npatchinfo>0){
     patchboundsCPP.CB(BOUND_VAL_TYPE);
     patchboundsCPP.CB(BOUND_SETCHOPMIN);
     patchboundsCPP.CB(BOUND_SETCHOPMAX);
   }
 
-  if(npartinfo>0){
+  if(global_scase.npartinfo>0){
     partboundsCPP.CB(BOUND_VAL_TYPE);
     partboundsCPP.CB(BOUND_SETCHOPMIN);
     partboundsCPP.CB(BOUND_SETCHOPMAX);
   }
 
-  if(nplot3dinfo>0){
+  if(global_scase.nplot3dinfo>0){
     plot3dboundsCPP.CB(BOUND_VAL_TYPE);
     plot3dboundsCPP.CB(BOUND_SETCHOPMIN);
     plot3dboundsCPP.CB(BOUND_SETCHOPMAX);
   }
 
-  if(slicecoll.nsliceinfo>0){
+  if(global_scase.slicecoll.nsliceinfo>0){
     sliceboundsCPP.CB(BOUND_VAL_TYPE);
     sliceboundsCPP.CB(BOUND_SETCHOPMIN);
     sliceboundsCPP.CB(BOUND_SETCHOPMAX);
@@ -1250,16 +1251,16 @@ int GetValType(int type){
       if(nhvacnodebounds > 0)return hvacnodeboundsCPP.get_valtype();
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0)return patchboundsCPP.get_valtype();
+      if(global_scase.npatchinfo>0)return patchboundsCPP.get_valtype();
       break;
     case BOUND_PART:
-      if(npartinfo>0)return partboundsCPP.get_valtype();
+      if(global_scase.npartinfo>0)return partboundsCPP.get_valtype();
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0)return plot3dboundsCPP.get_valtype();
+      if(global_scase.nplot3dinfo>0)return plot3dboundsCPP.get_valtype();
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0)return sliceboundsCPP.get_valtype();
+      if(global_scase.slicecoll.nsliceinfo>0)return sliceboundsCPP.get_valtype();
       break;
     default:
       assert(FFALSE);
@@ -1271,14 +1272,14 @@ int GetValType(int type){
 /* ------------------ GLUIGetChopHide ------------------------ */
 
 extern "C" int GLUIGetChopHide(char *label){
-  if(slicecoll.nsliceinfo>0)return sliceboundsCPP.get_chop_hide(label);
+  if(global_scase.slicecoll.nsliceinfo>0)return sliceboundsCPP.get_chop_hide(label);
   return 1;
 }
 
 /* ------------------ GLUISetChopHide ------------------------ */
 
 extern "C" void GLUISetChopHide(char *label, int val){
-  if(slicecoll.nsliceinfo>0)sliceboundsCPP.set_chop_hide(label, val);
+  if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.set_chop_hide(label, val);
 }
 
 /* ------------------ GLUIGetGetChopMin ------------------------ */
@@ -1292,16 +1293,16 @@ extern "C" int GLUIGetChopMin(int type, char *label, int *set_chopmin, float *ch
       if(nhvacnodebounds > 0)return hvacnodeboundsCPP.get_chopmin(label, set_chopmin, chopmin);
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0)return patchboundsCPP.get_chopmin(label, set_chopmin, chopmin);
+      if(global_scase.npatchinfo>0)return patchboundsCPP.get_chopmin(label, set_chopmin, chopmin);
       break;
     case BOUND_PART:
-      if(npartinfo>0)return partboundsCPP.get_chopmin(label, set_chopmin, chopmin);
+      if(global_scase.npartinfo>0)return partboundsCPP.get_chopmin(label, set_chopmin, chopmin);
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0)return plot3dboundsCPP.get_chopmin(label, set_chopmin, chopmin);
+      if(global_scase.nplot3dinfo>0)return plot3dboundsCPP.get_chopmin(label, set_chopmin, chopmin);
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0)return sliceboundsCPP.get_chopmin(label, set_chopmin, chopmin);
+      if(global_scase.slicecoll.nsliceinfo>0)return sliceboundsCPP.get_chopmin(label, set_chopmin, chopmin);
       break;
     default:
       assert(FFALSE);
@@ -1321,16 +1322,16 @@ extern "C" int GLUIGetChopMax(int type, char *label, int *set_chopmax, float *ch
       if(nhvacnodebounds > 0)return hvacnodeboundsCPP.get_chopmax(label, set_chopmax, chopmax);
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0)return patchboundsCPP.get_chopmax(label, set_chopmax, chopmax);
+      if(global_scase.npatchinfo>0)return patchboundsCPP.get_chopmax(label, set_chopmax, chopmax);
       break;
     case BOUND_PART:
-      if(npartinfo>0)return partboundsCPP.get_chopmax(label, set_chopmax, chopmax);
+      if(global_scase.npartinfo>0)return partboundsCPP.get_chopmax(label, set_chopmax, chopmax);
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0)return plot3dboundsCPP.get_chopmax(label, set_chopmax, chopmax);
+      if(global_scase.nplot3dinfo>0)return plot3dboundsCPP.get_chopmax(label, set_chopmax, chopmax);
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0)return sliceboundsCPP.get_chopmax(label, set_chopmax, chopmax);
+      if(global_scase.slicecoll.nsliceinfo>0)return sliceboundsCPP.get_chopmax(label, set_chopmax, chopmax);
       break;
     default:
       assert(FFALSE);
@@ -1350,16 +1351,16 @@ extern "C" int GLUISetChopMin(int type, char *label, int set_chopmin, float chop
     if(nhvacnodebounds > 0)return hvacnodeboundsCPP.set_chopmin(label, set_chopmin, chopmin);
     break;
   case BOUND_PATCH:
-    if(npatchinfo > 0)return patchboundsCPP.set_chopmin(label, set_chopmin, chopmin);
+    if(global_scase.npatchinfo > 0)return patchboundsCPP.set_chopmin(label, set_chopmin, chopmin);
     break;
   case BOUND_PART:
-    if(npartinfo > 0)return partboundsCPP.set_chopmin(label, set_chopmin, chopmin);
+    if(global_scase.npartinfo > 0)return partboundsCPP.set_chopmin(label, set_chopmin, chopmin);
     break;
   case BOUND_PLOT3D:
-    if(nplot3dinfo > 0)return plot3dboundsCPP.set_chopmin(label, set_chopmin, chopmin);
+    if(global_scase.nplot3dinfo > 0)return plot3dboundsCPP.set_chopmin(label, set_chopmin, chopmin);
     break;
   case BOUND_SLICE:
-    if(slicecoll.nsliceinfo > 0)return sliceboundsCPP.set_chopmin(label, set_chopmin, chopmin);
+    if(global_scase.slicecoll.nsliceinfo > 0)return sliceboundsCPP.set_chopmin(label, set_chopmin, chopmin);
     break;
   default:
     assert(FFALSE);
@@ -1379,16 +1380,16 @@ extern "C" int GLUISetChopMax(int type, char *label, int set_chopmax, float chop
     if(nhvacnodebounds > 0)return hvacnodeboundsCPP.set_chopmax(label, set_chopmax, chopmax);
     break;
   case BOUND_PATCH:
-    if(npatchinfo > 0)return patchboundsCPP.set_chopmax(label, set_chopmax, chopmax);
+    if(global_scase.npatchinfo > 0)return patchboundsCPP.set_chopmax(label, set_chopmax, chopmax);
     break;
   case BOUND_PART:
-    if(npartinfo > 0)return partboundsCPP.set_chopmax(label, set_chopmax, chopmax);
+    if(global_scase.npartinfo > 0)return partboundsCPP.set_chopmax(label, set_chopmax, chopmax);
     break;
   case BOUND_PLOT3D:
-    if(nplot3dinfo > 0)return plot3dboundsCPP.set_chopmax(label, set_chopmax, chopmax);
+    if(global_scase.nplot3dinfo > 0)return plot3dboundsCPP.set_chopmax(label, set_chopmax, chopmax);
     break;
   case BOUND_SLICE:
-    if(slicecoll.nsliceinfo > 0)return sliceboundsCPP.set_chopmax(label, set_chopmax, chopmax);
+    if(global_scase.slicecoll.nsliceinfo > 0)return sliceboundsCPP.set_chopmax(label, set_chopmax, chopmax);
     break;
   default:
     assert(FFALSE);
@@ -1408,16 +1409,16 @@ extern "C" int GLUIGetNValtypes(int type){
       if(nhvacnodebounds > 0)return hvacnodeboundsCPP.get_nvaltypes();
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0)return patchboundsCPP.get_nvaltypes();
+      if(global_scase.npatchinfo>0)return patchboundsCPP.get_nvaltypes();
       break;
     case BOUND_PART:
-      if(npartinfo>0)return partboundsCPP.get_nvaltypes();
+      if(global_scase.npartinfo>0)return partboundsCPP.get_nvaltypes();
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0)return plot3dboundsCPP.get_nvaltypes();
+      if(global_scase.nplot3dinfo>0)return plot3dboundsCPP.get_nvaltypes();
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0)return sliceboundsCPP.get_nvaltypes();
+      if(global_scase.slicecoll.nsliceinfo>0)return sliceboundsCPP.get_nvaltypes();
       break;
     default:
       assert(FFALSE);
@@ -1437,16 +1438,16 @@ extern "C" void GLUISetValTypeIndex(int type, int valtype_index){
       if(nhvacnodebounds > 0)hvacnodeboundsCPP.set_valtype_index(valtype_index);
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0)patchboundsCPP.set_valtype_index(valtype_index);
+      if(global_scase.npatchinfo>0)patchboundsCPP.set_valtype_index(valtype_index);
       break;
     case BOUND_PART:
-      if(npartinfo>0)partboundsCPP.set_valtype_index(valtype_index);
+      if(global_scase.npartinfo>0)partboundsCPP.set_valtype_index(valtype_index);
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0)plot3dboundsCPP.set_valtype_index(valtype_index);
+      if(global_scase.nplot3dinfo>0)plot3dboundsCPP.set_valtype_index(valtype_index);
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0)sliceboundsCPP.set_valtype_index(valtype_index);
+      if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.set_valtype_index(valtype_index);
       break;
     default:
       assert(FFALSE);
@@ -1471,25 +1472,25 @@ extern "C" void GLUIGetOnlyMinMax(int type, char *label, int *set_valmin, float 
       }
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0){
+      if(global_scase.npatchinfo>0){
         patchboundsCPP.get_min(label, set_valmin, valmin);
         patchboundsCPP.get_max(label, set_valmax, valmax);
       }
       break;
     case BOUND_PART:
-      if(npartinfo>0){
+      if(global_scase.npartinfo>0){
         partboundsCPP.get_min(label, set_valmin, valmin);
         partboundsCPP.get_max(label, set_valmax, valmax);
       }
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0){
+      if(global_scase.nplot3dinfo>0){
         plot3dboundsCPP.get_min(label, set_valmin, valmin);
         plot3dboundsCPP.get_max(label, set_valmax, valmax);
       }
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0){
+      if(global_scase.slicecoll.nsliceinfo>0){
         sliceboundsCPP.get_min(label, set_valmin, valmin);
         sliceboundsCPP.get_max(label, set_valmax, valmax);
       }
@@ -1519,28 +1520,28 @@ extern "C" void GLUIGetMinMax(int type, char *label, int *set_valmin, float *val
       }
       break;
     case BOUND_PATCH:
-      if(npatchinfo>0){
+      if(global_scase.npatchinfo>0){
         patchboundsCPP.set_valtype(label);
         patchboundsCPP.get_min(label, set_valmin, valmin);
         patchboundsCPP.get_max(label, set_valmax, valmax);
       }
       break;
     case BOUND_PART:
-      if(npartinfo>0){
+      if(global_scase.npartinfo>0){
         partboundsCPP.set_valtype(label);
         partboundsCPP.get_min(label, set_valmin, valmin);
         partboundsCPP.get_max(label, set_valmax, valmax);
       }
       break;
     case BOUND_PLOT3D:
-      if(nplot3dinfo>0){
+      if(global_scase.nplot3dinfo>0){
         plot3dboundsCPP.set_valtype(label);
         plot3dboundsCPP.get_min(label, set_valmin, valmin);
         plot3dboundsCPP.get_max(label, set_valmax, valmax);
       }
       break;
     case BOUND_SLICE:
-      if(slicecoll.nsliceinfo>0){
+      if(global_scase.slicecoll.nsliceinfo>0){
         sliceboundsCPP.set_valtype(label);
         sliceboundsCPP.get_min(label, set_valmin, valmin);
         sliceboundsCPP.get_max(label, set_valmax, valmax);
@@ -1832,10 +1833,10 @@ extern "C" void GLUIHVACDuctBoundsCPP_CB(int var){
     ReadHVACData(LOAD);
     break;
   case BOUND_RESEARCH_MODE:
-    if(npartinfo > 0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
-    if(npatchinfo > 0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
-    if(nplot3dinfo > 0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
-    if(slicecoll.nsliceinfo > 0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
+    if(global_scase.npartinfo > 0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
+    if(global_scase.npatchinfo > 0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
+    if(global_scase.nplot3dinfo > 0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
+    if(global_scase.slicecoll.nsliceinfo > 0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
     GLUIHVACDuctBoundsCPP_CB(BOUND_UPDATE_COLORS);
     break;
   case BOUND_VALMAX:
@@ -1864,10 +1865,10 @@ extern "C" void GLUIHVACNodeBoundsCPP_CB(int var){
     ReadHVACData(LOAD);
     break;
   case BOUND_RESEARCH_MODE:
-    if(npartinfo > 0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
-    if(npatchinfo > 0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
-    if(nplot3dinfo > 0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
-    if(slicecoll.nsliceinfo > 0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
+    if(global_scase.npartinfo > 0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
+    if(global_scase.npatchinfo > 0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
+    if(global_scase.nplot3dinfo > 0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
+    if(global_scase.slicecoll.nsliceinfo > 0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
     GLUIHVACNodeBoundsCPP_CB(BOUND_UPDATE_COLORS);
     break;
   case BOUND_VALMAX:
@@ -1934,7 +1935,7 @@ extern "C" void GLUIHVACSliceBoundsCPP_CB(int var){
         slicedata *sd;
 
         i = slice_loaded_list[ii];
-        sd = slicecoll.sliceinfo + i;
+        sd = global_scase.slicecoll.sliceinfo + i;
         if(sd->vloaded==0&&sd->display==0)continue;
         if(sd->slicefile_labelindex == slicefile_labelindex){
           last_slice = i;
@@ -1955,9 +1956,9 @@ extern "C" void GLUIHVACSliceBoundsCPP_CB(int var){
       GLUIHVACSliceBoundsCPP_CB(BOUND_UPDATE_COLORS);
       break;
     case BOUND_RESEARCH_MODE:
-      if(npartinfo>0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
-      if(npatchinfo>0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
-      if(nplot3dinfo>0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.npartinfo>0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.npatchinfo>0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.nplot3dinfo>0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
       if(nhvacductbounds>0)hvacductboundsCPP.CB(BOUND_RESEARCH_MODE);
       if(nhvacnodebounds > 0)hvacnodeboundsCPP.CB(BOUND_RESEARCH_MODE);
       break;
@@ -1977,10 +1978,10 @@ extern "C" void GLUIHVACSliceBoundsCPP_CB(int var){
       hist_update = 0;
       slice_loaded = 0;
       bounds = GLUIGetBoundsData(BOUND_SLICE);
-      for(i = 0;i < slicecoll.nsliceinfo;i++){
+      for(i = 0;i < global_scase.slicecoll.nsliceinfo;i++){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         if(slicei->loaded == 0)continue;
         slice_loaded = 1;
         if(slicei->hist_update == 1)hist_update = 1;
@@ -2017,14 +2018,14 @@ extern "C" void GLUIHVACSliceBoundsCPP_CB(int var){
 int HavePlot3DData(void){
   int i;
 
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     meshdata *meshi;
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->loaded==0)continue;
     if(plot3di->blocknumber<0)return 0;
-    meshi = meshinfo+plot3di->blocknumber;
+    meshi = global_scase.meshescoll.meshinfo+plot3di->blocknumber;
     if(meshi->qdata==NULL)return 0;
   }
   return 1;
@@ -2076,9 +2077,9 @@ extern "C" void GLUIPlot3DBoundsCPP_CB(int var){
       LoadPlot3dMenu(RELOAD_ALL);
       break;
     case BOUND_RESEARCH_MODE:
-      if(npartinfo>0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
-      if(npatchinfo>0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
-      if(slicecoll.nsliceinfo>0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.npartinfo>0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.npatchinfo>0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
       if(nhvacductbounds>0)hvacductboundsCPP.CB(BOUND_RESEARCH_MODE);
       if(nhvacnodebounds > 0)hvacnodeboundsCPP.CB(BOUND_RESEARCH_MODE);
       break;
@@ -2098,20 +2099,20 @@ extern "C" void GLUIPlot3DBoundsCPP_CB(int var){
       hist_update = 0;
       plot3d_loaded = 0;
       bounds = GLUIGetBoundsData(BOUND_PLOT3D);
-      for(i = 0;i < nplot3dinfo;i++){
+      for(i = 0;i < global_scase.nplot3dinfo;i++){
         plot3ddata *plot3di;
 
-        plot3di = plot3dinfo + i;
+        plot3di = global_scase.plot3dinfo + i;
         if(plot3di->loaded == 0)continue;
         plot3d_loaded = 1;
         if(plot3di->hist_update == 1)hist_update = 1;
         plot3di->hist_update = 0;
       }
       if(hist_update == 1){
-        for(i = 0;i < nplot3dinfo;i++){
+        for(i = 0;i < global_scase.nplot3dinfo;i++){
           plot3ddata *plot3di;
 
-          plot3di = plot3dinfo + i;
+          plot3di = global_scase.plot3dinfo + i;
           if(plot3di->loaded == 0)continue;
           GetPlot3DHists(plot3di);
         }
@@ -2180,14 +2181,14 @@ extern "C" void GLUIPartBoundsCPP_CB(int var){
       UpdatePartColors(NULL, 1);
       break;
     case BOUND_RELOAD_DATA:
-      if(npartinfo>0){
+      if(global_scase.npartinfo>0){
         LoadParticleMenu(PARTFILE_RELOADALL);
       }
       break;
     case BOUND_RESEARCH_MODE:
-      if(npatchinfo>0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
-      if(nplot3dinfo>0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
-      if(slicecoll.nsliceinfo>0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.npatchinfo>0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.nplot3dinfo>0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
       if(nhvacductbounds>0)hvacductboundsCPP.CB(BOUND_RESEARCH_MODE);
       if(nhvacnodebounds > 0)hvacnodeboundsCPP.CB(BOUND_RESEARCH_MODE);
       UpdatePartColors(NULL, 0);
@@ -2208,10 +2209,10 @@ extern "C" void GLUIPartBoundsCPP_CB(int var){
       hist_update = 0;
       part_loaded = 0;
       bounds = GLUIGetBoundsData(BOUND_PART);
-      for(i = 0;i < npartinfo;i++){
+      for(i = 0;i < global_scase.npartinfo;i++){
         partdata *parti;
 
-        parti = partinfo + i;
+        parti = global_scase.partinfo + i;
         if(parti->loaded == 0)continue;
         part_loaded = 1;
         if(parti->hist_update == 1)hist_update = 1;
@@ -2249,16 +2250,16 @@ extern "C" void GLUIPartBoundsCPP_CB(int var){
 int HavePatchData(void){
   int i;
 
-  for(i = 0; i<npatchinfo; i++){
+  for(i = 0; i<global_scase.npatchinfo; i++){
     patchdata *patchi;
     meshdata *meshi;
 
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==0)continue;
     switch(patchi->patch_filetype){
       case PATCH_STRUCTURED_NODE_CENTER:
       case PATCH_STRUCTURED_CELL_CENTER:
-        meshi = meshinfo+patchi->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo+patchi->blocknumber;
         if(meshi->patchval==NULL||meshi->cpatchval==NULL)return 0;
         break;
       case PATCH_GEOMETRY_BOUNDARY:
@@ -2295,7 +2296,7 @@ extern "C" void GLUIPatchBoundsCPP_CB(int var){
     case BOUND_CHOPMAX:
     case BOUND_CHOP_HIDE:
       updatefacelists = 1;
-      updatefaces = 1;
+      global_scase.updatefaces = 1;
       if(bounds->set_chopmax == 1 || bounds->set_chopmin == 1){
         update_bound_chop_data = 1;
         hide_internal_blockages = 0;
@@ -2334,33 +2335,33 @@ extern "C" void GLUIPatchBoundsCPP_CB(int var){
       break;
     case BOUND_RELOAD_DATA:
       SetLoadedPatchBounds(NULL, 0);
-      for(i = 0; i<npatchinfo; i++){
+      for(i = 0; i<global_scase.npatchinfo; i++){
         patchdata *patchi;
 
-        patchi = patchinfo+i;
+        patchi = global_scase.patchinfo+i;
         patchi->finalize = 0;
       }
-      for(i = npatchinfo-1; i>=0;  i--){
+      for(i = global_scase.npatchinfo-1; i>=0;  i--){
         patchdata *patchi;
 
-        patchi = patchinfo+i;
+        patchi = global_scase.patchinfo+i;
         if(patchi->loaded==0)continue;
         patchi->finalize = 1;
         break;
       }
-      for(i = 0; i<npatchinfo; i++){
+      for(i = 0; i<global_scase.npatchinfo; i++){
         patchdata *patchi;
         int errorcode;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->loaded == 0)continue;
         ReadBoundary(i,LOAD,&errorcode);
       }
       break;
     case BOUND_RESEARCH_MODE:
-      if(npartinfo>0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
-      if(nplot3dinfo>0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
-      if(slicecoll.nsliceinfo>0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.npartinfo>0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.nplot3dinfo>0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
+      if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
       if(nhvacductbounds>0)hvacductboundsCPP.CB(BOUND_RESEARCH_MODE);
       if(nhvacnodebounds > 0)hvacnodeboundsCPP.CB(BOUND_RESEARCH_MODE);
       break;
@@ -2380,10 +2381,10 @@ extern "C" void GLUIPatchBoundsCPP_CB(int var){
       hist_update = 0;
       bound_loaded = 0;
       bounds = GLUIGetBoundsData(BOUND_PATCH);
-      for(i = 0;i < npatchinfo;i++){
+      for(i = 0;i < global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->loaded == 0)continue;
         bound_loaded = 1;
         if(patchi->hist_update == 1)hist_update = 1;
@@ -2417,10 +2418,10 @@ extern "C" void GLUIPatchBoundsCPP_CB(int var){
 /* ------------------ GLUIUpdatdateResearchModeCPP ------------------------ */
 
 extern "C" void GLUIUpdatdateResearchModeCPP(void){
-  if(npatchinfo>0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
-  if(npartinfo>0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
-  if(nplot3dinfo>0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
-  if(slicecoll.nsliceinfo>0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
+  if(global_scase.npatchinfo>0)patchboundsCPP.CB(BOUND_RESEARCH_MODE);
+  if(global_scase.npartinfo>0)partboundsCPP.CB(BOUND_RESEARCH_MODE);
+  if(global_scase.nplot3dinfo>0)plot3dboundsCPP.CB(BOUND_RESEARCH_MODE);
+  if(global_scase.slicecoll.nsliceinfo>0)sliceboundsCPP.CB(BOUND_RESEARCH_MODE);
 }
 
 /* ------------------ SetLoadedSliceBounds ------------------------ */
@@ -2433,10 +2434,10 @@ void SetLoadedSliceBounds(int *list, int nlist){
   int i;
 
   if(list==NULL){
-    for(i = 0; i<slicecoll.nsliceinfo; i++){
+    for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo+i;
+      slicei = global_scase.slicecoll.sliceinfo+i;
       if(slicei->loaded==1&&slicei->display==1){
         label = slicei->label.shortlabel;
         break;
@@ -2446,7 +2447,7 @@ void SetLoadedSliceBounds(int *list, int nlist){
   else{
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+list[0];
+    slicei = global_scase.slicecoll.sliceinfo+list[0];
     label = slicei->label.shortlabel;
   }
   if(label==NULL)return;
@@ -2457,7 +2458,7 @@ void SetLoadedSliceBounds(int *list, int nlist){
   for(i = 0; i<nlist; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+list[i];
+    slicei = global_scase.slicecoll.sliceinfo+list[i];
     if(valmin>valmax){
       valmin = slicei->valmin_slice;
       valmax = slicei->valmax_slice;
@@ -2467,10 +2468,10 @@ void SetLoadedSliceBounds(int *list, int nlist){
       valmax = MAX(valmax, slicei->valmax_slice);
     }
   }
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     if(slicei->loaded==0)continue;
     if(strcmp(slicei->label.shortlabel, label)!=0)continue;
     if(valmin>valmax){
@@ -2505,8 +2506,8 @@ void SetLoadedPatchBounds(int *list, int nlist){
   int i;
 
   if(list==NULL){
-    for(i = 0; i<npatchinfo; i++){
-      patchi = patchinfo+i;
+    for(i = 0; i<global_scase.npatchinfo; i++){
+      patchi = global_scase.patchinfo+i;
       if(patchi->loaded==1&&patchi->display==1){
         label = patchi->label.shortlabel;
         break;
@@ -2514,7 +2515,7 @@ void SetLoadedPatchBounds(int *list, int nlist){
     }
   }
   else{
-    patchi = patchinfo+list[0];
+    patchi = global_scase.patchinfo+list[0];
     label = patchi->label.shortlabel;
   }
   if(label==NULL)return;
@@ -2523,7 +2524,7 @@ void SetLoadedPatchBounds(int *list, int nlist){
   valmax = 0.0;
   if(list==NULL)nlist = 0;
   for(i = 0; i<nlist; i++){
-    patchi = patchinfo+list[i];
+    patchi = global_scase.patchinfo+list[i];
     if(valmin>valmax){
       valmin = patchi->valmin_patch;
       valmax = patchi->valmax_patch;
@@ -2533,8 +2534,8 @@ void SetLoadedPatchBounds(int *list, int nlist){
       valmax = MAX(valmax, patchi->valmax_patch);
     }
   }
-  for(i = 0; i<npatchinfo; i++){
-    patchi = patchinfo+i;
+  for(i = 0; i<global_scase.npatchinfo; i++){
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==0)continue;
     if(strcmp(patchi->label.shortlabel, label)!=0)continue;
     if(valmin>valmax){
@@ -2575,11 +2576,11 @@ void SetLoadedPlot3DBounds(void){
   for(j = 0; j<MAXPLOT3DVARS; j++){
     valmin[j] = 1.0;
     valmax[j] = 0.0;
-    for(i = 0; i <nplot3dinfo; i++){
+    for(i = 0; i <global_scase.nplot3dinfo; i++){
       float *valmin_fds, *valmax_fds;
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo+i;
+      plot3di = global_scase.plot3dinfo+i;
       if(plot3di->loadnow == 0)continue;
       valmin_fds = plot3di->valmin_plot3d;
       valmax_fds = plot3di->valmax_plot3d;
@@ -2593,11 +2594,11 @@ void SetLoadedPlot3DBounds(void){
       }
     }
 
-    for(i = 0; i<nplot3dinfo; i++){
+    for(i = 0; i<global_scase.nplot3dinfo; i++){
       float *valmin_fds, *valmax_fds;
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo+i;
+      plot3di = global_scase.plot3dinfo+i;
       if(plot3di->loaded==0)continue;
       valmin_fds = plot3di->valmin_plot3d;
       valmax_fds = plot3di->valmax_plot3d;
@@ -2663,7 +2664,7 @@ void SetLoadedPartBounds(int *list, int nlist){
       float *valmin_part, *valmax_part;
       partdata *parti;
 
-      parti = partinfo+list[i];
+      parti = global_scase.partinfo+list[i];
       if(parti->have_bound_file==NO)continue;
       valmin_part = parti->valmin_part;
       valmax_part = parti->valmax_part;
@@ -2677,11 +2678,11 @@ void SetLoadedPartBounds(int *list, int nlist){
       }
     }
 
-    for(i = 0; i<npartinfo; i++){
+    for(i = 0; i<global_scase.npartinfo; i++){
       float *valmin_part, *valmax_part;
       partdata *parti;
 
-      parti = partinfo+i;
+      parti = global_scase.partinfo+i;
       if(parti->loaded==0||parti->have_bound_file==NO)continue;
       valmin_part = parti->valmin_part;
       valmax_part = parti->valmax_part;
@@ -3478,16 +3479,16 @@ void UpdateIsoControls(void){
 /* ------------------ GLUISliceInObstMenu2Dialog ------------------------ */
 
 extern "C" void GLUISliceInObstMenu2Dialog(int var){
-  show_slice_in_obst = var;
-  if(show_slice_in_obst==GAS_AND_SOLID){
+  global_scase.show_slice_in_obst = var;
+  if(global_scase.show_slice_in_obst==GAS_AND_SOLID){
     show_slice_in_gas   = 1;
     show_slice_in_solid = 1;
   }
-  else if(show_slice_in_obst==ONLY_IN_GAS){
+  else if(global_scase.show_slice_in_obst==ONLY_IN_GAS){
     show_slice_in_gas   = 1;
     show_slice_in_solid = 0;
   }
-  else if(show_slice_in_obst==ONLY_IN_SOLID){
+  else if(global_scase.show_slice_in_obst==ONLY_IN_SOLID){
     show_slice_in_gas   = 0;
     show_slice_in_solid = 1;
   }
@@ -3504,16 +3505,16 @@ extern "C" void GLUISliceInObstMenu2Dialog(int var){
 
 void SliceInObstDialog2Menu(void){
   if(show_slice_shaded[IN_GAS_GLUI] == 1 && show_slice_shaded[IN_SOLID_GLUI] == 1){
-    show_slice_in_obst = GAS_AND_SOLID;
+    global_scase.show_slice_in_obst = GAS_AND_SOLID;
   }
   else if(show_slice_shaded[IN_GAS_GLUI] == 1 && show_slice_shaded[IN_SOLID_GLUI] == 0){
-    show_slice_in_obst = ONLY_IN_GAS;
+    global_scase.show_slice_in_obst = ONLY_IN_GAS;
   }
   else if(show_slice_shaded[IN_GAS_GLUI] == 0 && show_slice_shaded[IN_SOLID_GLUI] == 1){
-    show_slice_in_obst = ONLY_IN_SOLID;
+    global_scase.show_slice_in_obst = ONLY_IN_SOLID;
   }
   else{
-    show_slice_in_obst = NEITHER_GAS_NOR_SOLID;
+    global_scase.show_slice_in_obst = NEITHER_GAS_NOR_SOLID;
   }
   updatemenu = 1;
 }
@@ -3564,7 +3565,7 @@ void LoadRolloutCB(int var){
 
 void BoundRolloutCB(int var){
   GLUIToggleRollout(boundprocinfo, nboundprocinfo, var);
-  if(nzoneinfo>0){
+  if(global_scase.nzoneinfo>0){
     if(var==ZONE_ROLLOUT){
       GLUISliceBoundCB(SETZONEVALMINMAX);
     }
@@ -3999,7 +4000,7 @@ extern "C" void BoundBoundCB(int var){
     break;
 #endif
   case SHOW_BOUNDARY_OUTLINE:
-    if(ngeom_data==0)break;
+    if(global_scase.ngeom_data==0)break;
     if(show_boundary_outline==1&&boundary_edgetype==OUTLINE_HIDDEN)boundary_edgetype = OUTLINE_POLYGON;
     if(show_boundary_outline==0&&boundary_edgetype!=OUTLINE_HIDDEN)boundary_edgetype = OUTLINE_HIDDEN;
     if(boundary_edgetype!=RADIO_boundary_edgetype->get_int_val())RADIO_boundary_edgetype->set_int_val(boundary_edgetype);
@@ -4084,11 +4085,11 @@ extern "C" void BoundBoundCB(int var){
         BoundBoundCB(HIDE_ALL_EXTERIOR_PATCH_DATA);
       }
       else{
-        for(i = 0;i < npatchinfo;i++){
+        for(i = 0;i < global_scase.npatchinfo;i++){
           patchdata *patchi;
           int n;
 
-          patchi = patchinfo + i;
+          patchi = global_scase.patchinfo + i;
           if(patchi->loaded == 0)continue;
           for(n = 0;n < patchi->npatches;n++){
             patchfacedata *pfi;
@@ -4200,12 +4201,12 @@ extern "C" void BoundBoundCB(int var){
     UpdateAllBoundaryColors(1);
     break;
   case FILE_RELOAD:
-    if(npatchinfo>0){
+    if(global_scase.npatchinfo>0){
 //      BoundBoundCB(FILE_UPDATE);
-      for(i = 0;i < npatchinfo;i++){
+      for(i = 0;i < global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->loaded == 0)continue;
         LoadBoundaryMenu(i);
       }
@@ -4288,13 +4289,13 @@ void CheckBounds(int var){
 void UpdateBoundaryFiles(void){
   int i;
 
-  for(i = 0;i < npatchinfo;i++){
+  for(i = 0;i < global_scase.npatchinfo;i++){
     patchdata *patchi;
     meshdata *meshi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->loaded == 0 || patchi->blocknumber < 0)continue;
-    meshi = meshinfo + patchi->blocknumber;
+    meshi = global_scase.meshescoll.meshinfo + patchi->blocknumber;
     if(meshi->use == 1 && patchi->display == 0){
       patchi->display = 1;
       updatefacelists = 1;
@@ -4329,10 +4330,10 @@ void MeshBoundCB(int var){
     MeshBoundCB(USEMESH_XYZ);
     break;
   case USEMESH_REMOVE_ALL:
-    for(i = 0; i < nmeshes; i++){
+    for(i = 0; i < global_scase.meshescoll.nmeshes; i++){
       meshdata *meshi;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       meshi->use = 0;
     }
     break;
@@ -4340,7 +4341,7 @@ void MeshBoundCB(int var){
     {
       meshdata *meshi;
 
-      meshi = meshinfo + set_mesh - 1;
+      meshi = global_scase.meshescoll.meshinfo + set_mesh - 1;
       meshclip[0] = meshi->boxmin[0];
       meshclip[2] = meshi->boxmin[1];
       meshclip[4] = meshi->boxmin[2];
@@ -4360,7 +4361,7 @@ void MeshBoundCB(int var){
   {
     meshdata *meshi;
 
-    meshi = meshinfo + set_mesh - 1;
+    meshi = global_scase.meshescoll.meshinfo + set_mesh - 1;
     meshi->use = 0;
   }
   break;
@@ -4373,18 +4374,18 @@ void MeshBoundCB(int var){
     break;
   case USEMESH_XYZ:
     updatemenu = 1;
-    for(i = 0;i < nmeshes;i++){
+    for(i = 0;i < global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       meshi->use = 1;
     }
     if(use_meshclip[0] == 0 && use_meshclip[1] == 0 && use_meshclip[2] == 0 &&
        use_meshclip[3] == 0 && use_meshclip[4] == 0 && use_meshclip[5] == 0)break;
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       float meshclip_min[3],  meshclip_max[3];
       int use_meshclip_min[3], use_meshclip_max[3];
       meshclip_min[0] = meshclip[0];
@@ -4553,10 +4554,10 @@ void TimeBoundCB(int var){
   case SET_FDS_TIMES:
     use_tload_begin = 1;
     use_tload_end   = 1;
-    tload_begin     = global_tbegin;
-    tload_end       = global_tend;
-    SPINNER_tload_begin->set_float_val(tload_begin);
-    SPINNER_tload_end->set_float_val(tload_end);
+    global_scase.tload_begin     = global_scase.global_tbegin;
+    global_scase.tload_end       = global_scase.global_tend;
+    SPINNER_tload_begin->set_float_val(global_scase.tload_begin);
+    SPINNER_tload_end->set_float_val(global_scase.tload_end);
     CHECKBOX_use_tload_begin->set_int_val(use_tload_begin);
     CHECKBOX_use_tload_end->set_int_val(use_tload_end);
     TimeBoundCB(TBOUNDS);
@@ -4648,7 +4649,7 @@ void ScriptCB(int var){
     suffix = TrimFront(script_renderfilesuffix);
     strcpy(script_renderfile, "");
     if(strlen(suffix) > 0){
-      strcpy(script_renderfile, fdsprefix);
+      strcpy(script_renderfile, global_scase.fdsprefix);
       strcat(script_renderfile, "_");
       strcat(script_renderfile, suffix);
       strcpy(label, _("Render: "));
@@ -4701,7 +4702,7 @@ void ScriptCB(int var){
     id = LIST_ini_list->get_int_val();
     ini_filename = GetIniFileName(id);
     if(ini_filename == NULL)break;
-    if(strcmp(ini_filename, caseini_filename) == 0){
+    if(strcmp(ini_filename, global_scase.paths.caseini_filename) == 0){
       ReadIni(NULL);
     }
     else if(id >= 0){
@@ -4725,7 +4726,7 @@ void ScriptCB(int var){
     break;
   case SCRIPT_EDIT_INI:
     strcpy(label, _("Save "));
-    strcat(label, fdsprefix);
+    strcat(label, global_scase.fdsprefix);
     TrimBack(script_inifile_suffix);
     if(strlen(script_inifile_suffix) > 0){
       strcat(label, "_");
@@ -4747,12 +4748,12 @@ void ScriptCB(int var){
 extern "C" void GLUIUpdateBoundTbounds(void){
   use_tload_end   = use_tload_end2;
   use_tload_begin = use_tload_begin2;
-  tload_end       = tload_end2;
-  tload_begin     = tload_begin2;
+  global_scase.tload_end       = tload_end2;
+  global_scase.tload_begin     = tload_begin2;
   if(CHECKBOX_use_tload_begin!=NULL)CHECKBOX_use_tload_begin->set_int_val(use_tload_begin);
   if(CHECKBOX_use_tload_end!=NULL)CHECKBOX_use_tload_end->set_int_val(use_tload_end);
-  if(SPINNER_tload_end!=NULL)SPINNER_tload_end->set_float_val(tload_end);
-  if(SPINNER_tload_begin!=NULL)SPINNER_tload_begin->set_float_val(tload_begin);
+  if(SPINNER_tload_end!=NULL)SPINNER_tload_end->set_float_val(global_scase.tload_end);
+  if(SPINNER_tload_begin!=NULL)SPINNER_tload_begin->set_float_val(global_scase.tload_begin);
 }
 
 /* ------------------ GLUIUpdateSliceXYZ ------------------------ */
@@ -4873,7 +4874,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
   // -------------- Show/Hide Loaded files -------------------
 
-  if(npartinfo > 0 || slicecoll.nsliceinfo > 0 || slicecoll.nvsliceinfo > 0 || nisoinfo > 0 || npatchinfo || smoke3dcoll.nsmoke3dinfo > 0 || nplot3dinfo > 0){
+  if(global_scase.npartinfo > 0 || global_scase.slicecoll.nsliceinfo > 0 || global_scase.slicecoll.nvsliceinfo > 0 || global_scase.nisoinfo > 0 || global_scase.npatchinfo || global_scase.smoke3dcoll.nsmoke3dinfo > 0 || global_scase.nplot3dinfo > 0){
     ROLLOUT_showhide = glui_bounds->add_rollout_to_panel(ROLLOUT_files,_("Show/Hide"), false, SHOWHIDE_ROLLOUT, FileRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_showhide, glui_bounds);
     ADDPROCINFO(fileprocinfo, nfileprocinfo, ROLLOUT_showhide, SHOWHIDE_ROLLOUT, glui_bounds);
@@ -4885,13 +4886,13 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
     glui_bounds->add_column_to_panel(ROLLOUT_showhide, false);
 
-    if(npartinfo > 0)BUTTON_PART = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Particle", FILESHOW_particle, FileShowCB);
-    if(slicecoll.nsliceinfo > 0)BUTTON_SLICE = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Slice", FILESHOW_slice, FileShowCB);
-    if(slicecoll.nvsliceinfo > 0)BUTTON_VSLICE = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Vector", FILESHOW_vslice, FileShowCB);
-    if(nisoinfo > 0)BUTTON_ISO = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Isosurface", FILESHOW_isosurface, FileShowCB);
-    if(npatchinfo > 0)BUTTON_BOUNDARY = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Boundary", FILESHOW_boundary, FileShowCB);
-    if(smoke3dcoll.nsmoke3dinfo > 0)BUTTON_3DSMOKE = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "3D smoke/fire", FILESHOW_3dsmoke, FileShowCB);
-    if(nplot3dinfo > 0)BUTTON_PLOT3D = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Plot3D", FILESHOW_plot3d, FileShowCB);
+    if(global_scase.npartinfo > 0)BUTTON_PART = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Particle", FILESHOW_particle, FileShowCB);
+    if(global_scase.slicecoll.nsliceinfo > 0)BUTTON_SLICE = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Slice", FILESHOW_slice, FileShowCB);
+    if(global_scase.slicecoll.nvsliceinfo > 0)BUTTON_VSLICE = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Vector", FILESHOW_vslice, FileShowCB);
+    if(global_scase.nisoinfo > 0)BUTTON_ISO = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Isosurface", FILESHOW_isosurface, FileShowCB);
+    if(global_scase.npatchinfo > 0)BUTTON_BOUNDARY = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Boundary", FILESHOW_boundary, FileShowCB);
+    if(global_scase.smoke3dcoll.nsmoke3dinfo > 0)BUTTON_3DSMOKE = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "3D smoke/fire", FILESHOW_3dsmoke, FileShowCB);
+    if(global_scase.nplot3dinfo > 0)BUTTON_PLOT3D = glui_bounds->add_button_to_panel(ROLLOUT_showhide, "Plot3D", FILESHOW_plot3d, FileShowCB);
     glui_bounds->add_button_to_panel(ROLLOUT_showhide, "File Sizes", FILESHOW_sizes, FileShowCB);
 
 
@@ -4900,7 +4901,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
 
 #ifdef pp_COMPRESS
-  if(smokezippath != NULL && (npatchinfo > 0 || smoke3dcoll.nsmoke3dinfo > 0 || slicecoll.nsliceinfo > 0)){
+  if(smokezippath != NULL && (global_scase.npatchinfo > 0 || global_scase.smoke3dcoll.nsmoke3dinfo > 0 || global_scase.slicecoll.nsliceinfo > 0)){
     ROLLOUT_compress = glui_bounds->add_rollout_to_panel(ROLLOUT_files,_("Compress"), false, COMPRESS_ROLLOUT, FileRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_compress, glui_bounds);
     ADDPROCINFO(fileprocinfo, nfileprocinfo, ROLLOUT_compress, COMPRESS_ROLLOUT, glui_bounds);
@@ -5007,7 +5008,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
   /*  zone (cfast) */
 
-  if(nzoneinfo>0){
+  if(global_scase.nzoneinfo>0){
     ROLLOUT_zone_bound = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds,_("Zone/slice temperatures"),false,ZONE_ROLLOUT,BoundRolloutCB);
     ADDPROCINFO(boundprocinfo, nboundprocinfo, ROLLOUT_zone_bound, ZONE_ROLLOUT, glui_bounds);
 
@@ -5038,7 +5039,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
   // ----------------------------------- 3D smoke ----------------------------------------
 
-  if(smoke3dcoll.nsmoke3dinfo>0||nvolrenderinfo>0){
+  if(global_scase.smoke3dcoll.nsmoke3dinfo>0||nvolrenderinfo>0){
     ROLLOUT_smoke3d = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds,_("3D smoke"),false,SMOKE3D_ROLLOUT,BoundRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_smoke3d, glui_bounds);
     ADDPROCINFO(boundprocinfo, nboundprocinfo, ROLLOUT_smoke3d, SMOKE3D_ROLLOUT, glui_bounds);
@@ -5046,7 +5047,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
   // ----------------------------------- Boundary ----------------------------------------
 
-  if(npatchinfo>0){
+  if(global_scase.npatchinfo>0){
     glui_active=1;
     ROLLOUT_bound = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds,_("Boundary"),false,BOUNDARY_ROLLOUT,BoundRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_bound, glui_bounds);
@@ -5080,7 +5081,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
     INSERT_ROLLOUT(ROLLOUT_boundary_settings, glui_bounds);
     ADDPROCINFO(subboundprocinfo, nsubboundprocinfo, ROLLOUT_boundary_settings, BOUNDARY_SETTINGS_ROLLOUT, glui_bounds);
 
-    if(ngeom_data > 0){
+    if(global_scase.ngeom_data > 0){
       glui_bounds->add_checkbox_to_panel(ROLLOUT_boundary_settings, _("shaded"), &show_boundary_shaded);
       CHECKBOX_show_boundary_outline=glui_bounds->add_checkbox_to_panel(ROLLOUT_boundary_settings, _("outline"), &show_boundary_outline, SHOW_BOUNDARY_OUTLINE, BoundBoundCB);
       glui_bounds->add_checkbox_to_panel(ROLLOUT_boundary_settings, _("points"), &show_boundary_points);
@@ -5145,7 +5146,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
   // ----------------------------------- Isosurface ----------------------------------------
 
-  if(nisoinfo>0){
+  if(global_scase.nisoinfo>0){
     ROLLOUT_iso = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds, "Isosurface", false, ISO_ROLLOUT, BoundRolloutCB);
     ADDPROCINFO(boundprocinfo, nboundprocinfo, ROLLOUT_iso, ISO_ROLLOUT, glui_bounds);
 
@@ -5252,7 +5253,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
   /* Particle File Bounds  */
 
   have_part = 0;
-  if(npartinfo > 0)have_part = 1;
+  if(global_scase.npartinfo > 0)have_part = 1;
   if(have_part==1){
     char label[100];
 
@@ -5287,8 +5288,8 @@ extern "C" void GLUIBoundsSetup(int main_window){
 #ifndef pp_PARTFRAME
     CHECKBOX_use_partload_threads = glui_bounds->add_checkbox_to_panel(PANEL_partread, _("Parallel loading"), &use_partload_threads);
     SPINNER_n_part_threads = glui_bounds->add_spinner_to_panel(PANEL_partread, _("Files loaded at once:"), GLUI_SPINNER_INT, &n_partload_threads);
-    if(npartinfo>1){
-      SPINNER_n_part_threads->set_int_limits(1,MIN(npartinfo,MAX_THREADS));
+    if(global_scase.npartinfo>1){
+      SPINNER_n_part_threads->set_int_limits(1,MIN(global_scase.npartinfo,MAX_THREADS));
     }
     else{
       SPINNER_n_part_threads->set_int_limits(1,1);
@@ -5302,7 +5303,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
   // ----------------------------------- Plot3D ----------------------------------------
 
-  if(nplot3dinfo>0){
+  if(global_scase.nplot3dinfo>0){
     glui_active=1;
     ROLLOUT_plot3d = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds,"Plot3D",false,PLOT3D_ROLLOUT,BoundRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_plot3d, glui_bounds);
@@ -5359,7 +5360,7 @@ extern "C" void GLUIBoundsSetup(int main_window){
 
   // ----------------------------------- HVAC ducts ----------------------------------------
 
-  if(hvaccoll.nhvacinfo > 0&&nhvacductbounds_cpp>0){
+  if(global_scase.hvaccoll.nhvacinfo > 0&&nhvacductbounds_cpp>0){
     glui_active = 1;
     ROLLOUT_hvacduct = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds, "HVAC ducts", false, HVACDUCT_ROLLOUT, BoundRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_hvacduct, glui_bounds);
@@ -5372,7 +5373,7 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
 
   // ----------------------------------- HVAC nodes ----------------------------------------
 
-  if(hvaccoll.nhvacinfo > 0 && nhvacnodebounds_cpp > 0){
+  if(global_scase.hvaccoll.nhvacinfo > 0 && nhvacnodebounds_cpp > 0){
     glui_active = 1;
     ROLLOUT_hvacnode = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds, "HVAC nodes", false, HVACNODE_ROLLOUT, BoundRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_hvacnode, glui_bounds);
@@ -5384,7 +5385,7 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
 
   // ----------------------------------- Slice ----------------------------------------
 
-  if(slicecoll.nsliceinfo>0){
+  if(global_scase.slicecoll.nsliceinfo>0){
     glui_active=1;
     ROLLOUT_slice = glui_bounds->add_rollout_to_panel(ROLLOUT_filebounds,"Slice",false,SLICE_ROLLOUT_BOUNDS,BoundRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_slice, glui_bounds);
@@ -5401,7 +5402,7 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
 
     CHECKBOX_average_slice=glui_bounds->add_checkbox_to_panel(ROLLOUT_slice_average,_("Average slice data"),&slice_average_flag);
     SPINNER_sliceaverage=glui_bounds->add_spinner_to_panel(ROLLOUT_slice_average,_("Time interval"),GLUI_SPINNER_FLOAT,&slice_average_interval);
-    SPINNER_sliceaverage->set_float_limits(0.0,MAX(120.0,tourcoll.tour_tstop));
+    SPINNER_sliceaverage->set_float_limits(0.0,MAX(120.0,global_scase.tourcoll.tour_tstop));
     glui_bounds->add_button_to_panel(ROLLOUT_slice_average,_("Reload"),FILE_RELOAD,GLUISliceBoundCB);
 
     ROLLOUT_line_contour = glui_bounds->add_rollout_to_panel(PANEL_slice_buttonsA, _("Line contours"), false, LINE_CONTOUR_ROLLOUT, SliceRolloutCB);
@@ -5434,7 +5435,7 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
       CHECKBOX_skip_subslice=glui_bounds->add_checkbox_to_panel(PANEL_slice_buttonsB,_("Skip coarse sub-slice"),&skip_slice_in_embedded_mesh);
     }
 
-    if(slicecoll.nsliceinfo>0){
+    if(global_scase.slicecoll.nsliceinfo>0){
       ROLLOUT_plotslice = glui_bounds->add_rollout_to_panel(PANEL_slice_buttonsA, "2D plots", false, SLICE_PLOT2D_ROLLOUT, SliceRolloutCB);
       INSERT_ROLLOUT(ROLLOUT_plotslice, glui_bounds);
       ADDPROCINFO(sliceprocinfo, nsliceprocinfo, ROLLOUT_plotslice, SLICE_PLOT2D_ROLLOUT, glui_bounds);
@@ -5505,7 +5506,7 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
 
 
     RADIO_button_cutcell = glui_bounds->add_radiobutton_to_group(RADIO_slice_celltype, "cut cell");
-    if(ngeom_data==0)RADIO_button_cutcell->disable();
+    if(global_scase.ngeom_data==0)RADIO_button_cutcell->disable();
 
     PANEL_immersed_outlinetype = glui_bounds->add_panel_to_panel(PANEL_immersed, "outline type", true);
     RADIO_slice_edgetype = glui_bounds->add_radiogroup_to_panel(PANEL_immersed_outlinetype, &glui_slice_edgetype, IMMERSED_SWITCH_EDGETYPE, GLUIImmersedBoundCB);
@@ -5552,17 +5553,17 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
     CHECKBOX_show_node_slices_and_vectors = glui_bounds->add_checkbox_to_panel(PANEL_showslice, _("node centered slices"), &show_node_slices_and_vectors);
     CHECKBOX_show_node_slices_and_vectors = glui_bounds->add_checkbox_to_panel(PANEL_showslice, _("cell centered slices"), &show_cell_slices_and_vectors);
 
-    if(ngeom_data > 0)glui_bounds->add_column_to_panel(ROLLOUT_slice_settings, false);
+    if(global_scase.ngeom_data > 0)glui_bounds->add_column_to_panel(ROLLOUT_slice_settings, false);
 
-    if(show_slice_in_obst==ONLY_IN_GAS){
+    if(global_scase.show_slice_in_obst==ONLY_IN_GAS){
       show_slice_in_gas   = 1;
       show_slice_in_solid = 0;
     }
-    else if(show_slice_in_obst==GAS_AND_SOLID){
+    else if(global_scase.show_slice_in_obst==GAS_AND_SOLID){
       show_slice_in_gas   = 1;
       show_slice_in_solid = 1;
     }
-    else if(show_slice_in_obst==ONLY_IN_SOLID){
+    else if(global_scase.show_slice_in_obst==ONLY_IN_SOLID){
       show_slice_in_gas   = 0;
       show_slice_in_solid = 1;
     }
@@ -5571,7 +5572,7 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
       show_slice_in_solid = 0;
     }
 
-    if(ngeom_data == 0)glui_bounds->add_column_to_panel(ROLLOUT_slice_settings, false);
+    if(global_scase.ngeom_data == 0)glui_bounds->add_column_to_panel(ROLLOUT_slice_settings, false);
 
     PANEL_slice_smoke = glui_bounds->add_panel_to_panel(ROLLOUT_slice_settings, "slice(fire)", true);
     glui_bounds->add_checkbox_to_panel(PANEL_slice_smoke, _("max blending"), &slices3d_max_blending);
@@ -5583,10 +5584,10 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
     glui_bounds->add_spinner_to_panel(PANEL_slice_misc, "slice offset", GLUI_SPINNER_FLOAT, &slice_dz);
     CHECKBOX_sortslices = glui_bounds->add_checkbox_to_panel(PANEL_slice_misc, "sort slices(back to front)", &sortslices, SORTSLICES, GLUISliceBoundCB);
     CHECKBOX_sortslices_debug = glui_bounds->add_checkbox_to_panel(PANEL_slice_misc, "sort slices(debug)", &sortslices_debug, SORTSLICES_DEBUG, GLUISliceBoundCB);
-    for(i = 0; i<nmeshes; i++){
+    for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
       meshdata *meshi;
 
-      meshi = meshinfo+i;
+      meshi = global_scase.meshescoll.meshinfo+i;
       max_slice_skip = MAX(max_slice_skip, meshi->ibar/2);
       max_slice_skip = MAX(max_slice_skip, meshi->jbar/2);
       max_slice_skip = MAX(max_slice_skip, meshi->kbar/2);
@@ -5596,7 +5597,7 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
     GLUISliceBoundCB(SLICE_SKIP);
     glui_bounds->add_checkbox_to_panel(PANEL_slice_misc, _("Output data (press r)"), &output_slicedata);
 
-    if(nterraininfo>0){
+    if(global_scase.nterraininfo>0){
       glui_bounds->add_checkbox_to_panel(ROLLOUT_slice_settings, _("terrain slice overlap"), &terrain_slice_overlap);
       glui_bounds->add_checkbox_to_panel(ROLLOUT_slice_settings, _("actual agl offset"), &agl_offset_actual);
     }
@@ -5664,12 +5665,12 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
   glui_bounds->add_button_to_panel(ROLLOUT_time2, _("Use FDS start/end times"), SET_FDS_TIMES, TimeBoundCB);
 
   PANEL_time2a = glui_bounds->add_panel_to_panel(ROLLOUT_time2, "", false);
-  SPINNER_tload_begin = glui_bounds->add_spinner_to_panel(PANEL_time2a, _("min time"), GLUI_SPINNER_FLOAT, &tload_begin, TBOUNDS, TimeBoundCB);
+  SPINNER_tload_begin = glui_bounds->add_spinner_to_panel(PANEL_time2a, _("min time"), GLUI_SPINNER_FLOAT, &global_scase.tload_begin, TBOUNDS, TimeBoundCB);
   glui_bounds->add_column_to_panel(PANEL_time2a, false);
   CHECKBOX_use_tload_begin = glui_bounds->add_checkbox_to_panel(PANEL_time2a, "", &use_tload_begin, TBOUNDS_USE, TimeBoundCB);
 
   PANEL_time2b = glui_bounds->add_panel_to_panel(ROLLOUT_time2, "", false);
-  SPINNER_tload_end = glui_bounds->add_spinner_to_panel(PANEL_time2b, _("max time"), GLUI_SPINNER_FLOAT, &tload_end, TBOUNDS, TimeBoundCB);
+  SPINNER_tload_end = glui_bounds->add_spinner_to_panel(PANEL_time2b, _("max time"), GLUI_SPINNER_FLOAT, &global_scase.tload_end, TBOUNDS, TimeBoundCB);
   glui_bounds->add_column_to_panel(PANEL_time2b, false);
   CHECKBOX_use_tload_end = glui_bounds->add_checkbox_to_panel(PANEL_time2b, "", &use_tload_end, TBOUNDS_USE, TimeBoundCB);
 
@@ -5732,7 +5733,7 @@ hvacductboundsCPP.setup("hvac", ROLLOUT_hvacduct, hvacductbounds_cpp, nhvacductb
 
   PANEL_addmesh = glui_bounds->add_panel_to_panel(PANEL_setmesh, "", false);
   SPINNER_set_mesh = glui_bounds->add_spinner_to_panel(PANEL_addmesh, "mesh:", GLUI_SPINNER_INT, &set_mesh);
-  SPINNER_set_mesh->set_int_limits(1, nmeshes);
+  SPINNER_set_mesh->set_int_limits(1, global_scase.meshescoll.nmeshes);
   glui_bounds->add_column_to_panel(PANEL_addmesh, false);
   glui_bounds->add_button_to_panel(PANEL_addmesh, "Add", USEMESH_SET_ONE, MeshBoundCB);
   glui_bounds->add_column_to_panel(PANEL_addmesh, false);
@@ -6022,8 +6023,8 @@ extern "C" void GLUIPlot3DBoundCB(int var){
    p3chopmax_temp=p3chopmax[list_p3_index];
    setp3chopmin_temp=setp3chopmin[list_p3_index];
    setp3chopmax_temp=setp3chopmax[list_p3_index];
-   if(plot3dinfo!=NULL){
-     plot3dmin_unit = (unsigned char *)plot3dinfo->label[list_p3_index].unit;
+   if(global_scase.plot3dinfo!=NULL){
+     plot3dmin_unit = (unsigned char *)global_scase.plot3dinfo->label[list_p3_index].unit;
      plot3dmax_unit = plot3dmin_unit;
    }
 
@@ -6087,8 +6088,8 @@ extern "C" void GLUIPlot3DBoundCB(int var){
     break;
   case FILE_RELOAD:
    GLUIPlot3DBoundCB(FILE_UPDATE);
-   for(i=0;i<nplot3dinfo;i++){
-     if(plot3dinfo[i].loaded==0)continue;
+   for(i=0;i<global_scase.nplot3dinfo;i++){
+     if(global_scase.plot3dinfo[i].loaded==0)continue;
      LoadPlot3dMenu(i);
    }
    break;
@@ -6377,7 +6378,7 @@ extern "C" void GLUIUpdateBoundaryListIndex(int patchfilenum){
   for(i=0;i<npatch2;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + patchfilenum;
+    patchi = global_scase.patchinfo + patchfilenum;
     if(strcmp(patchlabellist[i],patchi->label.shortlabel)==0){
       if(RADIO_bf == NULL){
         list_patch_index = i;
@@ -6495,7 +6496,7 @@ void PartBoundCB(int var){
   case TRACERS:
   case PARTFAST:
 #ifndef pp_PARTFRAME
-    if(npartinfo<=1){
+    if(global_scase.npartinfo<=1){
       CHECKBOX_use_partload_threads->disable();
       SPINNER_n_part_threads->disable();
       use_partload_threads = 0;
@@ -6655,13 +6656,13 @@ extern "C" void GLUISliceBoundCB(int var){
       break;
     case SLICE_PLOT_FILENAME:
       use_slice = 0;
-      strcpy(slice_plot_filename, fdsprefix);
+      strcpy(slice_plot_filename, global_scase.fdsprefix);
       strcat(slice_plot_filename, "_slice");
-      for(i = 0; i < slicecoll.nsliceinfo; i++){
+      for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
         slicedata *slicei;
         devicedata *devicei;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         devicei = &(slicei->vals2d);
         if(slicei->loaded == 0 || devicei->valid == 0)continue;
         strcat(slice_plot_filename, "_");
@@ -6707,13 +6708,13 @@ extern "C" void GLUISliceBoundCB(int var){
       update_vectorskip = 1;
       break;
     case ZONEVALMINMAX:
-      GetZoneColors(zonetu, nzonetotal, izonetu, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-      GetZoneColors(zonetl, nzonetotal, izonetl, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-      if(have_zonefl==1)GetZoneColors(zonefl, nzonetotal, izonefl, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-      if(have_zonelw==1)GetZoneColors(zonelw, nzonetotal, izonelw, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-      if(have_zoneuw==1)GetZoneColors(zoneuw, nzonetotal, izoneuw, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-      if(have_zonecl==1)GetZoneColors(zonecl, nzonetotal, izonecl, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-      if(have_target_data==1)GetZoneColors(zonetargets, nzonetotal_targets, izonetargets, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
+      GetZoneColors(zonetu, nzonetotal, izonetu, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+      GetZoneColors(zonetl, nzonetotal, izonetl, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+      if(have_zonefl==1)GetZoneColors(zonefl, nzonetotal, izonefl, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+      if(have_zonelw==1)GetZoneColors(zonelw, nzonetotal, izonelw, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+      if(have_zoneuw==1)GetZoneColors(zoneuw, nzonetotal, izoneuw, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+      if(have_zonecl==1)GetZoneColors(zonecl, nzonetotal, izonecl, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+      if(have_target_data==1)GetZoneColors(zonetargets, nzonetotal_targets, izonetargets, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
       zoneusermin=zonemin;
       zoneusermax=zonemax;
       break;
@@ -6732,8 +6733,8 @@ extern "C" void GLUISliceBoundCB(int var){
       else{
         EDIT_zone_max->set_float_val(zoneglobalmax);
       }
-      GetZoneColors(zonetu, nzonetotal, izonetu,zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
-      GetZoneColors(zonetl, nzonetotal, izonetl, zonemin, zonemax, nrgb, nrgb_full, colorlabelzone, colorvalueszone, zonelevels256);
+      GetZoneColors(zonetu, nzonetotal, izonetu,zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
+      GetZoneColors(zonetl, nzonetotal, izonetl, zonemin, zonemax, global_scase.nrgb, nrgb_full, global_scase.colorlabelzone, colorvalueszone, zonelevels256);
       break;
     case COLORBAR_LIST2:
       int list_index;
@@ -6774,10 +6775,10 @@ extern "C" void GLUISliceBoundCB(int var){
       break;
     case SORT_SURFACES:
       sort_geometry=sort_iso_triangles;
-      for(i=nsurfinfo;i<nsurfinfo+MAX_ISO_COLORS+1;i++){
+      for(i=global_scase.surfcoll.nsurfinfo;i<global_scase.surfcoll.nsurfinfo+MAX_ISO_COLORS+1;i++){
         surfdata *surfi;
 
-        surfi = surfinfo + i;
+        surfi = global_scase.surfcoll.surfinfo + i;
         surfi->transparent_level=transparent_level;
       }
       CHECKBOX_sort2->set_int_val(sort_iso_triangles);
@@ -6847,10 +6848,10 @@ extern "C" void GLUISliceBoundCB(int var){
       updatemenu = 1;
       break;
     case TRANSPARENTLEVEL:
-      for(i=nsurfinfo;i<nsurfinfo+MAX_ISO_COLORS+1;i++){
+      for(i=global_scase.surfcoll.nsurfinfo;i<global_scase.surfcoll.nsurfinfo+MAX_ISO_COLORS+1;i++){
         surfdata *surfi;
 
-        surfi = surfinfo + i;
+        surfi = global_scase.surfcoll.surfinfo + i;
         surfi->transparent_level=transparent_level;
       }
       UpdateRGBColors(colorbar_select_index);
@@ -6969,7 +6970,7 @@ extern "C" void GLUISliceBoundCB(int var){
     }
     for(ii = nslice_loaded - 1; ii >= 0; ii--){
       i = slice_loaded_list[ii];
-      sd = slicecoll.sliceinfo + i;
+      sd = global_scase.slicecoll.sliceinfo + i;
       if(sd->slicefile_labelindex == slicefile_labelindex){
         last_slice = i;
         break;
@@ -6977,7 +6978,7 @@ extern "C" void GLUISliceBoundCB(int var){
     }
     for(ii = 0; ii < nslice_loaded; ii++){
       i = slice_loaded_list[ii];
-      sd = slicecoll.sliceinfo + i;
+      sd = global_scase.slicecoll.sliceinfo + i;
       if(sd->slicefile_labelindex == slicefile_labelindex){
         int set_slicecolor;
 

--- a/Source/smokeview/glui_clip.cpp
+++ b/Source/smokeview/glui_clip.cpp
@@ -85,11 +85,11 @@ void ClipCB(int var){
     GLUIUpdateShowRotationCenter();
     break;
   case CLIP_MESH:
-    if(clip_mesh == 0){
+    if(global_scase.clip_mesh == 0){
       SetClipControls(DEFAULT_VALS);
     }
     else{
-      SetClipControls(clip_mesh);
+      SetClipControls(global_scase.clip_mesh);
     }
     break;
   case SAVE_SETTINGS_CLIP:
@@ -144,7 +144,7 @@ void ClipCB(int var){
       CHECKBOX_clip_ymax->enable();
       CHECKBOX_clip_zmax->enable();
       show_bothsides_blockages = 1;
-      updatefaces = 1;
+      global_scase.updatefaces = 1;
     }
     else{
       SPINNER_clip_xmin->disable();
@@ -161,7 +161,7 @@ void ClipCB(int var){
       CHECKBOX_clip_ymax->disable();
       CHECKBOX_clip_zmax->disable();
       show_bothsides_blockages = 0;
-      updatefaces = 1;
+      global_scase.updatefaces = 1;
     }
     break;
   case SPINNER_xlower:
@@ -230,7 +230,7 @@ void SetClipControls(int val){
     clipinfo.ymax = yclip_max;
     clipinfo.zmax = zclip_max;
   }
-  if(val >= 1 && val <= nmeshes){
+  if(val >= 1 && val <= global_scase.meshescoll.nmeshes){
     meshdata *meshi;
     float *xplt, *yplt, *zplt;
 
@@ -240,7 +240,7 @@ void SetClipControls(int val){
     dyclip = (ybarORIG - ybar0ORIG) / 1000.0;
     dzclip = (zbarORIG - zbar0ORIG) / 1000.0;
 
-    meshi = meshinfo + val - 1;
+    meshi = global_scase.meshescoll.meshinfo + val - 1;
 
     xplt = meshi->xplt_orig;
     yplt = meshi->yplt_orig;
@@ -335,11 +335,11 @@ extern "C" void GLUIClipSetup(int main_window){
     SetClipControls(INI_VALS);  // clip vals from ini file
   }
   else{
-    if(clip_mesh==0){
+    if(global_scase.clip_mesh==0){
       SetClipControls(DEFAULT_VALS);  // clip vals from global scene
     }
     else{
-      SetClipControls(clip_mesh);  // clip vals from mesh clip_mesh
+      SetClipControls(global_scase.clip_mesh);  // clip vals from mesh clip_mesh
     }
   }
 

--- a/Source/smokeview/glui_display.cpp
+++ b/Source/smokeview/glui_display.cpp
@@ -9,6 +9,7 @@
 #include "smokeviewvars.h"
 #include "glui_bounds.h"
 #include "glui_motion.h"
+#include "colorbars.h"
 #include "readlabel.h"
 
 GLUI *glui_labels=NULL;
@@ -332,7 +333,7 @@ void DisplayRolloutCB(int var){
 /* ------------------ UpdateGluiLabelText ------------------------ */
 
 void UpdateGluiLabelText(void){
-  if(LabelGetNUserLabels(&labelscoll)>0){
+  if(LabelGetNUserLabels(&global_scase.labelscoll)>0){
     labeldata *gl;
 
     gl=&LABEL_local;
@@ -415,7 +416,7 @@ void TextLabelsCB(int var){
     updatemenu = 1;
     break;
   case LB_UPDATE:
-    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = global_scase.labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->glui_id < 0)continue;
       LIST_LB_labels->delete_item(thislabel->glui_id);
     }
@@ -423,7 +424,7 @@ void TextLabelsCB(int var){
     //LabelResort(LABEL_global_ptr);
 
     count = 0;
-    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = global_scase.labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->labeltype == TYPE_SMV)continue;
       thislabel->glui_id = count;
       LIST_LB_labels->add_item(count++, thislabel->name);
@@ -439,8 +440,8 @@ void TextLabelsCB(int var){
     memcpy(&LABEL_global_ptr->useforegroundcolor, &gl->useforegroundcolor, sizeof(int));
     break;
   case LB_PREVIOUS:
-    new_label = LabelGet(&labelscoll, LIST_LB_labels->curr_text);
-    new_label = LabelPrevious(&labelscoll, new_label);
+    new_label = LabelGet(&global_scase.labelscoll, LIST_LB_labels->curr_text);
+    new_label = LabelPrevious(&global_scase.labelscoll, new_label);
     if(new_label == NULL)break;
     LABEL_global_ptr = new_label;
     if(new_label != NULL){
@@ -449,8 +450,8 @@ void TextLabelsCB(int var){
     }
     break;
   case LB_NEXT:
-    new_label = LabelGet(&labelscoll, LIST_LB_labels->curr_text);
-    new_label = LabelNext(&labelscoll, new_label);
+    new_label = LabelGet(&global_scase.labelscoll, LIST_LB_labels->curr_text);
+    new_label = LabelNext(&global_scase.labelscoll, new_label);
     if(new_label == NULL)break;
     LABEL_global_ptr = new_label;
     if(new_label != NULL){
@@ -459,7 +460,7 @@ void TextLabelsCB(int var){
     }
     break;
   case LB_LIST:
-    new_label = LabelGet(&labelscoll, LIST_LB_labels->curr_text);
+    new_label = LabelGet(&global_scase.labelscoll, LIST_LB_labels->curr_text);
     LABEL_global_ptr = new_label;
     if(new_label != NULL){
       LabelCopy(gl, new_label);
@@ -468,7 +469,7 @@ void TextLabelsCB(int var){
     break;
   case LB_ADD:
     updatemenu = 1;
-    if(LabelGetNUserLabels(&labelscoll) > 0){
+    if(LabelGetNUserLabels(&global_scase.labelscoll) > 0){
       strcpy(name, "copy of ");
       strcat(name, gl->name);
       strcpy(gl->name, name);
@@ -477,13 +478,13 @@ void TextLabelsCB(int var){
       gl = &LABEL_default;
     }
     gl->labeltype = TYPE_INI;
-    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = global_scase.labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->glui_id < 0)continue;
       LIST_LB_labels->delete_item(thislabel->glui_id);
     }
-    LabelInsert(&labelscoll, gl);
+    LabelInsert(&global_scase.labelscoll, gl);
     count = 0;
-    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = global_scase.labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->labeltype == TYPE_SMV)continue;
       thislabel->glui_id = count;
       LIST_LB_labels->add_item(count++, thislabel->name);
@@ -492,16 +493,16 @@ void TextLabelsCB(int var){
     break;
   case LB_DELETE:
     strcpy(name, LIST_LB_labels->curr_text);
-    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = global_scase.labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->glui_id < 0)continue;
       LIST_LB_labels->delete_item(thislabel->glui_id);
     }
-    thislabel = LabelGet(&labelscoll, name);
+    thislabel = LabelGet(&global_scase.labelscoll, name);
     if(thislabel != NULL){
       LabelDelete(thislabel);
     }
     count = 0;
-    for(thislabel = labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
+    for(thislabel = global_scase.labelscoll.label_first_ptr->next;thislabel->next != NULL;thislabel = thislabel->next){
       if(thislabel->labeltype == TYPE_SMV)continue;
       thislabel->glui_id = count;
       LIST_LB_labels->add_item(count++, thislabel->name);
@@ -632,7 +633,7 @@ void SurfaceCB(int var){
     {
       surfdata *surfi;
 
-      surfi = surfinfo + glui_surf_index;
+      surfi = global_scase.surfcoll.surfinfo + glui_surf_index;
       surfi->color = surfi->color_orig;
       surfi->transparent_level = surfi->transparent_level_orig;
       SurfaceCB(SURFACE_SELECT);
@@ -644,7 +645,7 @@ void SurfaceCB(int var){
       surfdata *surfi;
       float s_color[4];
 
-      surfi = surfinfo + glui_surf_index;
+      surfi = global_scase.surfcoll.surfinfo + glui_surf_index;
       s_color[0] = (float)glui_surface_color[0]/255.0;
       s_color[1] = (float)glui_surface_color[1]/255.0;
       s_color[2] = (float)glui_surface_color[2]/255.0;
@@ -661,7 +662,7 @@ void SurfaceCB(int var){
       s_color[3] = surfi->transparent_level;
       surfi->color = GetColorPtr(s_color);
       updatefacelists = 1;
-      updatefaces = 1;
+      global_scase.updatefaces = 1;
     }
     break;
   case SURFACE_SELECT:
@@ -670,7 +671,7 @@ void SurfaceCB(int var){
       float s_color[4];
       int i;
 
-      surfi = surfinfo + glui_surf_index;
+      surfi = global_scase.surfcoll.surfinfo + glui_surf_index;
       memcpy(s_color, surfi->color, 3*sizeof(float));
       s_color[3] = surfi->transparent_level;
 
@@ -692,8 +693,8 @@ extern "C" void GLUIUpdateTextureDisplay(void){
   int i;
   int showall = 1, hideall = 1, update=0;
 
-  for(i = 0;i < ntextureinfo;i++){
-    texti = textureinfo + i;
+  for(i = 0;i < global_scase.texture_coll.ntextureinfo;i++){
+    texti = global_scase.texture_coll.textureinfo + i;
     if(texti->loaded == 0 || texti->used == 0)continue;
     if(texti->display == 0)showall=0;
     if(texti->display == 1)hideall = 0;
@@ -776,7 +777,7 @@ extern "C" void GLUIDisplaySetup(int main_window){
 
   PANEL_gen1=glui_labels->add_panel_to_panel(ROLLOUT_general,"",GLUI_PANEL_NONE);
 
-  if(slicecoll.nsliceinfo>0)CHECKBOX_labels_average = glui_labels->add_checkbox_to_panel(PANEL_gen1, _("Average"), &vis_slice_average, LABELS_label, GLUILabelsCB);
+  if(global_scase.slicecoll.nsliceinfo>0)CHECKBOX_labels_average = glui_labels->add_checkbox_to_panel(PANEL_gen1, _("Average"), &vis_slice_average, LABELS_label, GLUILabelsCB);
   CHECKBOX_labels_axis = glui_labels->add_checkbox_to_panel(PANEL_gen1, _("Axis"), &visaxislabels, LABELS_label, GLUILabelsCB);
   CHECKBOX_visColorbarVertical   = glui_labels->add_checkbox_to_panel(PANEL_gen1, _("Colorbar(vertical)"),   &visColorbarVertical,   LABELS_vcolorbar, GLUILabelsCB);
   CHECKBOX_visColorbarHorizontal = glui_labels->add_checkbox_to_panel(PANEL_gen1, _("Colorbar(horizontal)"), &visColorbarHorizontal, LABELS_hcolorbar, GLUILabelsCB);
@@ -822,7 +823,7 @@ extern "C" void GLUIDisplaySetup(int main_window){
   glui_labels->add_radiobutton_to_group(RADIO_show_geom_boundingbox, "when mouse is pressed");
   glui_labels->add_radiobutton_to_group(RADIO_show_geom_boundingbox, "never");
 
-  if(ntickinfo > 0){
+  if(global_scase.ntickinfo > 0){
     CHECKBOX_labels_ticks->enable();
   }
   else{
@@ -842,7 +843,7 @@ extern "C" void GLUIDisplaySetup(int main_window){
   PANEL_gen3=glui_labels->add_panel_to_panel(ROLLOUT_general,"",GLUI_PANEL_NONE);
 
   PANEL_linewidth=glui_labels->add_panel_to_panel(PANEL_gen3,"line width");
-  SPINNER_linewidth=glui_labels->add_spinner_to_panel(PANEL_linewidth,_("blockage"),GLUI_SPINNER_FLOAT,&linewidth);
+  SPINNER_linewidth=glui_labels->add_spinner_to_panel(PANEL_linewidth,_("blockage"),GLUI_SPINNER_FLOAT,&global_scase.linewidth);
   SPINNER_linewidth->set_float_limits(1.0,10.0,GLUI_LIMIT_CLAMP);
   SPINNER_gridlinewidth=glui_labels->add_spinner_to_panel(PANEL_linewidth,_("grid"),GLUI_SPINNER_FLOAT,&gridlinewidth);
   SPINNER_gridlinewidth->set_float_limits(1.0,10.0,GLUI_LIMIT_CLAMP);
@@ -858,10 +859,10 @@ extern "C" void GLUIDisplaySetup(int main_window){
 
   int i, surfcount = 0, first_surf=-1;
 
-  for(i = 0; i<nsurfinfo; i++){
+  for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
     surfdata *surfi;
 
-    surfi = surfinfo+i;
+    surfi = global_scase.surfcoll.surfinfo+i;
     if(surfi->used_by_geom==0&&surfi->used_by_obst==0)continue;
     if(strcmp(surfi->surfacelabel, "INERT")==0)continue;
     if(first_surf<0)first_surf = i;
@@ -872,10 +873,10 @@ extern "C" void GLUIDisplaySetup(int main_window){
     glui_surf_index = first_surf;
     PANEL_surfs = glui_labels->add_panel_to_panel(PANEL_gen3, "Surface color");
     LIST_surfs = glui_labels->add_listbox_to_panel(PANEL_surfs, _("Select"), &glui_surf_index, SURFACE_SELECT, SurfaceCB);
-    for(i = 0; i<nsurfinfo; i++){
+    for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
       surfdata *surfi;
 
-      surfi = surfinfo+i;
+      surfi = global_scase.surfcoll.surfinfo+i;
       if(surfi->used_by_geom==0&&surfi->used_by_obst==0)continue;
       if(strcmp(surfi->surfacelabel, "INERT")==0)continue;
       LIST_surfs->add_item(i, surfi->surfacelabel);
@@ -898,12 +899,12 @@ extern "C" void GLUIDisplaySetup(int main_window){
 
   CHECKBOX_visaxislabels = glui_labels->add_checkbox_to_panel(PANEL_gen3, _("Show axis labels"), &visaxislabels, UPDATEMENU, UpdateMenuCB);
 
-  if(nzoneinfo > 0){
+  if(global_scase.nzoneinfo > 0){
     SPINNER_zone_hvac_diam = glui_labels->add_spinner_to_panel(PANEL_gen3, "HVAC (cfast)", GLUI_SPINNER_FLOAT, &zone_hvac_diam);
     SPINNER_zone_hvac_diam->set_float_limits(0.0, 1.0, GLUI_LIMIT_CLAMP);
   }
 
-  if(have_northangle==1){
+  if(global_scase.have_northangle==1){
     ROLLOUT_north = glui_labels->add_rollout_to_panel(PANEL_gen3,_("North direction"),false);
     INSERT_ROLLOUT(ROLLOUT_north, glui_labels);
     CHECKBOX_shownorth=glui_labels->add_checkbox_to_panel(ROLLOUT_north,_("show"),&vis_northangle,LABELS_shownorth,GLUILabelsCB);
@@ -1126,7 +1127,7 @@ extern "C" void GLUIDisplaySetup(int main_window){
     labeldata *thislabel;
     int count=0;
 
-    for(thislabel=labelscoll.label_first_ptr->next;thislabel->next!=NULL;thislabel=thislabel->next){
+    for(thislabel=global_scase.labelscoll.label_first_ptr->next;thislabel->next!=NULL;thislabel=thislabel->next){
       if(thislabel->labeltype==TYPE_SMV){
         thislabel->glui_id=-1;
         continue;
@@ -1306,7 +1307,7 @@ extern "C" void GLUILabelsCB(int var){
     break;
   case APPLY_VENTOFFSET:
     UpdateVentOffset();
-    updatefaces=1;
+    global_scase.updatefaces=1;
     break;
   case FLIP:
       colorbar_flip = 1 - colorbar_flip;

--- a/Source/smokeview/glui_geometry.cpp
+++ b/Source/smokeview/glui_geometry.cpp
@@ -225,10 +225,10 @@ extern "C" void GLUIUpdateHVACViews(void){
   /* ------------------ GLUIUpdateTerrainTexture ------------------------ */
 
 extern "C" void GLUIUpdateTerrainTexture(int val){
-  if(CHECKBOX_terrain_texture_show!=NULL&&val>=0&&val<nterrain_textures){
+  if(CHECKBOX_terrain_texture_show!=NULL&&val>=0&&val<global_scase.terrain_texture_coll.nterrain_textures){
     texturedata *texti;
 
-    texti = terrain_textures+val;
+    texti = global_scase.terrain_texture_coll.terrain_textures+val;
     if(texti->loaded==1&&CHECKBOX_terrain_texture_show[val]!=NULL){
       CHECKBOX_terrain_texture_show[val]->set_int_val(texti->display);
     }
@@ -312,10 +312,10 @@ extern "C" void GLUIGetGeomDialogState(void){
 int HaveTexture(void){
   int i;
 
-  for(i = 0; i < ntextureinfo; i++){
+  for(i = 0; i < global_scase.texture_coll.ntextureinfo; i++){
     texturedata *texti;
 
-    texti = textureinfo + i;
+    texti = global_scase.texture_coll.textureinfo + i;
     if(texti->loaded == 1 && texti->used == 1)return 1;
   }
   return 0;
@@ -411,13 +411,13 @@ extern "C" void GLUIUpdateVertexInfo(float *xyz1, float *xyz2){
 void Glui2HVAC(void){
   int i;
 
-  for(i = 0;i < hvaccoll.nhvacinfo;i++){
+  for(i = 0;i < global_scase.hvaccoll.nhvacinfo;i++){
     if(hvac_network_ductnode_index==-1||hvac_network_ductnode_index==i){
       int display;
       hvacdata *hvaci;
       char *network_name;
 
-      hvaci = hvaccoll.hvacinfo + i;
+      hvaci = global_scase.hvaccoll.hvacinfo + i;
       display      = hvaci->display;
       network_name = hvaci->network_name;
       memcpy(hvaci, glui_hvac, sizeof(hvacdata));
@@ -433,13 +433,13 @@ extern "C" void GLUIHVAC2Glui(int index){
   hvacdata *hvaci;
   int i;
 
-  if(index >= hvaccoll.nhvacinfo)return;
+  if(index >= global_scase.hvaccoll.nhvacinfo)return;
   if(index < 0){
     Glui2HVAC();
     return;
   }
 
-  hvaci = hvaccoll.hvacinfo + index;
+  hvaci = global_scase.hvaccoll.hvacinfo + index;
   memcpy(glui_hvac, hvaci, sizeof(hvacdata));
   for(i=0;i<3;i++){
     SPINNER_hvac_duct_color[i]->set_int_val(glui_hvac->duct_color[i]);
@@ -463,14 +463,14 @@ extern "C" void GLUIHVAC2Glui(int index){
 extern "C" void GLUIUpdateTerrain(void){
   if(CHECKBOX_terrain_top_surface!=NULL)CHECKBOX_terrain_top_surface->set_int_val(terrain_showonly_top);
   if(CHECKBOX_showonly_top != NULL)CHECKBOX_showonly_top->set_int_val(terrain_showonly_top);
-  if(RADIO_terrain_type!=NULL)RADIO_terrain_type->set_int_val(visTerrainType);
+  if(RADIO_terrain_type!=NULL)RADIO_terrain_type->set_int_val(global_scase.visTerrainType);
 }
 
 /* ------------------ GLUIUpdateHVACVarLists ------------------------ */
 
 extern "C" void GLUIUpdateHVACVarLists(void){
-  if(LIST_hvacductvar_index!=NULL)LIST_hvacductvar_index->set_int_val(hvaccoll.hvacductvar_index);
-  if(LIST_hvacnodevar_index!=NULL)LIST_hvacnodevar_index->set_int_val(hvaccoll.hvacnodevar_index);
+  if(LIST_hvacductvar_index!=NULL)LIST_hvacductvar_index->set_int_val(global_scase.hvaccoll.hvacductvar_index);
+  if(LIST_hvacnodevar_index!=NULL)LIST_hvacnodevar_index->set_int_val(global_scase.hvaccoll.hvacnodevar_index);
 }
 
 /* ------------------ HvacCB ------------------------ */
@@ -490,15 +490,15 @@ void HvacCB(int var){
       GLUIShowBoundsDialog(DLG_HVACNODE);
       break;
     case HVAC_NODE_LIST:
-      if(hvaccoll.hvacnodevar_index>=0){
-        if(hvaccoll.hvacnodevalsinfo->loaded == 0)ReadHVACData(LOAD);
-        HVACNodeValueMenu(hvaccoll.hvacnodevar_index);
+      if(global_scase.hvaccoll.hvacnodevar_index>=0){
+        if(global_scase.hvaccoll.hvacnodevalsinfo->loaded == 0)ReadHVACData(LOAD);
+        HVACNodeValueMenu(global_scase.hvaccoll.hvacnodevar_index);
       }
       break;
     case HVAC_DUCT_LIST:
-      if(hvaccoll.hvacductvar_index>=0){
-        if(hvaccoll.hvacductvalsinfo->loaded == 0)ReadHVACData(LOAD);
-        HVACDuctValueMenu(hvaccoll.hvacductvar_index);
+      if(global_scase.hvaccoll.hvacductvar_index>=0){
+        if(global_scase.hvaccoll.hvacductvalsinfo->loaded == 0)ReadHVACData(LOAD);
+        HVACDuctValueMenu(global_scase.hvaccoll.hvacductvar_index);
       }
     break;
     case HVAC_DUCTNODE_NETWORK:
@@ -537,7 +537,7 @@ void HvacCB(int var){
     case HVAC_SHOW_NETWORKS:
       if(hvac_show_networks==1){
         PANEL_hvac_network->enable();
-        if(hvaccoll.nhvacconnectinfo > 0){
+        if(global_scase.hvaccoll.nhvacconnectinfo > 0){
           PANEL_hvac_connections->disable();
           hvac_show_connections = 0;
           CHECKBOX_hvac_show_connection->set_int_val(hvac_show_connections);
@@ -560,10 +560,10 @@ void HvacCB(int var){
       break;
     case HVAC_SHOWALL_NETWORK:
     case HVAC_HIDEALL_NETWORK:
-      for(i=0;i<hvaccoll.nhvacinfo;i++){
+      for(i=0;i<global_scase.hvaccoll.nhvacinfo;i++){
         hvacdata *hvaci;
 
-        hvaci = hvaccoll.hvacinfo + i;
+        hvaci = global_scase.hvaccoll.hvacinfo + i;
         if(var==HVAC_SHOWALL_NETWORK)hvaci->display = 1;
         if(var==HVAC_HIDEALL_NETWORK)hvaci->display = 0;
         CHECKBOX_hvac_show_networks[i]->set_int_val(hvaci->display);
@@ -571,10 +571,10 @@ void HvacCB(int var){
       break;
     case HVAC_SHOWALL_CONNECTIONS:
     case HVAC_HIDEALL_CONNECTIONS:
-      for (i = 0; i < hvaccoll.nhvacconnectinfo; i++){
+      for (i = 0; i < global_scase.hvaccoll.nhvacconnectinfo; i++){
         hvacconnectdata *hi;
 
-        hi = hvaccoll.hvacconnectinfo + i;
+        hi = global_scase.hvaccoll.hvacconnectinfo + i;
         if(var==HVAC_SHOWALL_CONNECTIONS)hi->display = 1;
         if(var==HVAC_HIDEALL_CONNECTIONS)hi->display = 0;
         CHECKBOX_hvac_show_connections[i]->set_int_val(hi->display);
@@ -609,24 +609,24 @@ extern "C" void GLUIGeometrySetup(int main_window){
   glui_geometry = GLUI_Master.create_glui("Geometry",0,dialogX0,dialogY0);
   if(showedit_dialog==0)glui_geometry->hide();
 
-  if(hvaccoll.nhvacinfo > 0){
+  if(global_scase.hvaccoll.nhvacinfo > 0){
     have_geometry_dialog = 1;
     NewMemory(( void ** )&glui_hvac, sizeof(hvacdata));
-    memcpy(glui_hvac, hvaccoll.hvacinfo, sizeof(hvacdata));
+    memcpy(glui_hvac, global_scase.hvaccoll.hvacinfo, sizeof(hvacdata));
     ROLLOUT_hvac = glui_geometry->add_rollout("HVAC", false, HVAC_ROLLOUT, GeomRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_hvac, glui_geometry);
     ADDPROCINFO(geomprocinfo, ngeomprocinfo, ROLLOUT_hvac, HVAC_ROLLOUT, glui_geometry);
 
-    NewMemory((void **)&CHECKBOX_hvac_show_networks, hvaccoll.nhvacinfo*sizeof(GLUI_Checkbox *));
+    NewMemory((void **)&CHECKBOX_hvac_show_networks, global_scase.hvaccoll.nhvacinfo*sizeof(GLUI_Checkbox *));
     PANEL_hvac_options = glui_geometry->add_panel_to_panel(ROLLOUT_hvac, "", false);
     PANEL_hvac_options->set_alignment(GLUI_ALIGN_LEFT);
     CHECKBOX_hvac_metro_view = glui_geometry->add_checkbox_to_panel(PANEL_hvac_options, "metro view", &hvac_metro_view, HVAC_METRO_VIEW, HvacCB);
     CHECKBOX_hvac_cell_view = glui_geometry->add_checkbox_to_panel(PANEL_hvac_options, "show cells", &hvac_cell_view, HVAC_CELL_VIEW, HvacCB);
-    if(hvaccoll.nhvacconnectinfo > 0){
+    if(global_scase.hvaccoll.nhvacconnectinfo > 0){
       CHECKBOX_hvac_show_network = glui_geometry->add_checkbox_to_panel(PANEL_hvac_options, "Show by network", &hvac_show_networks, HVAC_SHOW_NETWORKS, HvacCB);
       CHECKBOX_hvac_show_connection = glui_geometry->add_checkbox_to_panel(PANEL_hvac_options, "Show by connection", &hvac_show_connections, HVAC_SHOW_CONNECTIONS, HvacCB);
     }
-    if(hvaccoll.nhvacconnectinfo > 0){
+    if(global_scase.hvaccoll.nhvacconnectinfo > 0){
       PANEL_hvac_group1 = glui_geometry->add_panel_to_panel(ROLLOUT_hvac, "", false);
       PANEL_hvac_network = glui_geometry->add_panel_to_panel(PANEL_hvac_group1, "networks");
     }
@@ -634,31 +634,31 @@ extern "C" void GLUIGeometrySetup(int main_window){
       hvac_show_networks = 1;
       PANEL_hvac_network = glui_geometry->add_panel_to_panel(ROLLOUT_hvac, "networks");
     }
-    for (i = 0; i < hvaccoll.nhvacinfo; i++){
+    for (i = 0; i < global_scase.hvaccoll.nhvacinfo; i++){
       hvacdata* hvaci;
 
-      hvaci = hvaccoll.hvacinfo + i;
+      hvaci = global_scase.hvaccoll.hvacinfo + i;
       CHECKBOX_hvac_show_networks[i] = glui_geometry->add_checkbox_to_panel(PANEL_hvac_network, hvaci->network_name, &hvaci->display);
     }
-    if(hvaccoll.nhvacinfo > 1){
+    if(global_scase.hvaccoll.nhvacinfo > 1){
       glui_geometry->add_button_to_panel(PANEL_hvac_network, "show all", HVAC_SHOWALL_NETWORK, HvacCB);
       glui_geometry->add_button_to_panel(PANEL_hvac_network, "hide all", HVAC_HIDEALL_NETWORK, HvacCB);
       //      glui_geometry->add_checkbox_to_panel(ROLLOUT_hvac, "copy settings to all networks", &hvac_copy_all, HVAC_COPY_ALL, HvacCB);
     }
 
-    if(hvaccoll.nhvacconnectinfo>0){
-      NewMemory((void **)&CHECKBOX_hvac_show_connections, hvaccoll.nhvacconnectinfo*sizeof(GLUI_Checkbox *));
+    if(global_scase.hvaccoll.nhvacconnectinfo>0){
+      NewMemory((void **)&CHECKBOX_hvac_show_connections, global_scase.hvaccoll.nhvacconnectinfo*sizeof(GLUI_Checkbox *));
       glui_geometry->add_column_to_panel(PANEL_hvac_group1, false);
       PANEL_hvac_connections = glui_geometry->add_panel_to_panel(PANEL_hvac_group1, "connections");
-      for (i = 0; i < hvaccoll.nhvacconnectinfo; i++){
+      for (i = 0; i < global_scase.hvaccoll.nhvacconnectinfo; i++){
         hvacconnectdata *hi;
         char label[100];
 
-        hi = hvaccoll.hvacconnectinfo + i;
+        hi = global_scase.hvaccoll.hvacconnectinfo + i;
         snprintf(label, sizeof(label), "%i", hi->index);
         CHECKBOX_hvac_show_connections[i] = glui_geometry->add_checkbox_to_panel(PANEL_hvac_connections, label, &hi->display);
       }
-      if(hvaccoll.nhvacconnectinfo > 1){
+      if(global_scase.hvaccoll.nhvacconnectinfo > 1){
         glui_geometry->add_button_to_panel(PANEL_hvac_connections, "show all", HVAC_SHOWALL_CONNECTIONS, HvacCB);
         glui_geometry->add_button_to_panel(PANEL_hvac_connections, "hide all", HVAC_HIDEALL_CONNECTIONS, HvacCB);
       }
@@ -666,10 +666,10 @@ extern "C" void GLUIGeometrySetup(int main_window){
 
     LIST_hvac_network_ductnode_index = glui_geometry->add_listbox_to_panel(ROLLOUT_hvac, "set duct/node properties for:", &hvac_network_ductnode_index, HVAC_DUCTNODE_NETWORK, HvacCB);
     LIST_hvac_network_ductnode_index->add_item(-1, "all networks");
-    for(i = 0; i<hvaccoll.nhvacinfo; i++){
+    for(i = 0; i<global_scase.hvaccoll.nhvacinfo; i++){
       hvacdata *hvaci;
 
-      hvaci = hvaccoll.hvacinfo + i;
+      hvaci = global_scase.hvaccoll.hvacinfo + i;
       LIST_hvac_network_ductnode_index->add_item(i, hvaci->network_name);
     }
 
@@ -688,13 +688,13 @@ extern "C" void GLUIGeometrySetup(int main_window){
     glui_geometry->add_radiobutton_to_group(RADIO_hvac_show_component_labels, "hide");
     SPINNER_hvac_component_size = glui_geometry->add_spinner_to_panel(PANEL_hvac_components, "size", GLUI_SPINNER_FLOAT, &glui_hvac->component_size, HVAC_PROPS, HvacCB);
 
-    if(hvaccoll.hvacductvalsinfo!=NULL&&hvaccoll.hvacductvalsinfo->n_duct_vars>0){
-      LIST_hvacductvar_index = glui_geometry->add_listbox_to_panel(PANEL_hvac_duct, "quantity:", &hvaccoll.hvacductvar_index, HVAC_DUCT_LIST, HvacCB);
+    if(global_scase.hvaccoll.hvacductvalsinfo!=NULL&&global_scase.hvaccoll.hvacductvalsinfo->n_duct_vars>0){
+      LIST_hvacductvar_index = glui_geometry->add_listbox_to_panel(PANEL_hvac_duct, "quantity:", &global_scase.hvaccoll.hvacductvar_index, HVAC_DUCT_LIST, HvacCB);
       LIST_hvacductvar_index->add_item(-1, "");
-      for(i = 0;i < hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
+      for(i = 0;i < global_scase.hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
         hvacvaldata *hi;
 
-        hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
+        hi = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + i;
         LIST_hvacductvar_index->add_item(i, hi->label.shortlabel);
       }
       glui_geometry->add_button_to_panel(PANEL_hvac_duct, _("Set duct bounds"), HVACDUCT_SET_BOUNDS, HvacCB);
@@ -720,13 +720,13 @@ extern "C" void GLUIGeometrySetup(int main_window){
       SPINNER_hvac_duct_color[i]->set_int_limits(0, 255);
       SPINNER_hvac_node_color[i]->set_int_limits(0, 255);
     }
-    if(hvaccoll.hvacnodevalsinfo!=NULL&&hvaccoll.hvacnodevalsinfo->n_node_vars>0){
-      LIST_hvacnodevar_index = glui_geometry->add_listbox_to_panel(PANEL_hvac_node, "quantity:", &hvaccoll.hvacnodevar_index, HVAC_NODE_LIST, HvacCB);
+    if(global_scase.hvaccoll.hvacnodevalsinfo!=NULL&&global_scase.hvaccoll.hvacnodevalsinfo->n_node_vars>0){
+      LIST_hvacnodevar_index = glui_geometry->add_listbox_to_panel(PANEL_hvac_node, "quantity:", &global_scase.hvaccoll.hvacnodevar_index, HVAC_NODE_LIST, HvacCB);
       LIST_hvacnodevar_index->add_item(-1, "");
-      for(i = 0;i < hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
+      for(i = 0;i < global_scase.hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
         hvacvaldata *hi;
 
-        hi = hvaccoll.hvacnodevalsinfo->node_vars + i;
+        hi = global_scase.hvaccoll.hvacnodevalsinfo->node_vars + i;
         LIST_hvacnodevar_index->add_item(i, hi->label.shortlabel);
       }
       glui_geometry->add_button_to_panel(PANEL_hvac_node, _("Set duct bounds"), HVACDUCT_SET_BOUNDS, HvacCB);
@@ -750,15 +750,15 @@ extern "C" void GLUIGeometrySetup(int main_window){
 
     glui_geometry->add_column_to_panel(PANEL_faces, false);
 
-    if(nsurfinfo>0){
+    if(global_scase.surfcoll.nsurfinfo>0){
       glui_geometry->add_statictext_to_panel(PANEL_faces, "");
 
       LIST_obst_surface[DOWN_X] = glui_geometry->add_listbox_to_panel(PANEL_faces, _("Left"), surface_indices+DOWN_X, UPDATE_LIST, GLUIObjectCB);
       LIST_obst_surface[DOWN_X]->set_w(260);
-      for(i = 0; i<nsurfinfo; i++){
+      for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
         surfdata *surfi;
 
-        surfi = surfinfo+sorted_surfidlist[i];
+        surfi = global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[i];
         if(surfi->used_by_obst!=1)continue;
         if(surfi->obst_surface==0)continue;
         surfacelabel = surfi->surfacelabel;
@@ -767,10 +767,10 @@ extern "C" void GLUIGeometrySetup(int main_window){
 
       LIST_obst_surface[UP_X] = glui_geometry->add_listbox_to_panel(PANEL_faces, _("Right"), surface_indices+UP_X, UPDATE_LIST, GLUIObjectCB);
       LIST_obst_surface[UP_X]->set_w(260);
-      for(i = 0; i<nsurfinfo; i++){
+      for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
         surfdata *surfi;
 
-        surfi = surfinfo+sorted_surfidlist[i];
+        surfi = global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[i];
         if(surfi->used_by_obst!=1)continue;
         if(surfi->obst_surface==0)continue;
         surfacelabel = surfi->surfacelabel;
@@ -779,10 +779,10 @@ extern "C" void GLUIGeometrySetup(int main_window){
 
       LIST_obst_surface[DOWN_Y] = glui_geometry->add_listbox_to_panel(PANEL_faces, _("Front"), surface_indices+DOWN_Y, UPDATE_LIST, GLUIObjectCB);
       LIST_obst_surface[DOWN_Y]->set_w(260);
-      for(i = 0; i<nsurfinfo; i++){
+      for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
         surfdata *surfi;
 
-        surfi = surfinfo+sorted_surfidlist[i];
+        surfi = global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[i];
         if(surfi->used_by_obst!=1)continue;
         if(surfi->obst_surface==0)continue;
         surfacelabel = surfi->surfacelabel;
@@ -791,10 +791,10 @@ extern "C" void GLUIGeometrySetup(int main_window){
 
       LIST_obst_surface[UP_Y] = glui_geometry->add_listbox_to_panel(PANEL_faces, _("Back"), surface_indices+UP_Y, UPDATE_LIST, GLUIObjectCB);
       LIST_obst_surface[UP_Y]->set_w(260);
-      for(i = 0; i<nsurfinfo; i++){
+      for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
         surfdata *surfi;
 
-        surfi = surfinfo+sorted_surfidlist[i];
+        surfi = global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[i];
         if(surfi->used_by_obst!=1)continue;
         if(surfi->obst_surface==0)continue;
         surfacelabel = surfi->surfacelabel;
@@ -803,10 +803,10 @@ extern "C" void GLUIGeometrySetup(int main_window){
 
       LIST_obst_surface[DOWN_Z] = glui_geometry->add_listbox_to_panel(PANEL_faces, _("Down"), surface_indices+DOWN_Z, UPDATE_LIST, GLUIObjectCB);
       LIST_obst_surface[DOWN_Z]->set_w(260);
-      for(i = 0; i<nsurfinfo; i++){
+      for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
         surfdata *surfi;
 
-        surfi = surfinfo+sorted_surfidlist[i];
+        surfi = global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[i];
         if(surfi->used_by_obst!=1)continue;
         if(surfi->obst_surface==0)continue;
         surfacelabel = surfi->surfacelabel;
@@ -815,10 +815,10 @@ extern "C" void GLUIGeometrySetup(int main_window){
 
       LIST_obst_surface[UP_Z] = glui_geometry->add_listbox_to_panel(PANEL_faces, _("Up"), surface_indices+UP_Z, UPDATE_LIST, GLUIObjectCB);
       LIST_obst_surface[UP_Z]->set_w(260);
-      for(i = 0; i<nsurfinfo; i++){
+      for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
         surfdata *surfi;
 
-        surfi = surfinfo+sorted_surfidlist[i];
+        surfi = global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[i];
         if(surfi->used_by_obst!=1)continue;
         if(surfi->obst_surface==0)continue;
         surfacelabel = surfi->surfacelabel;
@@ -838,7 +838,7 @@ extern "C" void GLUIGeometrySetup(int main_window){
       char meshlabel[255];
 
       strcpy(meshlabel, _("Mesh:"));
-      strcat(meshlabel, meshinfo->label);
+      strcat(meshlabel, global_scase.meshescoll.meshinfo->label);
       STATIC_mesh_index = glui_geometry->add_statictext_to_panel(PANEL_obj_stretch4, meshlabel);
 
     }
@@ -884,17 +884,17 @@ extern "C" void GLUIGeometrySetup(int main_window){
     EDIT_zmax->set_float_limits(zplt_orig[0], zplt_orig[kbar], GLUI_LIMIT_CLAMP);
   }
 
-  if(ngeominfo>0){
+  if(global_scase.ngeominfo>0){
     have_geometry_dialog = 1;
     ROLLOUT_unstructured = glui_geometry->add_rollout("Immersed", false, UNSTRUCTURED_ROLLOUT, GeomRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_unstructured, glui_geometry);
     ADDPROCINFO(geomprocinfo, ngeomprocinfo, ROLLOUT_unstructured, UNSTRUCTURED_ROLLOUT, glui_geometry);
     if(unstructured_isopen==1)ROLLOUT_unstructured->open();
 
-    for(i = 0; i<nmeshes; i++){
+    for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
       meshdata *meshi;
 
-      meshi = meshinfo+i;
+      meshi = global_scase.meshescoll.meshinfo+i;
       if(meshi->ncutcells>0){
         glui_geometry->add_checkbox_to_panel(ROLLOUT_unstructured, _("Show cutcells"), &show_cutcells);
         break;
@@ -911,7 +911,7 @@ extern "C" void GLUIGeometrySetup(int main_window){
     CHECKBOX_surface_outline = glui_geometry->add_checkbox_to_panel(PANEL_triangles, "outline", &show_faces_outline, VOL_SHOWHIDE, VolumeCB);
     CHECKBOX_surface_points = glui_geometry->add_checkbox_to_panel(PANEL_triangles,  "points",  &show_geom_verts,    VOL_SHOWHIDE, VolumeCB);
 
-    if(ncgeominfo>0){
+    if(global_scase.ncgeominfo>0){
       glui_geometry->add_column_to_panel(PANEL_face_cface, false);
       PANEL_cfaces = glui_geometry->add_panel_to_panel(PANEL_face_cface, "cfaces");
       PANEL_cfaces->set_alignment(GLUI_ALIGN_LEFT);
@@ -994,10 +994,10 @@ extern "C" void GLUIGeometrySetup(int main_window){
       int ii;
 
       ii = 0;
-      for(i = 0; i<nsurfinfo; i++){
+      for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
         surfdata *surfi;
 
-        surfi = surfinfo+sorted_surfidlist[i];
+        surfi = global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[i];
         if(surfi->used_by_geom==1){
           char label[100];
 
@@ -1073,13 +1073,13 @@ extern "C" void GLUIGeometrySetup(int main_window){
     SPINNER_geom_vert_exag = glui_geometry->add_spinner_to_panel(PANEL_geomtest2, "vertical exaggeration", GLUI_SPINNER_FLOAT, &geom_vert_exag, GEOM_VERT_EXAG, VolumeCB);
     SPINNER_geom_vert_exag->set_float_limits(0.1, 10.0);
 
-    if(nterrain_textures>0){
-      NewMemory((void **)&CHECKBOX_terrain_texture_show, sizeof(GLUI_Checkbox *)*nterrain_textures);
+    if(global_scase.terrain_texture_coll.nterrain_textures>0){
+      NewMemory((void **)&CHECKBOX_terrain_texture_show, sizeof(GLUI_Checkbox *)*global_scase.terrain_texture_coll.nterrain_textures);
       PANEL_terrain_images = glui_geometry->add_panel_to_panel(PANEL_group1, "terrain images");
-      for(i = 0; i<nterrain_textures; i++){
+      for(i = 0; i<global_scase.terrain_texture_coll.nterrain_textures; i++){
         texturedata *texti;
 
-        texti = terrain_textures+i;
+        texti = global_scase.terrain_texture_coll.terrain_textures+i;
         if(texti->loaded==1){
           CHECKBOX_terrain_texture_show[i] = glui_geometry->add_checkbox_to_panel(PANEL_terrain_images, texti->file, &(texti->display), i, TerrainTextureCB);
         }
@@ -1109,7 +1109,7 @@ extern "C" void GLUIGeometrySetup(int main_window){
     BUTTON_reset_zbounds = glui_geometry->add_button_to_panel(PANEL_elevation_color, _("Reset"), RESET_ZBOUNDS, VolumeCB);
   }
 
-  if(nterraininfo>0&&ngeominfo==0){
+  if(global_scase.nterraininfo>0&&global_scase.ngeominfo==0){
     have_geometry_dialog = 1;
     ROLLOUT_terrain = glui_geometry->add_rollout("Terrain", false, TERRAIN_ROLLOUT, GeomRolloutCB);
     INSERT_ROLLOUT(ROLLOUT_terrain, glui_geometry);
@@ -1117,7 +1117,7 @@ extern "C" void GLUIGeometrySetup(int main_window){
 
     CHECKBOX_terrain_top_surface = glui_geometry->add_checkbox_to_panel(ROLLOUT_terrain, "Show only top surface",
       &terrain_showonly_top, TERRAIN_TOP_ONLY, TerrainCB);
-    RADIO_terrain_type = glui_geometry->add_radiogroup_to_panel(ROLLOUT_terrain, &visTerrainType, TERRAIN_TYPE, TerrainCB);
+    RADIO_terrain_type = glui_geometry->add_radiogroup_to_panel(ROLLOUT_terrain, &global_scase.visTerrainType, TERRAIN_TYPE, TerrainCB);
     glui_geometry->add_radiobutton_to_group(RADIO_terrain_type, "3D surface");
     glui_geometry->add_radiobutton_to_group(RADIO_terrain_type, "Image");
     glui_geometry->add_radiobutton_to_group(RADIO_terrain_type, "Hidden");
@@ -1147,7 +1147,7 @@ extern "C" void GLUIGeometrySetup(int main_window){
 void TerrainCB(int var){
   switch(var){
     case TERRAIN_TYPE:
-      GeometryMenu(17+visTerrainType);
+      GeometryMenu(17+global_scase.visTerrainType);
       break;
     case TERRAIN_TOP_ONLY:
       terrain_showonly_top = 1 - terrain_showonly_top;
@@ -1167,8 +1167,8 @@ void GetGeomZBounds(float *zmin, float *zmax){
   geomlistdata *terrain;
   int first = 1;
 
-  if(geominfo->geomlistinfo == NULL)return;
-  terrain = geominfo->geomlistinfo - 1;
+  if(global_scase.geominfo->geomlistinfo == NULL)return;
+  terrain = global_scase.geominfo->geomlistinfo - 1;
 
   for(i = 0; i < terrain->nverts; i++){
     vertdata *verti;
@@ -1196,10 +1196,10 @@ void VolumeCB(int var){
   int i;
   switch(var){
   case SURF_GET:
-    for(i = 0; i<nsurfinfo; i++){
+    for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
       surfdata *surfi;
 
-      surfi = surfinfo+sorted_surfidlist[i];
+      surfi = global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[i];
       if(surfi->in_geom_list==geom_surf_index){
         int *rgb_local;
         float *axis;
@@ -1224,10 +1224,10 @@ void VolumeCB(int var){
     }
     break;
   case SURF_SET:
-    for(i = 0; i<nsurfinfo; i++){
+    for(i = 0; i<global_scase.surfcoll.nsurfinfo; i++){
       surfdata *surfi;
 
-      surfi = surfinfo+sorted_surfidlist[i];
+      surfi = global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[i];
       if(surfi->in_geom_list==geom_surf_index){
         int *rgb_local;
         float *axis;
@@ -1301,11 +1301,11 @@ void VolumeCB(int var){
     SPINNER_geom_zlevel->set_float_limits(terrain_zmin, terrain_zmax);
     UpdateChopColors();
   case SHOW_TEXTURE_1D_IMAGE:
-    if(show_texture_1dimage == 1&&nterrain_textures>0){
-      for(i=0; i<nterrain_textures; i++){
+    if(show_texture_1dimage == 1&&global_scase.terrain_texture_coll.nterrain_textures>0){
+      for(i=0; i<global_scase.terrain_texture_coll.nterrain_textures; i++){
         texturedata *texti;
 
-        texti = terrain_textures+i;
+        texti = global_scase.terrain_texture_coll.terrain_textures+i;
         if(texti->loaded==1){
           texti->display = 0;
           GLUIUpdateTerrainTexture(i);
@@ -1434,7 +1434,7 @@ extern "C" void GLUIUpdateBlockVals(int flag){
   EDIT_ymax->set_float_val(ymax);
   EDIT_zmin->set_float_val(zmin);
   EDIT_zmax->set_float_val(zmax);
-  if(bchighlight!=NULL&&nsurfinfo>0){
+  if(bchighlight!=NULL&&global_scase.surfcoll.nsurfinfo>0){
     wall_case=bchighlight->walltype;
     GLUIObjectCB(RADIO_WALL);
   }
@@ -1445,8 +1445,8 @@ extern "C" void GLUIUpdateBlockVals(int flag){
       char dialog_id[255];
       meshdata *blockmesh;
 
-      if(nmeshes>1){
-        blockmesh = meshinfo + bchighlight->meshindex;
+      if(global_scase.meshescoll.nmeshes>1){
+        blockmesh = global_scase.meshescoll.meshinfo + bchighlight->meshindex;
 //        sprintf(dialog_label,"Mesh label: %s",blockmesh->label);
         snprintf(dialog_label,sizeof(dialog_label),"Mesh label: %s",blockmesh->label);
         STATIC_mesh_index->set_text(dialog_label);
@@ -1481,19 +1481,19 @@ extern "C" void GLUIUpdateBlockVals(int flag){
         break;
       }
 
-      if(nsurfinfo>0){
+      if(global_scase.surfcoll.nsurfinfo>0){
         for(i=0;i<6;i++){
-          surface_indices[i] = inv_sorted_surfidlist[bchighlight->surf_index[i]];
-          surface_indices_bak[i] = inv_sorted_surfidlist[bchighlight->surf_index[i]];
+          surface_indices[i] = global_scase.surfcoll.inv_sorted_surfidlist[bchighlight->surf_index[i]];
+          surface_indices_bak[i] = global_scase.surfcoll.inv_sorted_surfidlist[bchighlight->surf_index[i]];
           LIST_obst_surface[i]->set_int_val(surface_indices[i]);
         }
       }
     }
     else{
-      if(nsurfinfo>0){
+      if(global_scase.surfcoll.nsurfinfo>0){
         for(i=0;i<6;i++){
-          surface_indices[i]=inv_sorted_surfidlist[0];
-          surface_indices_bak[i]=inv_sorted_surfidlist[0];
+          surface_indices[i]=global_scase.surfcoll.inv_sorted_surfidlist[0];
+          surface_indices_bak[i]=global_scase.surfcoll.inv_sorted_surfidlist[0];
           LIST_obst_surface[i]->set_int_val(surface_indices[i]);
         }
       }
@@ -1513,7 +1513,7 @@ extern "C" void GLUIObjectCB(int var){
       switch(wall_case){
       case WALL_1:
         temp=surface_indices_bak[UP_Z];
-        if(nsurfinfo>0){
+        if(global_scase.surfcoll.nsurfinfo>0){
           for(i=0;i<6;i++){
             surface_indices[i]=temp;
             LIST_obst_surface[i]->set_int_val(temp);
@@ -1521,7 +1521,7 @@ extern "C" void GLUIObjectCB(int var){
         }
         break;
       case WALL_3:
-        if(nsurfinfo>0){
+        if(global_scase.surfcoll.nsurfinfo>0){
           for(i=0;i<6;i++){
             temp=surface_indices_bak[i];
             surface_indices[i]=temp;
@@ -1530,7 +1530,7 @@ extern "C" void GLUIObjectCB(int var){
         }
         break;
       case WALL_6:
-        if(nsurfinfo>0){
+        if(global_scase.surfcoll.nsurfinfo>0){
           for(i=0;i<6;i++){
             temp=surface_indices_bak[i];
             surface_indices[i]=temp;
@@ -1545,8 +1545,8 @@ extern "C" void GLUIObjectCB(int var){
 
       if(bchighlight!=NULL){
         for(i=0;i<6;i++){
-          bchighlight->surf[i]=surfinfo+sorted_surfidlist[surface_indices_bak[i]];
-          bchighlight->surf_index[i]=sorted_surfidlist[surface_indices_bak[i]];
+          bchighlight->surf[i]=global_scase.surfcoll.surfinfo+global_scase.surfcoll.sorted_surfidlist[surface_indices_bak[i]];
+          bchighlight->surf_index[i]=global_scase.surfcoll.sorted_surfidlist[surface_indices_bak[i]];
         }
         bchighlight->changed_surface=1;
         if(bchighlight->blockage_id>0&&bchighlight->blockage_id<=nchanged_idlist){
@@ -1558,7 +1558,7 @@ extern "C" void GLUIObjectCB(int var){
       }
       break;
     case RADIO_WALL:
-      if(nsurfinfo==0)break;
+      if(global_scase.surfcoll.nsurfinfo==0)break;
       if(bchighlight!=NULL){
         bchighlight->walltype=wall_case;
       }

--- a/Source/smokeview/glui_objects.cpp
+++ b/Source/smokeview/glui_objects.cpp
@@ -291,7 +291,7 @@ extern "C" void GLUIUpdateWindRoseDevices(int option){
       vdevicesortdata *vdevsorti;
       vdevicedata *vd;
 
-      vdevsorti = vdevices_sorted+j;
+      vdevsorti = global_scase.devicecoll.vdevices_sorted+j;
       vd = vdevsorti->vdeviceinfo;
       if(vd->udev==NULL&&vd->vdev==NULL&&vd->wdev==NULL&&
          vd->angledev == NULL&&vd->veldev == NULL)continue;
@@ -363,7 +363,7 @@ void UpdateShowWindRoses(void){
       vdevicesortdata *vdevsorti;
       vdevicedata *vd;
 
-      vdevsorti = vdevices_sorted + j;
+      vdevsorti = global_scase.devicecoll.vdevices_sorted + j;
       vd = vdevsorti->vdeviceinfo;
       if(vd->udev==NULL&&vd->vdev==NULL&&vd->wdev==NULL&&
          vd->angledev == NULL&&vd->veldev == NULL)continue;
@@ -493,13 +493,13 @@ void AddCSVCurve(plot2ddata *plot2di, int index, int option){
       if(unit!=curve->scaled_unit)strcpy(curve->scaled_unit,  unit);
     }
     else{
-      csvfi  = csvfileinfo+curve->csv_file_index;
+      csvfi  = global_scase.csvcoll.csvfileinfo+curve->csv_file_index;
       c_type = curve->c_type;
       csvi   = csvfi->csvinfo+curve->csv_col_index;
     }
     if(c_type!=curve->c_type)strcpy(curve->c_type, c_type);
     if(strcmp(c_type, "devc")==0){
-      curve->quantity = deviceinfo[curve->csv_col_index-1].quantity;
+      curve->quantity = global_scase.devicecoll.deviceinfo[curve->csv_col_index-1].quantity;
     }
     plot2di->ncurves = nplots+1;
     strcpy(label, c_type);
@@ -771,7 +771,7 @@ void FilterList(void){
         strcpy(unit_label, "dimensionless");
       }
     }
-    if(isZoneFireModel==1){
+    if(global_scase.isZoneFireModel==1){
       compartment_id = LIST_curve_compartments->get_int_val();
     }
     for(i = 0; i < csvfi->ncsvinfo; i++){
@@ -785,7 +785,7 @@ void FilterList(void){
       if(doit==0&&csvi->dimensionless == 1 && strcmp(unit_label, "dimensionless")==0)doit = 1;
       if(doit==0&&csvi->dimensionless == 0 && strcmp(unit_label, csvi->label.unit) == 0)doit = 1;
       if(doit==0)continue;
-      if(isZoneFireModel==1&&compartment_id>=0){
+      if(global_scase.isZoneFireModel==1&&compartment_id>=0){
         if(
           strcmp(csvfi->c_type, "compartments") == 0 ||
           strcmp(csvfi->c_type, "masses") == 0       ||
@@ -818,7 +818,7 @@ char *GetCsvType(void){
   csvfiledata *csvfi;
 
   if(glui_csv_file_index>=0){
-    csvfi = csvfileinfo+glui_csv_file_index;
+    csvfi = global_scase.csvcoll.csvfileinfo+glui_csv_file_index;
     return csvfi->c_type;
   }
   else{
@@ -1012,7 +1012,7 @@ int InDevList(devicedata *devi, int n){
   for(j = 0; j<n; j++){
     devicedata *devj;
 
-    devj = deviceinfo+j;
+    devj = global_scase.devicecoll.deviceinfo+j;
     if(strcmp(devi->quantity, devj->quantity)==0&&devj->inlist==1)return 1;
   }
   return 0;
@@ -1023,25 +1023,25 @@ int InDevList(devicedata *devi, int n){
 void UpdatePlotDevList(void){
   int i;
 
-  for(i = 0; i<ndeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
     devicedata *devi;
 
-    devi = deviceinfo + i;
+    devi = global_scase.devicecoll.deviceinfo + i;
     devi->inlist = 0;
   }
   LIST_plot_add_dev->delete_item(-1);
-  for(i = 0; i<ndeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
     devicedata *devi;
 
-    devi = deviceinfo+i;
+    devi = global_scase.devicecoll.deviceinfo+i;
     devi->inlist = 1 - InDevList(devi, i);
     LIST_plot_add_dev->delete_item(i);
   }
   LIST_plot_add_dev->add_item(-1, "");
-  for(i = 0; i<ndeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
     devicedata *devi;
 
-    devi = deviceinfo+i;
+    devi = global_scase.devicecoll.deviceinfo+i;
     if(devi->inlist==1){
       char label[64];
 
@@ -1126,7 +1126,7 @@ void GLUIGenPlotCB(int var){
       unit = GetPlotUnit(glui_plot2dinfo, index);
       UpdateCurveControls(unit);
       if(BUTTON_plot_position != NULL){
-        if(glui_plot2dinfo->curve_index<ndeviceinfo){
+        if(glui_plot2dinfo->curve_index<global_scase.devicecoll.ndeviceinfo){
         }
         else{
           strcpy(label, "Set to device location");
@@ -1221,10 +1221,10 @@ void GLUIGenPlotCB(int var){
       SetPlot2DShowLabel();
       break;
     case GENPLOT_SET_PLOTPOS:
-      if(glui_plot2dinfo->curve_index<ndeviceinfo){
+      if(glui_plot2dinfo->curve_index<global_scase.devicecoll.ndeviceinfo){
         float *plot_xyz;
 
-        plot_xyz = deviceinfo[glui_plot2dinfo->curve_index].xyz;
+        plot_xyz = global_scase.devicecoll.deviceinfo[glui_plot2dinfo->curve_index].xyz;
         memcpy(glui_plot2dinfo->xyz, plot_xyz, 3 * sizeof(float));
         SPINNER_genplot_x->set_float_val(plot_xyz[0]);
         SPINNER_genplot_y->set_float_val(plot_xyz[1]);
@@ -1321,7 +1321,7 @@ void GLUIGenPlotCB(int var){
     case GENPLOT_RESET_DEV_PLOTS:
       char *dev_pos;
 
-      dev_pos = deviceinfo[idevice_add].quantity;
+      dev_pos = global_scase.devicecoll.deviceinfo[idevice_add].quantity;
       for(i = 0; i<nplot2dinfo; i++){
         plot2ddata *plot2di;
         curvedata *curvei;
@@ -1344,18 +1344,18 @@ void GLUIGenPlotCB(int var){
       char *dev_quant;
 
       GLUIGenPlotCB(GENPLOT_REM_DEV_PLOTS);
-      dev_quant = deviceinfo[idevice_add].quantity;
+      dev_quant = global_scase.devicecoll.deviceinfo[idevice_add].quantity;
       glui_csv_file_index = 0;
       LIST_csvfile->set_int_val(glui_csv_file_index);
       GLUIGenPlotCB(GENPLOT_CSV_FILETYPE);
-      for(i=0;i<ndeviceinfo;i++){
+      for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
         devicedata *devi;
 
-        devi = deviceinfo + i;
+        devi = global_scase.devicecoll.deviceinfo + i;
         if(strcmp(devi->quantity, dev_quant)!=0)continue;
         GLUIGenPlotCB(GENPLOT_ADD_PLOT);
 
-        icsv_cols = devi - deviceinfo +1;
+        icsv_cols = devi - global_scase.devicecoll.deviceinfo +1;
         LIST_csvID->set_int_val(icsv_cols);
         GLUIGenPlotCB(GENPLOT_ADD_CURVE);
 
@@ -1545,7 +1545,7 @@ extern "C" void GLUIDeviceCB(int var){
     for(j = treei->first; j<=treei->last; j++){
       vdevicesortdata *vdevsorti;
 
-      vdevsorti = vdevices_sorted+j;
+      vdevsorti = global_scase.devicecoll.vdevices_sorted+j;
       if(vdevsorti->dir==ZDIR){
         vdevicedata *vd;
 
@@ -1566,7 +1566,7 @@ extern "C" void GLUIDeviceCB(int var){
     for(j = treei->first; j<=treei->last; j++){
       vdevicesortdata *vdevsorti;
 
-      vdevsorti = vdevices_sorted+j;
+      vdevsorti = global_scase.devicecoll.vdevices_sorted+j;
       if(vdevsorti->dir==ZDIR){
         vdevicedata *vd;
 
@@ -1594,10 +1594,10 @@ extern "C" void GLUIDeviceCB(int var){
     updatemenu = 1;
     break;
   case DEVICE_TIMEAVERAGE:
-    for(i = 0; i<ndeviceinfo; i++){
+    for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
       devicedata *devicei;
 
-      devicei = deviceinfo+i;
+      devicei = global_scase.devicecoll.deviceinfo+i;
       devicei->update_avg = 1;
     }
     for(i = 0; i<nplot2dinfo; i++){
@@ -1699,11 +1699,11 @@ float GetDeviceTminTmax(void){
   float return_val=1.0;
   int first = 1, i;
 
-  for(i = 0; i<ndeviceinfo; i++){
+  for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
     devicedata *devicei;
     float *times;
 
-    devicei = deviceinfo+i;
+    devicei = global_scase.devicecoll.deviceinfo+i;
     times = devicei->times;
     if(times!=NULL&&devicei->nvals>0){
       float tval;
@@ -1726,10 +1726,10 @@ float GetDeviceTminTmax(void){
 int HaveExt(void){
   int i;
 
-  for(i = 0; i<ncsvfileinfo; i++){
+  for(i = 0; i<global_scase.csvcoll.ncsvfileinfo; i++){
     csvfiledata *csvfi;
 
-    csvfi = csvfileinfo+i;
+    csvfi = global_scase.csvcoll.csvfileinfo+i;
     if(strcmp(csvfi->c_type, "ext")==0)return 1;
   }
   return 0;
@@ -1761,10 +1761,10 @@ extern "C" void GLUIUpdatePlot2DINI(void){
 void UpdateCSVFileTypes(void){
   int i;
 
-  for(i = 0; i<ncsvfileinfo; i++){
+  for(i = 0; i<global_scase.csvcoll.ncsvfileinfo; i++){
     csvfiledata *csvfi;
 
-    csvfi = csvfileinfo+i;
+    csvfi = global_scase.csvcoll.csvfileinfo+i;
     if(strcmp(csvfi->c_type, "ext")!=0 && csvfi->glui_defined==0 && csvfi->defined == CSV_DEFINED && LIST_csvfile != NULL){
       csvfi->glui_defined = CSV_DEFINED;
       LIST_csvfile->add_item(i, csvfi->c_type);
@@ -1777,8 +1777,8 @@ void UpdateCSVFileTypes(void){
 extern "C" void GLUIUpdatePlot2DTbounds(void){
   use_tload_end2 = use_tload_end;
   use_tload_begin2 = use_tload_begin;
-  tload_end2 = tload_end;
-  tload_begin2 = tload_begin;
+  tload_end2 = global_scase.tload_end;
+  tload_begin2 = global_scase.tload_begin;
   if(CHECKBOX_genplot_use_valmax[2]!=NULL)CHECKBOX_genplot_use_valmax[2]->set_int_val(use_tload_end2);
   if(CHECKBOX_genplot_use_valmin[2]!=NULL)CHECKBOX_genplot_use_valmin[2]->set_int_val(use_tload_begin2);
   if(SPINNER_genplot_valmax[2]!=NULL)SPINNER_genplot_valmax[2]->set_float_val(tload_end2);
@@ -1794,7 +1794,7 @@ extern "C" void GLUIPlot2DSetup(int main_window){
   }
 
   have_ext = HaveExt();
-  if((ncsvfileinfo>0&&have_ext==0)||(ncsvfileinfo>1&&have_ext==1)){
+  if((global_scase.csvcoll.ncsvfileinfo>0&&have_ext==0)||(global_scase.csvcoll.ncsvfileinfo>1&&have_ext==1)){
     int i;
 
     glui_plot2d = GLUI_Master.create_glui("2D plots", 0, dialogX0, dialogY0);
@@ -1813,18 +1813,18 @@ extern "C" void GLUIPlot2DSetup(int main_window){
     CHECKBOX_show_genplot  = glui_plot2d->add_checkbox_to_panel(PANEL_plots, "show", &(glui_plot2dinfo->show), GENPLOT_SHOW_PLOT, GLUIGenPlotCB);
     glui_plot2d->add_checkbox_to_panel(PANEL_plots, "show plots", &plot2d_show_plots, GENPLOT_SHOW_PLOTS, GLUIGenPlotCB);
 
-    if(ndeviceinfo>0){
+    if(global_scase.devicecoll.ndeviceinfo>0){
       ROLLOUT_devplots = glui_plot2d->add_rollout_to_panel(PANEL_plots, "add plots at device locations", 0);
-      for(i = 0; i<ndeviceinfo; i++){
+      for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
         devicedata *devi;
 
-        devi = deviceinfo+i;
+        devi = global_scase.devicecoll.deviceinfo+i;
         devi->inlist = 0;
       }
-      for(i = 0; i<ndeviceinfo; i++){
+      for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
         devicedata *devi;
 
-        devi = deviceinfo+i;
+        devi = global_scase.devicecoll.deviceinfo+i;
         devi->inlist = 1-InDevList(devi, i);
       }
       LIST_plot_add_dev = glui_plot2d->add_listbox_to_panel(ROLLOUT_devplots,    "Add:",    &idevice_add,  GENPLOT_ADD_DEV_PLOTS,  GLUIGenPlotCB);
@@ -1847,9 +1847,9 @@ extern "C" void GLUIPlot2DSetup(int main_window){
     LIST_curve_unit = glui_plot2d->add_listbox_to_panel(PANEL_add_curve1, "unit:",    &icsv_units, GENPLOT_CURVE_UNIT, GLUIGenPlotCB);
     LIST_curve_unit->add_item(-1, "any");
 
-    if(isZoneFireModel==1){
+    if(global_scase.isZoneFireModel==1){
       LIST_curve_compartments = glui_plot2d->add_listbox_to_panel(PANEL_add_curve1, "compartment:", &icsv_compartments, GENPLOT_CURVE_UNIT, GLUIGenPlotCB);
-      for(i = 0;i < nrooms;i++){
+      for(i = 0;i < global_scase.nrooms;i++){
         char label[100];
 
         snprintf(label, sizeof(label), "%i", i + 1);
@@ -2028,7 +2028,7 @@ extern "C" void GLUIDeviceSetup(int main_window){
   glui_device = GLUI_Master.create_glui("Devices/Objects/2D plots",0,dialogX0,dialogY0);
   glui_device->hide();
 
-  if(ndeviceinfo>0){
+  if(global_scase.devicecoll.ndeviceinfo>0){
     int i;
 
     PANEL_objects = glui_device->add_panel("Devices/Objects/2D plots", false);
@@ -2042,7 +2042,7 @@ extern "C" void GLUIDeviceSetup(int main_window){
     CHECKBOX_device_orientation = glui_device->add_checkbox_to_panel(ROLLOUT_smvobjects, _("Orientation"), &show_device_orientation, DEVICE_show_orientation, GLUIDeviceCB);
     SPINNER_orientation_scale = glui_device->add_spinner_to_panel(ROLLOUT_smvobjects, _("Orientation scale"), GLUI_SPINNER_FLOAT, &orientation_scale);
     SPINNER_orientation_scale->set_float_limits(0.1, 10.0);
-    if(have_beam){
+    if(global_scase.have_beam){
       PANEL_beam = glui_device->add_panel_to_panel(ROLLOUT_smvobjects, "Beam sensor", true);
       CHECKBOX_showbeam_as_line = glui_device->add_checkbox_to_panel(PANEL_beam, _("Show beam as line"), &showbeam_as_line, DEVICE_SHOWBEAM, GLUIDeviceCB);
       SPINNER_beam_line_width = glui_device->add_spinner_to_panel(PANEL_beam, _("line width"), GLUI_SPINNER_FLOAT, &beam_line_width);
@@ -2056,12 +2056,12 @@ extern "C" void GLUIDeviceSetup(int main_window){
       SPINNER_beam_color[2]->set_int_limits(0, 255);
     }
 
-    if(GetNumActiveDevices()>0||isZoneFireModel==1){
+    if(GetNumActiveDevices()>0||global_scase.isZoneFireModel==1){
       ROLLOUT_velocityvectors = glui_device->add_rollout_to_panel(PANEL_objects, "Flow vectors", false, FLOWVECTORS_ROLLOUT, Device_Rollout_CB);
       INSERT_ROLLOUT(ROLLOUT_velocityvectors, glui_device);
       ADDPROCINFO(deviceprocinfo, ndeviceprocinfo, ROLLOUT_velocityvectors, FLOWVECTORS_ROLLOUT, glui_device);
 
-      if(nvdeviceinfo==0)ROLLOUT_velocityvectors->disable();
+      if(global_scase.devicecoll.nvdeviceinfo==0)ROLLOUT_velocityvectors->disable();
       CHECKBOX_device_1 = glui_device->add_checkbox_to_panel(ROLLOUT_velocityvectors, _("Show"), &showvdevice_val);
       PANEL_vector_type = glui_device->add_panel_to_panel(ROLLOUT_velocityvectors, _("type"), true);
       RADIO_vectortype = glui_device->add_radiogroup_to_panel(PANEL_vector_type, &vectortype);
@@ -2157,7 +2157,7 @@ extern "C" void GLUIDeviceSetup(int main_window){
             vdevicesortdata *vdevsorti;
             vdevicedata *vd;
 
-            vdevsorti = vdevices_sorted+j;
+            vdevsorti = global_scase.devicecoll.vdevices_sorted+j;
             vd = vdevsorti->vdeviceinfo;
             if(vd->udev==NULL&&vd->vdev==NULL&&vd->wdev==NULL&&
                vd->angledev==NULL&&vd->veldev==NULL)continue;
@@ -2197,7 +2197,7 @@ extern "C" void GLUIDeviceSetup(int main_window){
             vdevicesortdata *vdevsorti;
             vdevicedata *vd;
 
-            vdevsorti = vdevices_sorted+j;
+            vdevsorti = global_scase.devicecoll.vdevices_sorted+j;
             vd = vdevsorti->vdeviceinfo;
             xyz = NULL;
             if(xyz==NULL&&vd->udev!=NULL)xyz = vd->udev->xyz;

--- a/Source/smokeview/glui_shooter.cpp
+++ b/Source/smokeview/glui_shooter.cpp
@@ -294,22 +294,22 @@ extern "C" void GLUIShooterSetup(int main_window){
   PANEL_shooter_frameB=glui_shooter->add_panel_to_panel(PANEL_shooter_frameE,_("Size"));
 
   SPINNER_shooter_x=glui_shooter->add_spinner_to_panel(PANEL_shooter_frameA,"x",GLUI_SPINNER_FLOAT,shooter_xyz,SHOOTER_XYZ,ShooterCB);
-  SPINNER_shooter_x->set_float_limits(xbar0,xbarORIG);
+  SPINNER_shooter_x->set_float_limits(global_scase.xbar0,xbarORIG);
 
   SPINNER_shooter_y=glui_shooter->add_spinner_to_panel(PANEL_shooter_frameA,"y",GLUI_SPINNER_FLOAT,shooter_xyz+1,SHOOTER_XYZ,ShooterCB);
-  SPINNER_shooter_y->set_float_limits(ybar0,ybarORIG);
+  SPINNER_shooter_y->set_float_limits(global_scase.ybar0,ybarORIG);
 
   SPINNER_shooter_z=glui_shooter->add_spinner_to_panel(PANEL_shooter_frameA,"z",GLUI_SPINNER_FLOAT,shooter_xyz+2,SHOOTER_XYZ,ShooterCB);
-  SPINNER_shooter_z->set_float_limits(zbar0,zbarORIG);
+  SPINNER_shooter_z->set_float_limits(global_scase.zbar0,zbarORIG);
 
   SPINNER_shooter_dx=glui_shooter->add_spinner_to_panel(PANEL_shooter_frameB,"dx",GLUI_SPINNER_FLOAT,shooter_dxyz,SHOOTER_DXYZ,ShooterCB);
-  SPINNER_shooter_dx->set_float_limits(0.0,xbarORIG-xbar0);
+  SPINNER_shooter_dx->set_float_limits(0.0,xbarORIG-global_scase.xbar0);
 
   SPINNER_shooter_dy=glui_shooter->add_spinner_to_panel(PANEL_shooter_frameB,"dy",GLUI_SPINNER_FLOAT,shooter_dxyz+1,SHOOTER_DXYZ,ShooterCB);
-  SPINNER_shooter_dy->set_float_limits(0.0,ybarORIG-ybar0);
+  SPINNER_shooter_dy->set_float_limits(0.0,ybarORIG-global_scase.ybar0);
 
   SPINNER_shooter_dz=glui_shooter->add_spinner_to_panel(PANEL_shooter_frameB,"dz",GLUI_SPINNER_FLOAT,shooter_dxyz+2,SHOOTER_DXYZ,ShooterCB);
-  SPINNER_shooter_dz->set_float_limits(0.0,zbarORIG-zbar0);
+  SPINNER_shooter_dz->set_float_limits(0.0,zbarORIG-global_scase.zbar0);
 
   PANEL_shooter_frameF=glui_shooter->add_panel_to_panel(ROLLOUT_shooter_frame,_("Velocities"));
   SPINNER_shooter_u=glui_shooter->add_spinner_to_panel(PANEL_shooter_frameF,"u",GLUI_SPINNER_FLOAT,shooter_uvw,SHOOTER_UVW,ShooterCB);

--- a/Source/smokeview/glui_smoke.cpp
+++ b/Source/smokeview/glui_smoke.cpp
@@ -308,7 +308,7 @@ void SmokeRolloutCB(int var){
   int i;
 
   if(LISTBOX_VOL_tour==NULL)return;
-  for(i=0;i<tourcoll.ntourinfo;i++){
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
     LISTBOX_VOL_tour->delete_item(i);
   }
 }
@@ -319,11 +319,11 @@ extern "C" void GLUICreateVolTourList(void){
   int i;
 
   if(LISTBOX_VOL_tour==NULL)return;
-  for(i=0;i<tourcoll.ntourinfo;i++){
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
     tourdata *touri;
     char label[1000];
 
-    touri = tourcoll.tourinfo + i;
+    touri = global_scase.tourcoll.tourinfo + i;
     strcpy(label,"");
     if(i==selectedtour_index)strcat(label,"*");
     if(strlen(touri->label)>0)strcat(label,touri->label);
@@ -334,7 +334,7 @@ extern "C" void GLUICreateVolTourList(void){
       LISTBOX_VOL_tour->add_item(i,"error");
     }
   }
-  if(selectedtour_index>=TOURINDEX_MANUAL&&selectedtour_index<tourcoll.ntourinfo){
+  if(selectedtour_index>=TOURINDEX_MANUAL&&selectedtour_index<global_scase.tourcoll.ntourinfo){
     LISTBOX_VOL_tour->set_int_val(selectedtour_index);
   }
 }
@@ -363,9 +363,9 @@ extern "C" void GLUI3dSmokeSetup(int main_window){
   int i;
 
 
-  if(smoke3dcoll.nsmoke3dinfo<=0&&nvolrenderinfo<=0)return;
+  if(global_scase.smoke3dcoll.nsmoke3dinfo<=0&&nvolrenderinfo<=0)return;
   if(CHECKBOX_meshvisptr!=NULL)FREEMEMORY(CHECKBOX_meshvisptr);
-  NewMemory((void **)&CHECKBOX_meshvisptr,nmeshes*sizeof(GLUI_Checkbox *));
+  NewMemory((void **)&CHECKBOX_meshvisptr,global_scase.meshescoll.nmeshes*sizeof(GLUI_Checkbox *));
 
   glui_3dsmoke=glui_bounds;
 
@@ -411,7 +411,7 @@ extern "C" void GLUI3dSmokeSetup(int main_window){
 
   //---------------------------------------------Slice render settings--------------------------------------------------------------
 
-  if(smoke3dcoll.nsmoke3dinfo>0){
+  if(global_scase.smoke3dcoll.nsmoke3dinfo>0){
     if(nvolrenderinfo > 0){
       ROLLOUT_slices = glui_3dsmoke->add_rollout_to_panel(ROLLOUT_smoke3d, _("Slice render settings"), false, SLICERENDER_ROLLOUT, SmokeRolloutCB);
       INSERT_ROLLOUT(ROLLOUT_slices, glui_3dsmoke);
@@ -427,7 +427,7 @@ extern "C" void GLUI3dSmokeSetup(int main_window){
     SPINNER_load_3dsmoke->set_float_limits(0.0, 255.0);
 
 #define HRRPUV_CUTOFF_MAX (hrrpuv_max_smv-0.01)
-    SPINNER_load_hrrpuv = glui_3dsmoke->add_spinner_to_panel(PANEL_load_options, _("HRRPUV >"), GLUI_SPINNER_FLOAT, &load_hrrpuv_cutoff);
+    SPINNER_load_hrrpuv = glui_3dsmoke->add_spinner_to_panel(PANEL_load_options, _("HRRPUV >"), GLUI_SPINNER_FLOAT, &global_scase.load_hrrpuv_cutoff);
     SPINNER_load_hrrpuv->set_float_limits(0.0, HRRPUV_CUTOFF_MAX);
 
     glui_3dsmoke->add_checkbox_to_panel(PANEL_load_options,"override cutoffs", &override_3dsmoke_cutoff);
@@ -492,7 +492,7 @@ extern "C" void GLUI3dSmokeSetup(int main_window){
   }
 
   PANEL_fire_cutoff = glui_3dsmoke->add_panel_to_panel(ROLLOUT_firecolor, "Color as fire when:");
-  SPINNER_hrrpuv_cutoff = glui_3dsmoke->add_spinner_to_panel(PANEL_fire_cutoff, "HRRPUV (kW/m3) > ", GLUI_SPINNER_FLOAT, &global_hrrpuv_cutoff, GLOBAL_FIRE_CUTOFF, GLUISmoke3dCB);
+  SPINNER_hrrpuv_cutoff = glui_3dsmoke->add_spinner_to_panel(PANEL_fire_cutoff, "HRRPUV (kW/m3) > ", GLUI_SPINNER_FLOAT, &global_scase.global_hrrpuv_cutoff, GLOBAL_FIRE_CUTOFF, GLUISmoke3dCB);
   SPINNER_hrrpuv_cutoff->set_float_limits(0.0, HRRPUV_CUTOFF_MAX);
   {
     char temp_cutoff_label[300];
@@ -602,9 +602,9 @@ extern "C" void GLUI3dSmokeSetup(int main_window){
   GLUISmoke3dCB(UPDATE_SMOKEFIRE_COLORS2);
   GLUISmoke3dCB(USE_SMOKE_RGB);
 
-  if(smoke3dcoll.nsmoke3dinfo<=0||nvolrenderinfo<=0){
+  if(global_scase.smoke3dcoll.nsmoke3dinfo<=0||nvolrenderinfo<=0){
     smoke_render_option=RENDER_SLICE;
-    if(smoke3dcoll.nsmoke3dinfo>0)smoke_render_option=RENDER_SLICE;
+    if(global_scase.smoke3dcoll.nsmoke3dinfo>0)smoke_render_option=RENDER_SLICE;
     if(nvolrenderinfo>0)smoke_render_option=RENDER_VOLUME;
   }
 
@@ -714,23 +714,23 @@ extern "C" void GLUI3dSmokeSetup(int main_window){
     SPINNER_skipframe = glui_3dsmoke->add_spinner_to_panel(ROLLOUT_generate_images, _("skip frame"), GLUI_SPINNER_INT, &vol_skipframe0, SKIP_FRAME, GLUISmoke3dCB);
     GLUISmoke3dCB(START_FRAME);
     GLUISmoke3dCB(SKIP_FRAME);
-    if(tourcoll.ntourinfo > 0){
+    if(global_scase.tourcoll.ntourinfo > 0){
       selectedtour_index = TOURINDEX_MANUAL;
       selectedtour_index_old = TOURINDEX_MANUAL;
       LISTBOX_VOL_tour = glui_3dsmoke->add_listbox_to_panel(ROLLOUT_generate_images, "Tour:", &selectedtour_index, VOL_TOUR_LIST, GLUISmoke3dCB);
 
       LISTBOX_VOL_tour->add_item(TOURINDEX_MANUAL, "Manual");
       LISTBOX_VOL_tour->add_item(-999, "-");
-      for(i = 0; i < tourcoll.ntourinfo; i++){
+      for(i = 0; i < global_scase.tourcoll.ntourinfo; i++){
         tourdata *touri;
 
-        touri = tourcoll.tourinfo + i;
+        touri = global_scase.tourcoll.tourinfo + i;
         LISTBOX_VOL_tour->add_item(i, touri->label);
       }
       LISTBOX_VOL_tour->set_int_val(selectedtour_index);
     }
 
-    strcpy(vol_prefix, fdsprefix);
+    strcpy(vol_prefix, global_scase.fdsprefix);
     EDIT_vol_prefix = glui_3dsmoke->add_edittext_to_panel(ROLLOUT_generate_images, "image prefix:", GLUI_EDITTEXT_TEXT, vol_prefix, VOL_PREFIX, GLUISmoke3dCB);
     EDIT_vol_prefix->set_w(200);
 
@@ -789,7 +789,7 @@ void GLUIGetPixelsPerTriangle(void){
   float x_pixels_per_triangle=1000000.0, y_pixels_per_triangle=1000000.0, pixels_per_triangle;
   char label[500];
 
-  if(STATIC_pixels_per_triangle == NULL)return; 
+  if(STATIC_pixels_per_triangle == NULL)return;
   if(nplotx_all>0)x_pixels_per_triangle = smoke3d_skipx*(float)glui_screenWidth/(float)nplotx_all;
   if(nploty_all>0)y_pixels_per_triangle = smoke3d_skipy*(float)glui_screenHeight/(float)nploty_all;
   pixels_per_triangle = MIN(x_pixels_per_triangle, y_pixels_per_triangle);
@@ -817,7 +817,7 @@ extern "C" void GLUISmoke3dCB(int var){
   float temp_min, temp_max;
 
   case FORCE_ALPHA_OPAQUE:
-    update_smoke_alphas = 1;
+    global_scase.update_smoke_alphas = 1;
     updatemenu = 1;
     break;
   case USE_FIRE_ALPHA:
@@ -992,7 +992,7 @@ extern "C" void GLUISmoke3dCB(int var){
     }
     TrimBack(vol_prefix);
     vol_prefixptr=TrimFront(vol_prefix);
-    if(strlen(vol_prefixptr)==0)vol_prefixptr=fdsprefix;
+    if(strlen(vol_prefixptr)==0)vol_prefixptr=global_scase.fdsprefix;
     InitVolrenderScript(vol_prefixptr, tour_label, vol_startframe0, vol_skipframe0);
     break;
   case NONGPU_VOL_FACTOR:
@@ -1031,7 +1031,7 @@ extern "C" void GLUISmoke3dCB(int var){
     break;
   case EXTINCTION_RESET_FDS:
     if(SOOT_index>=0){
-      glui_smoke3d_extinct = smoke3dtypes[SOOT_index].extinction;
+      glui_smoke3d_extinct = global_scase.smoke3dcoll.smoke3dtypes[SOOT_index].extinction;
       if(SPINNER_smoke3d_extinct2!=NULL)SPINNER_smoke3d_extinct2->set_float_val(glui_smoke3d_extinct);
       if(SPINNER_smoke3d_extinct!=NULL)SPINNER_smoke3d_extinct->set_float_val(glui_smoke3d_extinct);
       GLUISmoke3dCB(SMOKE_EXTINCT);
@@ -1044,20 +1044,20 @@ extern "C" void GLUISmoke3dCB(int var){
     GLUISmoke3dCB(SMOKE_EXTINCT);
     break;
   case CUTOFF_RESET:
-    global_hrrpuv_cutoff = global_hrrpuv_cutoff_default;
+    global_scase.global_hrrpuv_cutoff = global_scase.global_hrrpuv_cutoff_default;
     global_temp_cutoff = global_temp_cutoff_default;
     SPINNER_temperature_cutoff->set_float_val(global_temp_cutoff);
-    SPINNER_hrrpuv_cutoff->set_float_val(global_hrrpuv_cutoff);
+    SPINNER_hrrpuv_cutoff->set_float_val(global_scase.global_hrrpuv_cutoff);
     break;
   case VOLTEST_DEPTH:
     voltest_soot1 = log(2.0)/(mass_extinct*voltest_depth1);
     voltest_soot2 = log(2.0)/(mass_extinct*voltest_depth2);
     break;
   case VOLTEST_UPDATE:
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       if(meshi->volrenderinfo->loaded == 0)continue;
       meshi->voltest_update = 1;
     }
@@ -1264,10 +1264,10 @@ extern "C" void GLUISmoke3dCB(int var){
     IdleCB();
     break;
   case UPDATE_SMOKECOLORS:
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       meshi->update_smoke3dcolors=1;
     }
     glutPostRedisplay();
@@ -1277,7 +1277,7 @@ extern "C" void GLUISmoke3dCB(int var){
     IdleCB();
      break;
    case SMOKE_EXTINCT:
-     update_smoke_alphas = 1;
+     global_scase.update_smoke_alphas = 1;
      glui_smoke3d_extinct = MAX(glui_smoke3d_extinct, 0.0);
      SPINNER_smoke3d_extinct->set_float_val(glui_smoke3d_extinct);
      SPINNER_smoke3d_extinct2->set_float_val(glui_smoke3d_extinct);
@@ -1298,7 +1298,7 @@ extern "C" void GLUISmoke3dCB(int var){
     {
       volrenderdata *vr;
 
-      vr = meshinfo->volrenderinfo;
+      vr = global_scase.meshescoll.meshinfo->volrenderinfo;
       if(vr!=NULL&&vr->smokeslice!=NULL&&vr->smokeslice->slice_filetype==SLICE_CELL_CENTER){
         if(usegpu==1&&combine_meshes==1){
           combine_meshes=0;

--- a/Source/smokeview/glui_trainer.cpp
+++ b/Source/smokeview/glui_trainer.cpp
@@ -211,10 +211,10 @@ void TrainerCB(int var){
         rotation_type = EYE_CENTERED;
         HandleRotationType(ROTATION_2AXIS);
       }
-      for(i = 0;i < tourcoll.ntourinfo;i++){
+      for(i = 0;i < global_scase.tourcoll.ntourinfo;i++){
         tourdata *touri;
 
-        touri = tourcoll.tourinfo + i;
+        touri = global_scase.tourcoll.tourinfo + i;
         touri->display = 0;
       }
       viewtourfrompath = 1;
@@ -346,10 +346,10 @@ extern "C" void GLUITrainerSetup(int main_window){
     int i;
     LIST_trainerpath->add_item(-1,_("Manual"));
     LIST_trainerpath->add_item(-2,"-");
-    for(i=0;i<tourcoll.ntourinfo;i++){
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
       tourdata *touri;
 
-      touri = tourcoll.tourinfo + i;
+      touri = global_scase.tourcoll.tourinfo + i;
       LIST_trainerpath->add_item(i,touri->menulabel);
     }
   }

--- a/Source/smokeview/infoheader.c
+++ b/Source/smokeview/infoheader.c
@@ -59,7 +59,7 @@ int initialiseInfoHeader(titledata *titleinfo_ptr,
   snprintf(line,MAX_TITLE_LINE_LENGTH,"Smokeview build: %s",smv_githash_string);
   strncpy(titleinfo_ptr->smvbuildline, line, MAX_TITLE_LINE_LENGTH);
 
-  if(fds_githash!=NULL){
+  if(global_scase.fds_githash!=NULL){
     snprintf(line,MAX_TITLE_LINE_LENGTH,"FDS build: %s",fds_githash_string);
     strncpy(titleinfo_ptr->fdsbuildline, line, MAX_TITLE_LINE_LENGTH);
   }

--- a/Source/smokeview/lua_api.c
+++ b/Source/smokeview/lua_api.c
@@ -1260,8 +1260,8 @@ int LuaCreateCase(lua_State *L) {
   lua_newtable(L);
   // lua_pushstring(L, chidfilebase);
   // lua_setfield(L, -2, "chid");
-  lua_pushstring(L, fdsprefix);
-  lua_setfield(L, -2, "fdsprefix");
+  lua_pushstring(L, global_scase.fdsprefix);
+  lua_setfield(L, -2, "global_scase.fdsprefix");
 
   lua_pushcfunction(L, &LuaCaseTitle);
   lua_setfield(L, -2, "plot_title");
@@ -5665,7 +5665,7 @@ int LoadLuaScript(const char *filename) {
 int LoadSsfScript(const char *filename) {
   // char filename[1024];
   //   if (strlen(script_filename) == 0) {
-  //       strncpy(filename, fdsprefix, 1020);
+  //       strncpy(filename, global_scase.fdsprefix, 1020);
   //       strcat(filename, ".ssf");
   //   } else {
   //       strncpy(filename, script_filename, 1024);
@@ -5680,7 +5680,7 @@ int LoadSsfScript(const char *filename) {
   int level = 0;
   char l_string[1024];
   snprintf(l_string, 1024, "require(\"ssfparser\")\nrunSSF(\"%s.ssf\")",
-           fdsprefix);
+           global_scase.fdsprefix);
   int ssfparser_loaded_err = luaL_dostring(lua_instance, "require \"ssfparser\"");
   if(ssfparser_loaded_err) {
     fprintf(stderr, "Failed to load ssfparser\n");

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -208,14 +208,14 @@ char *ProcessCommandLine(CommandlineArgs *args){
 #endif
   len_casename = (int)strlen(argi);
   CheckMemory;
-  FREEMEMORY(fdsprefix);
+  FREEMEMORY(global_scase.fdsprefix);
   len_memory = len_casename + strlen(".part") + 100;
-  NewMemory((void **)&fdsprefix, (unsigned int)len_memory);
-  STRCPY(fdsprefix, argi);
+  NewMemory((void **)&global_scase.fdsprefix, (unsigned int)len_memory);
+  STRCPY(global_scase.fdsprefix, argi);
 
-  if(fdsprefix!=NULL&&strlen(fdsprefix)>0){
+  if(global_scase.fdsprefix!=NULL&&strlen(global_scase.fdsprefix)>0){
     NewMemory((void **)&filename_local, (unsigned int)len_memory+4);
-    strcpy(filename_local, fdsprefix);
+    strcpy(filename_local, global_scase.fdsprefix);
     strcat(filename_local, ".smv");
   }
   else{
@@ -231,15 +231,15 @@ char *ProcessCommandLine(CommandlineArgs *args){
         char *dirlast = NULL, *caselast = NULL;
 
         FREEMEMORY(smokeview_casedir);
-        FREEMEMORY(fdsprefix);
+        FREEMEMORY(global_scase.fdsprefix);
         NewMemory((void **)&smokeview_casedir, strlen(filename_local) + 1);
-        NewMemory((void **)&fdsprefix, strlen(filename_local) + 1);
+        NewMemory((void **)&global_scase.fdsprefix, strlen(filename_local) + 1);
         strcpy(smokeview_casedir, filename_local);
         dirlast = strrchr(smokeview_casedir, '\\');
         if(dirlast != NULL){
           strcpy(filename_local, dirlast + 1);
-          strcpy(fdsprefix, filename_local);
-          caselast = strrchr(fdsprefix, '.');
+          strcpy(global_scase.fdsprefix, filename_local);
+          caselast = strrchr(global_scase.fdsprefix, '.');
           if(caselast != NULL)caselast[0] = 0;
           dirlast[1] = 0;
           len_casename = strlen(filename_local);
@@ -253,13 +253,13 @@ char *ProcessCommandLine(CommandlineArgs *args){
 #endif
     if(filename_local==NULL)return NULL;
   }
-  strcpy(movie_name, fdsprefix);
-  strcpy(render_file_base, fdsprefix);
-  strcpy(html_file_base, fdsprefix);
+  strcpy(movie_name, global_scase.fdsprefix);
+  strcpy(render_file_base, global_scase.fdsprefix);
+  strcpy(html_file_base, global_scase.fdsprefix);
   smv_ext = strstr(html_file_base, ".smv");
   if(smv_ext!=NULL)*smv_ext = 0;
-  FREEMEMORY(trainer_filename);
-  FREEMEMORY(test_filename);
+  FREEMEMORY(global_scase.paths.trainer_filename);
+  FREEMEMORY(global_scase.paths.test_filename);
 
   strcpy(input_filename_ext, "");
 
@@ -277,150 +277,150 @@ char *ProcessCommandLine(CommandlineArgs *args){
         strcmp(input_filename_ext, ".smt") == 0)
         ){
         c_ext[0] = 0;
-        STRCPY(fdsprefix, argi);
-        strcpy(movie_name, fdsprefix);
-        strcpy(render_file_base, fdsprefix);
-        FREEMEMORY(trainer_filename);
-        NewMemory((void **)&trainer_filename, (unsigned int)(len_casename + 7));
-        STRCPY(trainer_filename, argi);
-        STRCAT(trainer_filename, ".svd");
-        FREEMEMORY(test_filename);
-        NewMemory((void **)&test_filename, (unsigned int)(len_casename + 7));
-        STRCPY(test_filename, argi);
-        STRCAT(test_filename, ".smt");
+        STRCPY(global_scase.fdsprefix, argi);
+        strcpy(movie_name, global_scase.fdsprefix);
+        strcpy(render_file_base, global_scase.fdsprefix);
+        FREEMEMORY(global_scase.paths.trainer_filename);
+        NewMemory((void **)&global_scase.paths.trainer_filename, (unsigned int)(len_casename + 7));
+        STRCPY(global_scase.paths.trainer_filename, argi);
+        STRCAT(global_scase.paths.trainer_filename, ".svd");
+        FREEMEMORY(global_scase.paths.test_filename);
+        NewMemory((void **)&global_scase.paths.test_filename, (unsigned int)(len_casename + 7));
+        STRCPY(global_scase.paths.test_filename, argi);
+        STRCAT(global_scase.paths.test_filename, ".smt");
       }
     }
   }
 
-  FREEMEMORY(log_filename);
-  NewMemory((void **)&log_filename, len_casename + strlen(".smvlog") + 1);
-  STRCPY(log_filename, fdsprefix);
-  STRCAT(log_filename, ".smvlog");
+  FREEMEMORY(global_scase.paths.log_filename);
+  NewMemory((void **)&global_scase.paths.log_filename, len_casename + strlen(".smvlog") + 1);
+  STRCPY(global_scase.paths.log_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.log_filename, ".smvlog");
 
-  FREEMEMORY(caseini_filename);
-  NewMemory((void **)&caseini_filename, len_casename + strlen(".ini") + 1);
-  STRCPY(caseini_filename, fdsprefix);
-  STRCAT(caseini_filename, ".ini");
+  FREEMEMORY(global_scase.paths.caseini_filename);
+  NewMemory((void **)&global_scase.paths.caseini_filename, len_casename + strlen(".ini") + 1);
+  STRCPY(global_scase.paths.caseini_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.caseini_filename, ".ini");
 
 #ifdef pp_FRAME
-  FREEMEMORY(frametest_filename);
-  NewMemory((void **)&frametest_filename, len_casename + strlen(".tst") + 1);
-  STRCPY(frametest_filename, fdsprefix);
-  STRCAT(frametest_filename, ".tst");
+  FREEMEMORY(global_scase.paths.frametest_filename);
+  NewMemory((void **)&global_scase.paths.frametest_filename, len_casename + strlen(".tst") + 1);
+  STRCPY(global_scase.paths.frametest_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.frametest_filename, ".tst");
 #endif
 
-  FREEMEMORY(fedsmv_filename);
-  NewMemory((void **)&fedsmv_filename, len_casename + strlen(".fedsmv") + 1);
-  STRCPY(fedsmv_filename, fdsprefix);
-  STRCAT(fedsmv_filename, ".fedsmv");
+  FREEMEMORY(global_scase.paths.fedsmv_filename);
+  NewMemory((void **)&global_scase.paths.fedsmv_filename, len_casename + strlen(".fedsmv") + 1);
+  STRCPY(global_scase.paths.fedsmv_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.fedsmv_filename, ".fedsmv");
 
-  FREEMEMORY(expcsv_filename);
-  NewMemory((void **)&expcsv_filename, len_casename + strlen("_exp.csv") + 1);
-  STRCPY(expcsv_filename, fdsprefix);
-  STRCAT(expcsv_filename, "_exp.csv");
+  FREEMEMORY(global_scase.paths.expcsv_filename);
+  NewMemory((void **)&global_scase.paths.expcsv_filename, len_casename + strlen("_exp.csv") + 1);
+  STRCPY(global_scase.paths.expcsv_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.expcsv_filename, "_exp.csv");
 
-  FREEMEMORY(stepcsv_filename);
-  NewMemory((void **)&stepcsv_filename, len_casename + strlen("_steps.csv") + 1);
-  STRCPY(stepcsv_filename, fdsprefix);
-  STRCAT(stepcsv_filename, "_steps.csv");
+  FREEMEMORY(global_scase.paths.stepcsv_filename);
+  NewMemory((void **)&global_scase.paths.stepcsv_filename, len_casename + strlen("_steps.csv") + 1);
+  STRCPY(global_scase.paths.stepcsv_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.stepcsv_filename, "_steps.csv");
 
-  FREEMEMORY(dEcsv_filename);
-  NewMemory((void **)&dEcsv_filename, len_casename + strlen("_dE.csv") + 1);
-  STRCPY(dEcsv_filename, fdsprefix);
-  STRCAT(dEcsv_filename, "_dE.csv");
+  FREEMEMORY(global_scase.paths.dEcsv_filename);
+  NewMemory((void **)&global_scase.paths.dEcsv_filename, len_casename + strlen("_dE.csv") + 1);
+  STRCPY(global_scase.paths.dEcsv_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.dEcsv_filename, "_dE.csv");
 
-  FREEMEMORY(html_filename);
-  NewMemory((void **)&html_filename, len_casename+strlen(".html")+1);
-  STRCPY(html_filename, fdsprefix);
-  STRCAT(html_filename, ".html");
+  FREEMEMORY(global_scase.paths.html_filename);
+  NewMemory((void **)&global_scase.paths.html_filename, len_casename+strlen(".html")+1);
+  STRCPY(global_scase.paths.html_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.html_filename, ".html");
 
-  FREEMEMORY(smv_orig_filename);
-  NewMemory((void **)&smv_orig_filename, len_casename+strlen(".smo")+1);
-  STRCPY(smv_orig_filename, fdsprefix);
-  STRCAT(smv_orig_filename, ".smo");
+  FREEMEMORY(global_scase.paths.smv_orig_filename);
+  NewMemory((void **)&global_scase.paths.smv_orig_filename, len_casename+strlen(".smo")+1);
+  STRCPY(global_scase.paths.smv_orig_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.smv_orig_filename, ".smo");
 
-  FREEMEMORY(hrr_filename);
-  NewMemory((void **)&hrr_filename, len_casename+strlen("_hrr.csv")+1);
-  STRCPY(hrr_filename, fdsprefix);
-  STRCAT(hrr_filename, "_hrr.csv");
+  FREEMEMORY(global_scase.paths.hrr_filename);
+  NewMemory((void **)&global_scase.paths.hrr_filename, len_casename+strlen("_hrr.csv")+1);
+  STRCPY(global_scase.paths.hrr_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.hrr_filename, "_hrr.csv");
 
-  FREEMEMORY(htmlvr_filename);
-  NewMemory((void **)&htmlvr_filename, len_casename+strlen("_vr.html")+1);
-  STRCPY(htmlvr_filename, fdsprefix);
-  STRCAT(htmlvr_filename, "_vr.html");
+  FREEMEMORY(global_scase.paths.htmlvr_filename);
+  NewMemory((void **)&global_scase.paths.htmlvr_filename, len_casename+strlen("_vr.html")+1);
+  STRCPY(global_scase.paths.htmlvr_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.htmlvr_filename, "_vr.html");
 
-  FREEMEMORY(htmlobst_filename);
-  NewMemory((void **)&htmlobst_filename, len_casename+strlen("_obst.json")+1);
-  STRCPY(htmlobst_filename, fdsprefix);
-  STRCAT(htmlobst_filename, "_obst.json");
+  FREEMEMORY(global_scase.paths.htmlobst_filename);
+  NewMemory((void **)&global_scase.paths.htmlobst_filename, len_casename+strlen("_obst.json")+1);
+  STRCPY(global_scase.paths.htmlobst_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.htmlobst_filename, "_obst.json");
 
-  FREEMEMORY(htmlslicenode_filename);
-  NewMemory((void **)&htmlslicenode_filename, len_casename+strlen("_slicenode.json")+1);
-  STRCPY(htmlslicenode_filename, fdsprefix);
-  STRCAT(htmlslicenode_filename, "_slicenode.json");
+  FREEMEMORY(global_scase.paths.htmlslicenode_filename);
+  NewMemory((void **)&global_scase.paths.htmlslicenode_filename, len_casename+strlen("_slicenode.json")+1);
+  STRCPY(global_scase.paths.htmlslicenode_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.htmlslicenode_filename, "_slicenode.json");
 
-  FREEMEMORY(htmlslicecell_filename);
-  NewMemory((void **)&htmlslicecell_filename, len_casename+strlen("_slicecell.json")+1);
-  STRCPY(htmlslicecell_filename, fdsprefix);
-  STRCAT(htmlslicecell_filename, "_slicecell.json");
+  FREEMEMORY(global_scase.paths.htmlslicecell_filename);
+  NewMemory((void **)&global_scase.paths.htmlslicecell_filename, len_casename+strlen("_slicecell.json")+1);
+  STRCPY(global_scase.paths.htmlslicecell_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.htmlslicecell_filename, "_slicecell.json");
 
-  FREEMEMORY(event_filename);
-  NewMemory((void **)&event_filename, len_casename+strlen("_events.csv")+1);
-  STRCPY(event_filename, fdsprefix);
-  STRCAT(event_filename, "_events.csv");
+  FREEMEMORY(global_scase.paths.event_filename);
+  NewMemory((void **)&global_scase.paths.event_filename, len_casename+strlen("_events.csv")+1);
+  STRCPY(global_scase.paths.event_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.event_filename, "_events.csv");
 
   if(filename_local==NULL){
     NewMemory((void **)&filename_local, (unsigned int)(len_casename+6));
-    STRCPY(filename_local, fdsprefix);
+    STRCPY(filename_local, global_scase.fdsprefix);
     STRCAT(filename_local, ".smv");
   }
   {
     char scriptbuffer[1024];
 
-    STRCPY(scriptbuffer, fdsprefix);
+    STRCPY(scriptbuffer, global_scase.fdsprefix);
     STRCAT(scriptbuffer, ".ssf");
     if(default_script == NULL&&FILE_EXISTS(scriptbuffer) == YES){
       default_script = InsertScriptFile(scriptbuffer);
     }
   }
   if(filename_local!= NULL){
-    FREEMEMORY(fds_filein);
-    NewMemory((void **)&fds_filein, strlen(fdsprefix) + 6);
-    STRCPY(fds_filein, fdsprefix);
-    STRCAT(fds_filein, ".fds");
-    if(FILE_EXISTS(fds_filein) == NO){
-      FREEMEMORY(fds_filein);
+    FREEMEMORY(global_scase.paths.fds_filein);
+    NewMemory((void **)&global_scase.paths.fds_filein, strlen(global_scase.fdsprefix) + 6);
+    STRCPY(global_scase.paths.fds_filein, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.fds_filein, ".fds");
+    if(FILE_EXISTS(global_scase.paths.fds_filein) == NO){
+      FREEMEMORY(global_scase.paths.fds_filein);
     }
   }
-  if(ffmpeg_command_filename == NULL){
-    NewMemory((void **)&ffmpeg_command_filename, (unsigned int)(len_casename + 12));
-    STRCPY(ffmpeg_command_filename, fdsprefix);
-    STRCAT(ffmpeg_command_filename, "_ffmpeg");
+  if(global_scase.paths.ffmpeg_command_filename == NULL){
+    NewMemory((void **)&global_scase.paths.ffmpeg_command_filename, (unsigned int)(len_casename + 12));
+    STRCPY(global_scase.paths.ffmpeg_command_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.ffmpeg_command_filename, "_ffmpeg");
 #ifdef WIN32
-    STRCAT(ffmpeg_command_filename,".bat");
+    STRCAT(global_scase.paths.ffmpeg_command_filename,".bat");
 #else
-    STRCAT(ffmpeg_command_filename,".sh");
+    STRCAT(global_scase.paths.ffmpeg_command_filename,".sh");
 #endif
   }
-  if(stop_filename == NULL){
-    NewMemory((void **)&stop_filename, (unsigned int)(len_casename + strlen(".stop") + 1));
-    STRCPY(stop_filename, fdsprefix);
-    STRCAT(stop_filename, ".stop");
+  if(global_scase.paths.stop_filename == NULL){
+    NewMemory((void **)&global_scase.paths.stop_filename, (unsigned int)(len_casename + strlen(".stop") + 1));
+    STRCPY(global_scase.paths.stop_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.stop_filename, ".stop");
   }
-  if(smvzip_filename == NULL){
-    NewMemory((void **)&smvzip_filename, (unsigned int)(len_casename + strlen(".smvzip") + 1));
-    STRCPY(smvzip_filename, fdsprefix);
-    STRCAT(smvzip_filename, ".smvzip");
+  if(global_scase.paths.smvzip_filename == NULL){
+    NewMemory((void **)&global_scase.paths.smvzip_filename, (unsigned int)(len_casename + strlen(".smvzip") + 1));
+    STRCPY(global_scase.paths.smvzip_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.smvzip_filename, ".smvzip");
   }
-  if(sliceinfo_filename == NULL){
-    NewMemory((void **)&sliceinfo_filename, strlen(fdsprefix) + strlen(".sinfo") + 1);
-    STRCPY(sliceinfo_filename, fdsprefix);
-    STRCAT(sliceinfo_filename, ".sinfo");
+  if(global_scase.paths.sliceinfo_filename == NULL){
+    NewMemory((void **)&global_scase.paths.sliceinfo_filename, strlen(global_scase.fdsprefix) + strlen(".sinfo") + 1);
+    STRCPY(global_scase.paths.sliceinfo_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.sliceinfo_filename, ".sinfo");
   }
-  if(deviceinfo_filename==NULL){
-    NewMemory((void **)&deviceinfo_filename, strlen(fdsprefix)+strlen("_device.info")+1);
-    STRCPY(deviceinfo_filename, fdsprefix);
-    STRCAT(deviceinfo_filename, "_device.info");
+  if(global_scase.paths.deviceinfo_filename==NULL){
+    NewMemory((void **)&global_scase.paths.deviceinfo_filename, strlen(global_scase.fdsprefix)+strlen("_device.info")+1);
+    STRCPY(global_scase.paths.deviceinfo_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.deviceinfo_filename, "_device.info");
   }
 
   // if smokezip created part2iso files then concatenate .smv entries found in the .isosmv file
@@ -429,27 +429,27 @@ char *ProcessCommandLine(CommandlineArgs *args){
   {
     FILE *stream_iso = NULL;
 
-    NewMemory((void **)&iso_filename, len_casename + strlen(".isosmv") + 1);
-    STRCPY(iso_filename, fdsprefix);
-    STRCAT(iso_filename, ".isosmv");
-    stream_iso = fopen(iso_filename, "r");
+    NewMemory((void **)&global_scase.paths.iso_filename, len_casename + strlen(".isosmv") + 1);
+    STRCPY(global_scase.paths.iso_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.iso_filename, ".isosmv");
+    stream_iso = fopen(global_scase.paths.iso_filename, "r");
     if(stream_iso != NULL){
       fclose(stream_iso);
     }
     else{
-      FREEMEMORY(iso_filename);
+      FREEMEMORY(global_scase.paths.iso_filename);
     }
   }
 
-  if(trainer_filename == NULL){
-    NewMemory((void **)&trainer_filename, (unsigned int)(len_casename + 6));
-    STRCPY(trainer_filename, fdsprefix);
-    STRCAT(trainer_filename, ".svd");
+  if(global_scase.paths.trainer_filename == NULL){
+    NewMemory((void **)&global_scase.paths.trainer_filename, (unsigned int)(len_casename + 6));
+    STRCPY(global_scase.paths.trainer_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.trainer_filename, ".svd");
   }
-  if(test_filename == NULL){
-    NewMemory((void **)&test_filename, (unsigned int)(len_casename + 6));
-    STRCPY(test_filename, fdsprefix);
-    STRCAT(test_filename, ".svd");
+  if(global_scase.paths.test_filename == NULL){
+    NewMemory((void **)&global_scase.paths.test_filename, (unsigned int)(len_casename + 6));
+    STRCPY(global_scase.paths.test_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.test_filename, ".svd");
   }
 
 #ifdef pp_OSX_HIGHRES
@@ -568,8 +568,8 @@ char *ProcessCommandLine(CommandlineArgs *args){
       SMV_EXIT(0);
     }
     if(args->noblank){
-      iblank_set_on_commandline = 1;
-      use_iblank = 0;
+      global_scase.iblank_set_on_commandline = 1;
+      global_scase.use_iblank = 0;
     }
     if(args->nobounds){
       no_bounds = 1;
@@ -595,14 +595,14 @@ char *ProcessCommandLine(CommandlineArgs *args){
       lookfor_compressed_files = 1;
     }
     if(args->blank){
-      iblank_set_on_commandline = 1;
-      use_iblank = 1;
+      global_scase.iblank_set_on_commandline = 1;
+      global_scase.use_iblank = 1;
     }
     if(args->gversion){
       vis_title_gversion = 1;
     }
     if(args->redirect){
-      LOG_FILENAME = fopen(log_filename, "w");
+      LOG_FILENAME = fopen(global_scase.paths.log_filename, "w");
       if(LOG_FILENAME != NULL){
         redirect = 1;
         SetStdOut(LOG_FILENAME);
@@ -627,7 +627,7 @@ char *ProcessCommandLine(CommandlineArgs *args){
       from_commandline = 1;
       use_iso_threads=0;
       strcpy(luascript_filename, "");
-      strncpy(luascript_filename, fdsprefix, MAX_LUASCRIPT_FILENAME_BUFFER-5);
+      strncpy(luascript_filename, global_scase.fdsprefix, MAX_LUASCRIPT_FILENAME_BUFFER-5);
       strcat(luascript_filename, ".lua");
       runluascript = 1;
     }
@@ -715,25 +715,25 @@ char *ProcessCommandLine(CommandlineArgs *args){
   if(update_ssf == 1){
     int len_prefix = 0;
 
-    len_prefix = strlen(fdsprefix);
+    len_prefix = strlen(global_scase.fdsprefix);
 
     FREEMEMORY(ssf_from);
     NewMemory((void **)&ssf_from, len_prefix + 4 + 1);
-    strcpy(ssf_from, fdsprefix);
+    strcpy(ssf_from, global_scase.fdsprefix);
     strcat(ssf_from, ".ssf");
 
     FREEMEMORY(ssf_to);
     NewMemory((void **)&ssf_to, len_prefix + 4 + 1);
-    strcpy(ssf_to, fdsprefix);
+    strcpy(ssf_to, global_scase.fdsprefix);
     strcat(ssf_to, ".ssf");
   }
   if(make_volrender_script == 1){
 
     NewMemory((void **)&volrender_scriptname, (unsigned int)(len_casename + 14 + 1));
-    STRCPY(volrender_scriptname, fdsprefix);
+    STRCPY(volrender_scriptname, global_scase.fdsprefix);
     STRCAT(volrender_scriptname, "_volrender.ssf");
 
-    InitVolrenderScript(fdsprefix, NULL, vol_startframe0, vol_skipframe0);
+    InitVolrenderScript(global_scase.fdsprefix, NULL, vol_startframe0, vol_skipframe0);
   }
   return filename_local;
 }

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -405,15 +405,15 @@ void GetFileSizes(void){
   int i;
 
   printf("\n");
-  if(smoke3dcoll.nsmoke3dinfo>0){
+  if(global_scase.smoke3dcoll.nsmoke3dinfo>0){
     float hrrpuv = 0.0, soot = 0.0, temp = 0.0, co2 = 0.0;
     float hrrpuv2 = 0.0, soot2 = 0.0, temp2 = 0.0, co22 = 0.0;
 
-    for(i = 0; i<smoke3dcoll.nsmoke3dinfo; i++){
+    for(i = 0; i<global_scase.smoke3dcoll.nsmoke3dinfo; i++){
       smoke3ddata *smoke3di;
       FILE_SIZE file_size, compressed_file_size;
 
-      smoke3di = smoke3dcoll.smoke3dinfo+i;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo+i;
 
       file_size = GetFileSizeSMV(smoke3di->reg_file);
       compressed_file_size = GetFileSizeSMV(smoke3di->comp_file);
@@ -446,15 +446,15 @@ void GetFileSizes(void){
   }
 
   printf("\n");
-  if(npartinfo>0){
+  if(global_scase.npartinfo>0){
     float part = 0.0;
     char label[100];
 
-    for(i = 0; i<npartinfo; i++){
+    for(i = 0; i<global_scase.npartinfo; i++){
       partdata *parti;
       FILE_SIZE file_size;
 
-      parti = partinfo+i;
+      parti = global_scase.partinfo+i;
       file_size = GetFileSizeSMV(parti->file);
       part += file_size;
     }
@@ -465,17 +465,17 @@ void GetFileSizes(void){
   }
 
   printf("\n");
-  if(npatchinfo>0){
+  if(global_scase.npatchinfo>0){
     patchdata **patchlist;
     float sum = 0.0, compressed_sum=0;
 
     printf("boundary files sizes: \n");
-    NewMemory((void **)&patchlist, npatchinfo*sizeof(patchdata *));
-    for(i = 0; i<npatchinfo; i++){
-      patchlist[i] = patchinfo+i;
+    NewMemory((void **)&patchlist, global_scase.npatchinfo*sizeof(patchdata *));
+    for(i = 0; i<global_scase.npatchinfo; i++){
+      patchlist[i] = global_scase.patchinfo+i;
     }
-    qsort((patchdata **)patchlist, (size_t)npatchinfo, sizeof(patchdata *), ComparePatchLabels);
-    for(i = 0; i<npatchinfo; i++){
+    qsort((patchdata **)patchlist, (size_t)global_scase.npatchinfo, sizeof(patchdata *), ComparePatchLabels);
+    for(i = 0; i<global_scase.npatchinfo; i++){
       patchdata *patchi, *patchim1;
       FILE_SIZE file_size, compressed_file_size;
 
@@ -493,7 +493,7 @@ void GetFileSizes(void){
         sum = file_size;
         compressed_sum = compressed_file_size;
       }
-      if(i==npatchinfo-1){
+      if(i==global_scase.npatchinfo-1){
         PrintFileSizes(patchi->label.longlabel,sum,compressed_sum);
       }
     }
@@ -507,16 +507,16 @@ void GetFileSizes(void){
 
 void HideAllSmoke(void){
   int i;
-  for(i = 0; i < smoke3dcoll.nsmoke3dinfo; i++){
+  for(i = 0; i < global_scase.smoke3dcoll.nsmoke3dinfo; i++){
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     if(smoke3di->loaded == 1)smoke3di->display = 0;
   }
-  for(i = 0; i < nisoinfo; i++){
+  for(i = 0; i < global_scase.nisoinfo; i++){
     isodata *isoi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     if(isoi->loaded == 1)isoi->display = 0;
   }
 }
@@ -527,8 +527,8 @@ void HideAllSlices(void){
   int i;
 
   GLUTSETCURSOR(GLUT_CURSOR_WAIT);
-  for(i = 0; i < slicecoll.nsliceinfo; i++){
-    slicecoll.sliceinfo[i].display = 0;
+  for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
+    global_scase.slicecoll.sliceinfo[i].display = 0;
   }
   updatemenu = 1;
   GLUTPOSTREDISPLAY;
@@ -539,16 +539,16 @@ void HideAllSlices(void){
 
 void ShowAllSmoke(void){
   int i;
-  for(i = 0; i < smoke3dcoll.nsmoke3dinfo; i++){
+  for(i = 0; i < global_scase.smoke3dcoll.nsmoke3dinfo; i++){
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     if(smoke3di->loaded == 1)smoke3di->display = 1;
   }
-  for(i = 0; i < nisoinfo; i++){
+  for(i = 0; i < global_scase.nisoinfo; i++){
     isodata *isoi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     if(isoi->loaded == 1)isoi->display = 1;
   }
 }
@@ -587,10 +587,10 @@ void ShowMultiSliceMenu(int value){
       multislicedata *mslicei;
       slicedata *sd;
 
-      mslicei = slicecoll.multisliceinfo+value;
+      mslicei = global_scase.slicecoll.multisliceinfo+value;
       mdisplay = 0;
 
-      sd = slicecoll.sliceinfo+mslicei->islices[0];
+      sd = global_scase.slicecoll.sliceinfo+mslicei->islices[0];
       if(slicefile_labelindex==sd->slicefile_labelindex){
         if(plotstate!=DYNAMIC_PLOTS){
           plotstate = DYNAMIC_PLOTS;
@@ -607,12 +607,12 @@ void ShowMultiSliceMenu(int value){
       }
       else{
         plotstate = DYNAMIC_PLOTS;
-        sd = slicecoll.sliceinfo+mslicei->islices[0];
+        sd = global_scase.slicecoll.sliceinfo+mslicei->islices[0];
         slicefile_labelindex = sd->slicefile_labelindex;
         mdisplay = 1;
       }
       for(i = 0; i<mslicei->nslices; i++){
-        sd = slicecoll.sliceinfo+mslicei->islices[i];
+        sd = global_scase.slicecoll.sliceinfo+mslicei->islices[i];
         if(sd->loaded==0)continue;
         sd->display = mdisplay;
       }
@@ -632,17 +632,17 @@ void ShowAllSlices(char *type1, char *type2){
 
   GLUTSETCURSOR(GLUT_CURSOR_WAIT);
   if(trainer_showall_mslice == 1){
-    for(i = 0; i < slicecoll.nsliceinfo; i++){
+    for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
       slicei->display = 0;
       if(slicei->loaded == 0)continue;
       if(
         (type1 != NULL&&STRCMP(slicei->label.longlabel, type1) == 0) ||
         (type2 != NULL&&STRCMP(slicei->label.longlabel, type2) == 0)
        ){
-        slicecoll.sliceinfo[i].display = 1;
+        global_scase.slicecoll.sliceinfo[i].display = 1;
         slicefile_labelindex = slicei->slicefile_labelindex;
       }
     }
@@ -843,7 +843,7 @@ void LabelMenu(int value){
     visLabels=1;
     visMeshlabel=1;
     vis_slice_average=1;
-    if(ntickinfo>0)visFDSticks=1;
+    if(global_scase.ntickinfo>0)visFDSticks=1;
     visgridloc=1;
     vis_hrr_label=1;
     show_firecutoff=1;
@@ -866,7 +866,7 @@ void LabelMenu(int value){
     visMeshlabel=0;
     vis_hrr_label=0;
     show_firecutoff=0;
-    if(ntickinfo>0)visFDSticks=0;
+    if(global_scase.ntickinfo>0)visFDSticks=0;
     visgridloc=0;
     vis_slice_average=0;
 #ifdef pp_memstatus
@@ -1149,8 +1149,8 @@ void Smoke3DShowMenu(int value){
       break;
 #endif
     case SET_SMOKE3D:
-      for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
-        smoke3di = smoke3dcoll.smoke3dinfo + i;
+      for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
+        smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
         if(smoke3di->loaded==1)smoke3di->display=show_3dsmoke;
       }
     break;
@@ -1159,7 +1159,7 @@ void Smoke3DShowMenu(int value){
     }
   }
   else{
-    smoke3di = smoke3dcoll.smoke3dinfo + value;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + value;
     if(plotstate!=DYNAMIC_PLOTS){
       plotstate=DYNAMIC_PLOTS;
       smoke3di->display=1;
@@ -1208,7 +1208,7 @@ void IsoShowMenu(int value){
     for(i=0;i<loaded_isomesh->nisolevels;i++){
       surfdata *surfi;
 
-      surfi = surfinfo + nsurfinfo + 1 + i;
+      surfi = global_scase.surfcoll.surfinfo + global_scase.surfcoll.nsurfinfo + 1 + i;
       surfi->transparent_level=1.0;
     }
     use_transparency_data=0;
@@ -1219,7 +1219,7 @@ void IsoShowMenu(int value){
     for(i=0;i<loaded_isomesh->nisolevels;i++){
       surfdata *surfi;
 
-      surfi = surfinfo + nsurfinfo + 1 + i;
+      surfi = global_scase.surfcoll.surfinfo + global_scase.surfcoll.nsurfinfo + 1 + i;
       surfi->transparent_level=transparent_level;
     }
     use_transparency_data=1;
@@ -1230,10 +1230,10 @@ void IsoShowMenu(int value){
     for(i=0;i<loaded_isomesh->nisolevels;i++){
       surfdata *surfi;
 
-      surfi = surfinfo + nsurfinfo + 1 + i;
+      surfi = global_scase.surfcoll.surfinfo + global_scase.surfcoll.nsurfinfo + 1 + i;
       surfi->transparent_level=transparent_level;
     }
-    surfinfo[nsurfinfo+1].transparent_level=1.0;
+    global_scase.surfcoll.surfinfo[global_scase.surfcoll.nsurfinfo+1].transparent_level=1.0;
     use_transparency_data=1;
     break;
    case MENU_ISOSHOW_MAXSOLID:
@@ -1242,11 +1242,11 @@ void IsoShowMenu(int value){
     for(i=0;i<loaded_isomesh->nisolevels;i++){
       surfdata *surfi;
 
-      surfi = surfinfo + nsurfinfo + 1 + i;
+      surfi = global_scase.surfcoll.surfinfo + global_scase.surfcoll.nsurfinfo + 1 + i;
       surfi->transparent_level=transparent_level;
     }
     use_transparency_data=1;
-    surfinfo[nsurfinfo+1+loaded_isomesh->nisolevels-1].transparent_level=1.0;
+    global_scase.surfcoll.surfinfo[global_scase.surfcoll.nsurfinfo+1+loaded_isomesh->nisolevels-1].transparent_level=1.0;
     break;
    case MENU_ISOSHOW_HIDEALL:
     show_iso_shaded=0;
@@ -1271,7 +1271,7 @@ void IsoShowMenu(int value){
      showlevels[value-100] = 1 - showlevels[value-100];
     }
     else if(value>=1000&&value<=10000){      // we can only have 9900 isosurface files
-     isoi = isoinfo + value - 1000;          // hope that is enough!!
+     isoi = global_scase.isoinfo + value - 1000;          // hope that is enough!!
      if(plotstate!=DYNAMIC_PLOTS){
        plotstate=DYNAMIC_PLOTS;
        isoi->display=1;
@@ -1300,8 +1300,8 @@ void IsoShowMenu(int value){
       else if(value==TOGGLE_ISO){
         show_isofiles = 1 - show_isofiles;
       }
-      for(i=0;i<nisoinfo;i++){
-        isoinfo[i].display=show_isofiles;
+      for(i=0;i<global_scase.nisoinfo;i++){
+        global_scase.isoinfo[i].display=show_isofiles;
       }
       UpdateShow();
     }
@@ -1326,8 +1326,8 @@ void ShowVSliceMenu(int value){
     if(value == SHOW_ALL)showall_slices = 1 - showall_slices;
     if(value == GLUI_SHOWALL_VSLICE)showall_slices = 1;
     if(value == GLUI_HIDEALL_VSLICE)showall_slices = 0;
-    for(i=0;i<slicecoll.nvsliceinfo;i++){
-      vd = slicecoll.vsliceinfo+i;
+    for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
+      vd = global_scase.slicecoll.vsliceinfo+i;
       if(vd->loaded==0)continue;
       vd->display= showall_slices;
     }
@@ -1358,8 +1358,8 @@ void ShowVSliceMenu(int value){
     show_cell_slices_and_vectors=1-show_cell_slices_and_vectors;
     return;
   }
-  vd = slicecoll.vsliceinfo + value;
-  if(slicefile_labelindex==slicecoll.sliceinfo[vd->ival].slicefile_labelindex){
+  vd = global_scase.slicecoll.vsliceinfo + value;
+  if(slicefile_labelindex==global_scase.slicecoll.sliceinfo[vd->ival].slicefile_labelindex){
     if(plotstate!=DYNAMIC_PLOTS){
       plotstate=DYNAMIC_PLOTS;
       vd->display=1;
@@ -1370,30 +1370,30 @@ void ShowVSliceMenu(int value){
     if(vd->iu!=-1){
       slicedata *sd;
 
-      sd = slicecoll.sliceinfo+vd->iu;
+      sd = global_scase.slicecoll.sliceinfo+vd->iu;
       sd->vloaded=vd->display;
     }
     if(vd->iv!=-1){
       slicedata *sd;
 
-      sd = slicecoll.sliceinfo+vd->iv;
+      sd = global_scase.slicecoll.sliceinfo+vd->iv;
       sd->vloaded=vd->display;
     }
     if(vd->iw!=-1){
       slicedata *sd;
 
-      sd = slicecoll.sliceinfo+vd->iw;
+      sd = global_scase.slicecoll.sliceinfo+vd->iw;
       sd->vloaded=vd->display;
     }
     if(vd->ival!=-1){
       slicedata *sd;
 
-      sd = slicecoll.sliceinfo+vd->ival;
+      sd = global_scase.slicecoll.sliceinfo+vd->ival;
       sd->vloaded=vd->display;
     }
   }
   else{
-    slicefile_labelindex = slicecoll.sliceinfo[vd->ival].slicefile_labelindex;
+    slicefile_labelindex = global_scase.slicecoll.sliceinfo[vd->ival].slicefile_labelindex;
     vd->display=1;
   }
   plotstate=GetPlotState(DYNAMIC_PLOTS);
@@ -1424,8 +1424,8 @@ void ShowHideSliceMenu(int value){
       if(value == GLUI_SHOWALL)showall_slices = 1;
       if(value == GLUI_HIDEALL)showall_slices = 0;
       if(value == SHOW_ALL)showall_slices = 1-showall_slices;
-      for(i=0;i<slicecoll.nsliceinfo;i++){
-        slicecoll.sliceinfo[i].display=showall_slices;
+      for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
+        global_scase.slicecoll.sliceinfo[i].display=showall_slices;
       }
       break;
     case MENU_SHOWSLICE_IN_GAS:
@@ -1459,7 +1459,7 @@ void ShowHideSliceMenu(int value){
   else{
     slicedata *sd;
 
-    sd = slicecoll.sliceinfo + value;
+    sd = global_scase.slicecoll.sliceinfo + value;
     if(slicefile_labelindex==sd->slicefile_labelindex){
       if(plotstate!=DYNAMIC_PLOTS){
         plotstate=DYNAMIC_PLOTS;
@@ -1629,9 +1629,9 @@ void DialogMenu(int value){
   case DIALOG_GEOMETRY:
     showedit_dialog=1-showedit_dialog;
     if(showedit_dialog==1){
-      if(fds_filein!=NULL&&updategetobstlabels==1){
+      if(global_scase.paths.fds_filein!=NULL&&updategetobstlabels==1){
         CheckMemoryOff;
-        GetObstLabels(fds_filein);
+        GetObstLabels(global_scase.paths.fds_filein);
         CheckMemoryOn;
         updategetobstlabels=0;
       }
@@ -2110,20 +2110,20 @@ void RenderMenu(int value){
 
       json_option = HTML_CURRENT_TIME;
       if(value==RenderJSONALL)json_option = HTML_ALL_TIMES;
-      if(Obst2Data(htmlobst_filename)!=0){
-        printf("blockage data output to %s\n", htmlobst_filename);
+      if(Obst2Data(global_scase.paths.htmlobst_filename)!=0){
+        printf("blockage data output to %s\n", global_scase.paths.htmlobst_filename);
       }
       else{
         printf("no blockage data to output\n");
       }
-      if(SliceNode2Data(htmlslicenode_filename, json_option)!=0){
-        printf("node centered slice file data output to %s\n", htmlslicenode_filename);
+      if(SliceNode2Data(global_scase.paths.htmlslicenode_filename, json_option)!=0){
+        printf("node centered slice file data output to %s\n", global_scase.paths.htmlslicenode_filename);
       }
       else{
         printf("no node centered slice file data to output\n");
       }
-      if(SliceCell2Data(htmlslicecell_filename, json_option)!=0){
-        printf("cell centered slice file data output to %s\n", htmlslicecell_filename);
+      if(SliceCell2Data(global_scase.paths.htmlslicecell_filename, json_option)!=0){
+        printf("cell centered slice file data output to %s\n", global_scase.paths.htmlslicecell_filename);
       }
       else{
         printf("no cell centered slice file data to output\n");
@@ -2132,10 +2132,10 @@ void RenderMenu(int value){
     }
     break;
   case RenderHTML:
-    Smv2Html(html_filename,   HTML_CURRENT_TIME, FROM_SMOKEVIEW);
+    Smv2Html(global_scase.paths.html_filename,   HTML_CURRENT_TIME, FROM_SMOKEVIEW);
     break;
   case RenderHTMLALL:
-    Smv2Html(html_filename,   HTML_ALL_TIMES, FROM_SMOKEVIEW);
+    Smv2Html(global_scase.paths.html_filename,   HTML_ALL_TIMES, FROM_SMOKEVIEW);
     break;
   case RenderCancel:
     RenderState(RENDER_OFF);
@@ -2168,12 +2168,12 @@ void RenderMenu(int value){
     else{
       if(stept == 0)Keyboard('t', FROM_SMOKEVIEW);
       ResetItimes0();
-      for(i=0;i<slicecoll.nsliceinfo;i++){
-        sd=slicecoll.sliceinfo+i;
+      for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
+        sd=global_scase.slicecoll.sliceinfo+i;
         sd->itime=0;
       }
-      for(i=0;i<nmeshes;i++){
-        meshi=meshinfo+i;
+      for(i=0;i<global_scase.meshescoll.nmeshes;i++){
+        meshi=global_scase.meshescoll.meshinfo+i;
         meshi->patch_itime=0;
       }
     }
@@ -2216,12 +2216,12 @@ void ParticleShowMenu(int value){
   partdata *parti;
   int i;
 
-  if(npartinfo==0)return;
+  if(global_scase.npartinfo==0)return;
   if(value==MENU_DUMMY)return;
   if(value<0){
     value = -value;
     value--;
-    parti = partinfo + value;
+    parti = global_scase.partinfo + value;
     parti->display = 1 - parti->display;
     updatemenu=1;
     GLUTPOSTREDISPLAY;
@@ -2244,8 +2244,8 @@ void ParticleShowMenu(int value){
       case MENU_PARTSHOW_SHOWALL:
         visSprinkPart=1;
         visSmokePart=2;
-        for(i=0;i<npartinfo;i++){
-          parti = partinfo + i;
+        for(i=0;i<global_scase.npartinfo;i++){
+          parti = global_scase.partinfo + i;
           if(parti->loaded==0)continue;
           parti->display=1;
         }
@@ -2255,8 +2255,8 @@ void ParticleShowMenu(int value){
       case MENU_PARTSHOW_HIDEALL:
         visSprinkPart=0;
         visSmokePart=0;
-        for(i=0;i<npartinfo;i++){
-          parti = partinfo + i;
+        for(i=0;i<global_scase.npartinfo;i++){
+          parti = global_scase.partinfo + i;
           if(parti->loaded==0)continue;
           parti->display=0;
         }
@@ -2283,8 +2283,8 @@ void ParticleShowMenu(int value){
       case 3:
         visSprinkPart=1;
         visSmokePart=2;
-        for(i=0;i<npartinfo;i++){
-          parti = partinfo + i;
+        for(i=0;i<global_scase.npartinfo;i++){
+          parti = global_scase.partinfo + i;
           if(parti->loaded==0)continue;
           parti->display=1;
         }
@@ -2497,10 +2497,10 @@ void TextureShowMenu(int value){
 
   updatefacelists=1;
   if(value>=0){
-    texti = textureinfo + value;
+    texti = global_scase.texture_coll.textureinfo + value;
     texti->display = 1-texti->display;
-    for(i=0;i<ntextureinfo;i++){
-      texti = textureinfo + i;
+    for(i=0;i<global_scase.texture_coll.ntextureinfo;i++){
+      texti = global_scase.texture_coll.textureinfo + i;
       if(texti->loaded==0||texti->used==0)continue;
       if(texti->display==0){
         showall_textures = 0;
@@ -2515,8 +2515,8 @@ void TextureShowMenu(int value){
     case MENU_TEXTURE_SHOWALL2:
       // load all textures if none are loaded
       loadall_textures = 1;
-      for(i = 0; i < ntextureinfo; i++){
-        texti = textureinfo + i;
+      for(i = 0; i < global_scase.texture_coll.ntextureinfo; i++){
+        texti = global_scase.texture_coll.textureinfo + i;
         if(texti->loaded == 1 && texti->used == 1&&texti->display==1){
           loadall_textures = 0;
           break;
@@ -2525,16 +2525,16 @@ void TextureShowMenu(int value){
       // if loadall_textures==1 then fall through and run MENU_TEXTURE_SHOWALL block
       if(loadall_textures == 0)break;
     case MENU_TEXTURE_SHOWALL:
-      for(i=0;i<ntextureinfo;i++){
-        texti = textureinfo + i;
+      for(i=0;i<global_scase.texture_coll.ntextureinfo;i++){
+        texti = global_scase.texture_coll.textureinfo + i;
         if(texti->loaded==0||texti->used==0)continue;
         texti->display=1;
       }
       showall_textures=1;
       break;
     case MENU_TEXTURE_HIDEALL:
-      for(i=0;i<ntextureinfo;i++){
-        texti = textureinfo + i;
+      for(i=0;i<global_scase.texture_coll.ntextureinfo;i++){
+        texti = global_scase.texture_coll.textureinfo + i;
         if(texti->loaded==0||texti->used==0)continue;
         texti->display=0;
       }
@@ -2546,15 +2546,15 @@ void TextureShowMenu(int value){
     }
   }
   visGeomTextures=0;
-  for(i=0;i<ngeominfo;i++){
+  for(i=0;i<global_scase.ngeominfo;i++){
     geomdata *geomi;
     surfdata *surf;
     texturedata *textii=NULL;
 
-    geomi = geominfo + i;
+    geomi = global_scase.geominfo + i;
     surf = geomi->surfgeom;
-    if(terrain_textures!=NULL){
-      textii = terrain_textures+iterrain_textures;
+    if(global_scase.terrain_texture_coll.terrain_textures!=NULL){
+      textii = global_scase.terrain_texture_coll.terrain_textures+iterrain_textures;
     }
     else{
       if(surf!=NULL)textii = surf->textureinfo;
@@ -2565,8 +2565,8 @@ void TextureShowMenu(int value){
     }
   }
 
-  for(i=0;i<ntextureinfo;i++){
-    texti = textureinfo + i;
+  for(i=0;i<global_scase.texture_coll.ntextureinfo;i++){
+    texti = global_scase.texture_coll.textureinfo + i;
     if(texti->loaded==1&&texti->used==1&&texti->display==1){
       if(value!=visBLOCKOutline&&value!=visBLOCKSolidOutline&&value!=visBLOCKHide){
         BlockageMenu(visBLOCKAsInput);
@@ -2635,17 +2635,17 @@ void Plot3DShowMenu(int value){
      Plot3DShowMenu(DISPLAY_PLOT3D);
      break;
    case DISPLAY_PLOT3D:
-     for(i=0;i<nplot3dinfo;i++){
-       if(plot3dinfo[i].loaded==1)plot3dinfo[i].display=show_plot3dfiles;
+     for(i=0;i<global_scase.nplot3dinfo;i++){
+       if(global_scase.plot3dinfo[i].loaded==1)global_scase.plot3dinfo[i].display=show_plot3dfiles;
      }
      break;
    default:
      if(value>=1000){
        if(plotstate==STATIC_PLOTS){
-         plot3dinfo[value-1000].display=1-plot3dinfo[value-1000].display;
+         global_scase.plot3dinfo[value-1000].display=1-global_scase.plot3dinfo[value-1000].display;
        }
        else{
-         plot3dinfo[value-1000].display=1;
+         global_scase.plot3dinfo[value-1000].display=1;
        }
      }
      break;
@@ -2822,7 +2822,7 @@ void SmokeviewIniMenu(int value){
     WriteIni(LOCAL_INI,NULL);
     break;
   case MENU_READSVO:
-    ReadDefaultObjectCollection(objectscoll, fdsprefix, setbw, isZoneFireModel);
+    ReadDefaultObjectCollection(&global_scase.objectscoll, global_scase.fdsprefix, setbw, global_scase.isZoneFireModel);
     break;
   case MENU_DUMMY:
     break;
@@ -3122,7 +3122,7 @@ void LoadVolsmoke3DMenu(int value){
     volrenderdata *vr;
 
     update_smokecolorbar = 1;
-    meshi = meshinfo + value;
+    meshi = global_scase.meshescoll.meshinfo + value;
     vr = meshi->volrenderinfo;
     if(vr->smokeslice != NULL&&vr->fireslice != NULL){
       if(scriptoutstream != NULL){
@@ -3193,12 +3193,12 @@ void UnloadAllSliceFiles(char *longlabel){
   int len;
 
   if(longlabel!=NULL)len = strlen(longlabel);
-  for(i=0; i<slicecoll.nvsliceinfo; i++){
+  for(i=0; i<global_scase.slicecoll.nvsliceinfo; i++){
     vslicedata *vslicei;
     char *label2;
     int len2;
 
-    vslicei = slicecoll.vsliceinfo+i;
+    vslicei = global_scase.slicecoll.vsliceinfo+i;
     if(vslicei->loaded==0)continue;
     if(vslicei->val==NULL)continue;
     label2 = vslicei->val->label.longlabel;
@@ -3207,12 +3207,12 @@ void UnloadAllSliceFiles(char *longlabel){
       ReadVSlice(i,ALL_FRAMES, NULL, UNLOAD, DEFER_SLICECOLOR, &errorcode);
     }
   }
-  for(i=0; i<slicecoll.nsliceinfo; i++){
+  for(i=0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     char *label2;
     int len2;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     if(slicei->loaded==0||slicei->vloaded==1)continue;
     label2 = slicei->label.longlabel;
     len2 = strlen(label2);
@@ -3227,30 +3227,30 @@ void UnloadAllSliceFiles(char *longlabel){
 void ReloadAllVectorSliceFiles(int load_flag){
   int i, errorcode;
 
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     slicei->uvw = 0;
   }
-  for(i = 0; i<slicecoll.nvsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nvsliceinfo; i++){
     vslicedata *vslicei;
 
-    vslicei = slicecoll.vsliceinfo+i;
+    vslicei = global_scase.slicecoll.vsliceinfo+i;
     vslicei->reload = 0;
     if(vslicei->loaded==1&&vslicei->display==1)vslicei->reload = 1;
-    if(vslicei->iu>=0)slicecoll.sliceinfo[vslicei->iu].uvw = 1;
-    if(vslicei->iv>=0)slicecoll.sliceinfo[vslicei->iv].uvw = 1;
-    if(vslicei->iw>=0)slicecoll.sliceinfo[vslicei->iw].uvw = 1;
+    if(vslicei->iu>=0)global_scase.slicecoll.sliceinfo[vslicei->iu].uvw = 1;
+    if(vslicei->iv>=0)global_scase.slicecoll.sliceinfo[vslicei->iv].uvw = 1;
+    if(vslicei->iw>=0)global_scase.slicecoll.sliceinfo[vslicei->iw].uvw = 1;
   }
 
     //*** reload vector slice files
 
 #ifndef pp_SLICEFRAME
-  for(i = 0; i<slicecoll.nvsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nvsliceinfo; i++){
     vslicedata *vslicei;
 
-    vslicei = slicecoll.vsliceinfo+i;
+    vslicei = global_scase.slicecoll.vsliceinfo+i;
     if(vslicei->reload==1){
       ReadVSlice(i, ALL_FRAMES, NULL, UNLOAD, DEFER_SLICECOLOR, &errorcode);
     }
@@ -3258,19 +3258,19 @@ void ReloadAllVectorSliceFiles(int load_flag){
 #endif
   int lastslice=0;
 
-  for(i = slicecoll.nvsliceinfo-1; i>=0; i--){
+  for(i = global_scase.slicecoll.nvsliceinfo-1; i>=0; i--){
     vslicedata *vslicei;
 
-    vslicei = slicecoll.vsliceinfo+i;
+    vslicei = global_scase.slicecoll.vsliceinfo+i;
     if(vslicei->reload==1){
       lastslice = i;
       break;
     }
   }
-  for(i = 0; i<slicecoll.nvsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nvsliceinfo; i++){
     vslicedata *vslicei;
 
-    vslicei = slicecoll.vsliceinfo+i;
+    vslicei = global_scase.slicecoll.vsliceinfo+i;
     if(vslicei->reload==1){
       if(i==lastslice){
         ReadVSlice(i, ALL_FRAMES, NULL, load_flag, SET_SLICECOLOR, &errorcode);
@@ -3293,15 +3293,15 @@ void ReloadAllSliceFiles(int load_flag){
   float load_time;
   slicedata **reload_slicelist;
 
-  if(slicecoll.nsliceinfo == 0)return;
-  NewMemory((void **)&reload_slicelist, slicecoll.nsliceinfo*sizeof(slicedata *));
+  if(global_scase.slicecoll.nsliceinfo == 0)return;
+  NewMemory((void **)&reload_slicelist, global_scase.slicecoll.nsliceinfo*sizeof(slicedata *));
   slicefile_labelindex_save = slicefile_labelindex;
   START_TIMER(load_time);
 
-  for(ii=0; ii<slicecoll.nsliceinfo; ii++){
+  for(ii=0; ii<global_scase.slicecoll.nsliceinfo; ii++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+ii;
+    slicei = global_scase.slicecoll.sliceinfo+ii;
     reload_slicelist[ii] = NULL;
     if(slicei->loaded==1&&slicei->display==1){ // don't reload a slice file that is part of a vector slice
       if(slicei->vloaded==0){
@@ -3309,14 +3309,14 @@ void ReloadAllSliceFiles(int load_flag){
       }
     }
   }
-  for(ii = 0; ii < slicecoll.nsliceinfo; ii++){
+  for(ii = 0; ii < global_scase.slicecoll.nsliceinfo; ii++){
     slicedata *slicei;
     int i;
     int errorcode;
 
     slicei = reload_slicelist[ii];
     if(slicei==NULL)continue;
-    i = slicei-slicecoll.sliceinfo;
+    i = slicei-global_scase.slicecoll.sliceinfo;
 
     if(slicei->slice_filetype == SLICE_GEOM){
 #ifdef pp_SLICEFRAME
@@ -3393,11 +3393,11 @@ void UnloadAllSmoke3D(int type){
   int i;
 
   update_glui_merge_smoke = 1;
-  if(smoke3dcoll.nsmoke3dinfo > 0){
-    for(i = 0; i < smoke3dcoll.nsmoke3dinfo; i++){
+  if(global_scase.smoke3dcoll.nsmoke3dinfo > 0){
+    for(i = 0; i < global_scase.smoke3dcoll.nsmoke3dinfo; i++){
       smoke3ddata *smoke3di;
 
-      smoke3di = smoke3dcoll.smoke3dinfo + i;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
       if(type == -1 || smoke3di->type == type)smoke3di->request_load = 0;
       if(smoke3di->loaded == 0)continue;
       if(type == -1 || smoke3di->type == type){
@@ -3458,7 +3458,7 @@ void LoadUnloadMenu(int value){
     if(scriptoutstream!=NULL){
       fprintf(scriptoutstream,"UNLOADALL\n");
     }
-    if(hvaccoll.nhvacinfo>0){
+    if(global_scase.hvaccoll.nhvacinfo>0){
       LoadHVACMenu(MENU_HVAC_UNLOAD);
     }
     if(nvolrenderinfo>0){
@@ -3467,10 +3467,10 @@ void LoadUnloadMenu(int value){
 
     LoadVSliceMenu2(UNLOAD_ALL);
 
-    for(i = 0; i < slicecoll.nsliceinfo; i++){
+    for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
       if(slicei->loaded == 1){
         if(slicei->slice_filetype == SLICE_GEOM){
           ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0, &errorcode);
@@ -3480,22 +3480,22 @@ void LoadUnloadMenu(int value){
         }
       }
     }
-    for(i = 0; i<nplot3dinfo; i++){
+    for(i = 0; i<global_scase.nplot3dinfo; i++){
       ReadPlot3D("",i,UNLOAD,&errorcode);
     }
-    for(i=0;i<npatchinfo;i++){
+    for(i=0;i<global_scase.npatchinfo;i++){
       ReadBoundary(i,UNLOAD,&errorcode);
     }
-    for(i=0;i<npartinfo;i++){
+    for(i=0;i<global_scase.npartinfo;i++){
       ReadPart("",i,UNLOAD,&errorcode);
     }
-    for(i=0;i<nisoinfo;i++){
+    for(i=0;i<global_scase.nisoinfo;i++){
       ReadIso("",i,UNLOAD,NULL,&errorcode);
     }
-    for(i=0;i<nzoneinfo;i++){
+    for(i=0;i<global_scase.nzoneinfo;i++){
       ReadZone(i,UNLOAD,&errorcode);
     }
-    if(smoke3dcoll.nsmoke3dinfo > 0){
+    if(global_scase.smoke3dcoll.nsmoke3dinfo > 0){
       UnloadAllSmoke3D(-1);
     }
     if(nvolrenderinfo>0){
@@ -3523,12 +3523,12 @@ void LoadUnloadMenu(int value){
     load_flag = LOAD;
 #endif
     THREADcontrol(compress_threads, THREAD_LOCK);
-    if(hrr_csv_filename!=NULL){
+    if(global_scase.paths.hrr_csv_filename!=NULL){
       ReadHRR(LOAD);
     }
 
     //*** reload hvac file
-      if(hvaccoll.hvacductvalsinfo!=NULL&&hvaccoll.hvacductvalsinfo->loaded==1){
+      if(global_scase.hvaccoll.hvacductvalsinfo!=NULL&&global_scase.hvaccoll.hvacductvalsinfo->loaded==1){
         LoadHVACMenu(MENU_HVAC_LOAD);
       }
 
@@ -3545,12 +3545,12 @@ void LoadUnloadMenu(int value){
 
     //*** reload plot3d files
 
-    for(i = 0; i<nplot3dinfo; i++){
-      plot3dinfo[i].finalize=0;
+    for(i = 0; i<global_scase.nplot3dinfo; i++){
+      global_scase.plot3dinfo[i].finalize=0;
     }
-    for(i = nplot3dinfo-1; i>=0; i--){
-      if(plot3dinfo[i].loaded==1){
-        plot3dinfo[i].finalize = 1;
+    for(i = global_scase.nplot3dinfo-1; i>=0; i--){
+      if(global_scase.plot3dinfo[i].loaded==1){
+        global_scase.plot3dinfo[i].finalize = 1;
         break;
       }
     }
@@ -3559,10 +3559,10 @@ void LoadUnloadMenu(int value){
     int file_count=0;
     float plot3d_timer;
     START_TIMER(plot3d_timer);
-    for(i=0;i<nplot3dinfo;i++){
-      if(plot3dinfo[i].loaded==1){
+    for(i=0;i<global_scase.nplot3dinfo;i++){
+      if(global_scase.plot3dinfo[i].loaded==1){
         plot3d_loaded = 1;
-        total_plot3d_filesize += ReadPlot3D(plot3dinfo[i].file,i,LOAD,&errorcode);
+        total_plot3d_filesize += ReadPlot3D(global_scase.plot3dinfo[i].file,i,LOAD,&errorcode);
         file_count++;
       }
     }
@@ -3576,10 +3576,10 @@ void LoadUnloadMenu(int value){
 
     //*** reload boundary files
 
-    for(i = 0;i < npatchinfo;i++){
+    for(i = 0;i < global_scase.npatchinfo;i++){
       patchdata *patchi;
 
-      patchi = patchinfo + i;
+      patchi = global_scase.patchinfo + i;
       assert(patchi->loaded==0||patchi->loaded==1);
       if(patchi->loaded == 1){
 #ifdef pp_BOUNDFRAME
@@ -3595,10 +3595,10 @@ void LoadUnloadMenu(int value){
 
     //*** reload 3d smoke files
 
-    for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
+    for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
       smoke3ddata *smoke3di;
 
-      smoke3di = smoke3dcoll.smoke3dinfo + i;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
       if(smoke3di->request_load==1){
 #ifdef pp_SMOKEFRAME
         ReadSmoke3D(ALL_SMOKE_FRAMES, i, load_flag, FIRST_TIME, &errorcode);
@@ -3619,10 +3619,10 @@ void LoadUnloadMenu(int value){
     }
 #else
     int npartloaded_local = 0;
-    for(i=0;i<npartinfo;i++){
+    for(i=0;i<global_scase.npartinfo;i++){
       partdata *parti;
 
-      parti = partinfo+i;
+      parti = global_scase.partinfo+i;
       if(parti->loaded==1){
         parti->reload=1;
         npartloaded_local++;
@@ -3643,10 +3643,10 @@ void LoadUnloadMenu(int value){
 
     update_readiso_geom_wrapup = UPDATE_ISO_START_ALL;
     CancelUpdateTriangles();
-    for(i = 0; i<nisoinfo; i++){
+    for(i = 0; i<global_scase.nisoinfo; i++){
       isodata *isoi;
 
-      isoi = isoinfo + i;
+      isoi = global_scase.isoinfo + i;
       if(isoi->loaded==0)continue;
 #ifdef pp_ISOFRAME
       ReadIso(isoi->file, i, load_flag, NULL, &errorcode);
@@ -3717,7 +3717,7 @@ void LoadUnloadMenu(int value){
       LOG_FILENAME=NULL;
     }
     if(redirect==1){
-      LOG_FILENAME=fopen(log_filename,"w");
+      LOG_FILENAME=fopen(global_scase.paths.log_filename,"w");
       if(LOG_FILENAME==NULL)redirect=0;
     }
     if(redirect==1){
@@ -3758,16 +3758,16 @@ void TourMenu(int value){
     DialogMenu(DIALOG_TOUR_SHOW);
     break;
   case MENU_TOUR_CLEARALL:
-    for(i=0;i<tourcoll.ntourinfo;i++){  // clear all tours
-      touri = tourcoll.tourinfo + i;
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){  // clear all tours
+      touri = global_scase.tourcoll.tourinfo + i;
       touri->display=touri->display2;
     }
     if(viewtourfrompath==1){
       SetViewPoint(RESTORE_EXTERIOR_VIEW);
     }
     from_glui_trainer=0;
-    for(i=0;i<tourcoll.ntourinfo;i++){
-      touri = tourcoll.tourinfo + i;
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+      touri = global_scase.tourcoll.tourinfo + i;
       if(touri->display==1){
         selected_tour=touri;
         break;
@@ -3776,8 +3776,8 @@ void TourMenu(int value){
     selected_tour=NULL;
     break;
   case MENU_TOUR_MANUAL:
-    for(i=0;i<tourcoll.ntourinfo;i++){  // clear all tours
-      touri = tourcoll.tourinfo + i;
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){  // clear all tours
+      touri = global_scase.tourcoll.tourinfo + i;
       touri->display=0;
     }
     if(viewtourfrompath==1){
@@ -3797,8 +3797,8 @@ void TourMenu(int value){
     }
     break;
   case MENU_TOUR_SHOWALL:               // show all tours
-    for(i=0;i<tourcoll.ntourinfo;i++){
-      touri = tourcoll.tourinfo + i;
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+      touri = global_scase.tourcoll.tourinfo + i;
       touri->display=1;
     }
     plotstate=GetPlotState(DYNAMIC_PLOTS);
@@ -3808,8 +3808,8 @@ void TourMenu(int value){
     if(viewtourfrompath==0)SetViewPoint(RESTORE_EXTERIOR_VIEW);
     break;
   case MENU_TOUR_DEFAULT:
-    for(i=0;i<tourcoll.ntourinfo;i++){
-      touri = tourcoll.tourinfo + i;
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+      touri = global_scase.tourcoll.tourinfo + i;
       touri->display=0;
     }
     SetViewPoint(RESTORE_EXTERIOR_VIEW);
@@ -3818,18 +3818,18 @@ void TourMenu(int value){
   default:
     if(value<-22){
       tourlocus_type=2;
-      objectscoll->iavatar_types=(-value-23);
-      if(selectedtour_index>=0&&selectedtour_index<tourcoll.ntourinfo){
-        tourcoll.tourinfo[selectedtour_index].glui_avatar_index=objectscoll->iavatar_types;
+      global_scase.objectscoll.iavatar_types=(-value-23);
+      if(selectedtour_index>=0&&selectedtour_index<global_scase.tourcoll.ntourinfo){
+        global_scase.tourcoll.tourinfo[selectedtour_index].glui_avatar_index=global_scase.objectscoll.iavatar_types;
       }
     }
 
     //  show one tour
 
-    if(value>=0&&value<tourcoll.ntourinfo){
+    if(value>=0&&value<global_scase.tourcoll.ntourinfo){
       int j;
 
-      touri = tourcoll.tourinfo + value;
+      touri = global_scase.tourcoll.tourinfo + value;
       touri->display = 1 - touri->display;
       if(touri->display==1){
         selectedtour_index=value;
@@ -3837,10 +3837,10 @@ void TourMenu(int value){
         selected_tour=touri;
       }
       else{
-        for(j=0;j<tourcoll.ntourinfo;j++){
+        for(j=0;j<global_scase.tourcoll.ntourinfo;j++){
           tourdata *tourj;
 
-          tourj = tourcoll.tourinfo + j;
+          tourj = global_scase.tourcoll.tourinfo + j;
           if(touri==tourj||tourj->display==0)continue;
           selectedtour_index=j;
           selected_frame=tourj->first_frame.next;
@@ -3881,7 +3881,7 @@ void SetTour(tourdata *thetour){
   int tournumber;
 
   if(thetour==NULL)return;
-  tournumber = thetour - tourcoll.tourinfo;
+  tournumber = thetour - global_scase.tourcoll.tourinfo;
   TourMenu(tournumber);
 }
 
@@ -3899,8 +3899,8 @@ void UpdateStreakValue(float value){
       break;
     }
   }
-  for(i=0;i<npartinfo;i++){
-    parti = partinfo + i;
+  for(i=0;i<global_scase.npartinfo;i++){
+    parti = global_scase.partinfo + i;
     if(parti->loaded==1)break;
   }
   if(parti!=NULL&&parti->loaded==1&&parti->ntimes>1){
@@ -3949,12 +3949,12 @@ void PropMenu(int value){
 
   // value = iobject*npropinfo + iprop
 
-  iprop = value%npropinfo;
-  iobject = value / npropinfo;
-  if(iprop >= 0 && iprop < npropinfo){
+  iprop = value%global_scase.propcoll.npropinfo;
+  iobject = value / global_scase.propcoll.npropinfo;
+  if(iprop >= 0 && iprop < global_scase.propcoll.npropinfo){
     propdata *propi;
 
-    propi = propinfo + iprop;
+    propi = global_scase.propcoll.propinfo + iprop;
     if(iobject >= 0 && iobject < propi->nsmokeview_ids){
       int i;
 
@@ -3965,10 +3965,10 @@ void PropMenu(int value){
         propi->vars_indep, propi->nvars_indep,
         propi->vars_indep_index);
 
-      for(i = 0;i < npartclassinfo;i++){
+      for(i = 0;i < global_scase.npartclassinfo;i++){
         partclassdata *partclassi;
 
-        partclassi = partclassinfo + i;
+        partclassi = global_scase.partclassinfo + i;
         UpdatePartClassDepend(partclassi);
 
       }
@@ -4030,7 +4030,7 @@ void ParticlePropShowMenu(int value){
       int i;
 
       vis = current_property->class_vis;
-      for(i=0;i< npartclassinfo;i++){
+      for(i=0;i< global_scase.npartclassinfo;i++){
         vis[i]=1;
       }
     }
@@ -4041,7 +4041,7 @@ void ParticlePropShowMenu(int value){
       int i;
 
       vis = current_property->class_vis;
-      for(i=0;i< npartclassinfo;i++){
+      for(i=0;i< global_scase.npartclassinfo;i++){
         vis[i]=0;
       }
     }
@@ -4091,7 +4091,7 @@ void ParticlePropShowMenu(int value){
     else{
       partclassdata *partclassj;
 
-      partclassj = partclassinfo + iclass;
+      partclassj = global_scase.partclassinfo + iclass;
       partclassj->vis_type=vistype;
       PropMenu(propvalue);
     }
@@ -4105,11 +4105,11 @@ void ParticlePropShowMenu(int value){
 void UnloadAllPartFiles(void){
   int i;
 
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
     int errorcode;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     if(parti->loaded==0)continue;
     ReadPart(parti->file, i, UNLOAD, &errorcode);
   }
@@ -4120,12 +4120,12 @@ void UnloadAllPartFiles(void){
 void LoadAllPartFiles(int partnum){
   int i;
 
-  for(i = 0;i<npartinfo;i++){
+  for(i = 0;i<global_scase.npartinfo;i++){
     partdata *parti;
     int errorcode;
     FILE_SIZE file_size;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
 #ifdef pp_PARTFRAME
     if(partnum != RELOAD_LOADED_PART_FILES && partnum != LOAD_ALL_PART_FILES){
       IF_NOT_USEMESH_CONTINUE(parti->loaded, parti->blocknumber);
@@ -4171,11 +4171,11 @@ void SetupPart(int value){
   int i;
   int *list = NULL, nlist = 0;
 
-  NewMemory((void **)&list, npartinfo*sizeof(int));
-  for(i = 0; i<npartinfo; i++){
+  NewMemory((void **)&list, global_scase.npartinfo*sizeof(int));
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     if(
       load_only_when_unloaded == 0 &&
       parti->loaded == 1){
@@ -4190,10 +4190,10 @@ void SetupPart(int value){
   }
   SetLoadedPartBounds(list, nlist);
   FREEMEMORY(list);
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     parti->finalize = 0;
     parti->skipload = 1;
     parti->loadstatus = FILE_UNLOADED;
@@ -4207,16 +4207,16 @@ void SetupPart(int value){
   if(value>=0){
     partdata *parti;
 
-    parti = partinfo+value;
-    assert(value>=0&&value<npartinfo);
-    value = CLAMP(value, 0, npartinfo-1);
+    parti = global_scase.partinfo+value;
+    assert(value>=0&&value<global_scase.npartinfo);
+    value = CLAMP(value, 0, global_scase.npartinfo-1);
     parti->finalize = 1;
   }
   else{
-    for(i = npartinfo-1; i>=0; i--){
+    for(i = global_scase.npartinfo-1; i>=0; i--){
       partdata *parti;
 
-      parti = partinfo+i;
+      parti = global_scase.partinfo+i;
       if(parti->skipload==1)continue;
       parti->finalize = 1;
       break;
@@ -4259,16 +4259,16 @@ void LoadAllPartFilesMT(int partnum){
 
   INIT_PRINT_TIMER(part_timer);
   if(partnum < 0){
-    for(i = 0; i < npartinfo; i++){
+    for(i = 0; i < global_scase.npartinfo; i++){
       partdata *parti;
 
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
       parti->finalize = 0;
     }
-    for(i = npartinfo - 1; i >= 0; i--){
+    for(i = global_scase.npartinfo - 1; i >= 0; i--){
       partdata *parti;
 
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
       if(parti->loaded == 1){
         parti->finalize = 1;
         FinalizePartLoad(parti);
@@ -4277,7 +4277,7 @@ void LoadAllPartFilesMT(int partnum){
     }
   }
   else{
-    FinalizePartLoad(partinfo + partnum);
+    FinalizePartLoad(global_scase.partinfo + partnum);
   }
   PRINT_TIMER(part_timer, "finalize particle time");
 }
@@ -4297,7 +4297,7 @@ void LoadParticleMenu(int value){
     char  *partfile;
     partdata *parti;
 
-    parti = partinfo + value;
+    parti = global_scase.partinfo + value;
     partfile = parti->file;
     parti->finalize = 1;
     if(scriptoutstream!=NULL){
@@ -4309,12 +4309,12 @@ void LoadParticleMenu(int value){
     if(scriptoutstream==NULL||script_defer_loading==0){
       SetupPart(value);                                                // load only particle file with index value
       LoadAllPartFilesMT(value);
-      if(partinfo[value].file_size == 0.0)printf("***warning: particle file has no particles\n");
+      if(global_scase.partinfo[value].file_size == 0.0)printf("***warning: particle file has no particles\n");
     }
   }
   else{
     if(value==MENU_PARTICLE_UNLOAD_ALL){
-      for(i=0;i<npartinfo;i++){
+      for(i=0;i<global_scase.npartinfo;i++){
         ReadPart("", i, UNLOAD, &errorcode);
       }
     }
@@ -4330,20 +4330,20 @@ void LoadParticleMenu(int value){
     }
     else if(value == MENU_PART_NUM_FILE_SIZE){
       int total = 0;
-      for(i = 0;i < npartinfo;i++){
+      for(i = 0;i < global_scase.npartinfo;i++){
         partdata *parti;
 
-        parti = partinfo + i;
+        parti = global_scase.partinfo + i;
         total += parti->npoints_file;
       }
       printf("Particle number/file size: %i/", total);
       FILE_SIZE total_size;
 
       total_size=0;
-      for(i = 0; i < npartinfo; i++){
+      for(i = 0; i < global_scase.npartinfo; i++){
         partdata *parti;
 
-        parti = partinfo + i;
+        parti = global_scase.partinfo + i;
         total_size += GetFileSizeSMV(parti->reg_file);
       }
       if(total_size > 1000000000){
@@ -4388,19 +4388,19 @@ void LoadParticleMenu(int value){
 
         START_TIMER(part_load_time);
         int have_particles = 0, load_particles=0;
-        for(i = 0; i<npartinfo; i++){
+        for(i = 0; i<global_scase.npartinfo; i++){
           partdata *parti;
 
-          parti = partinfo+i;
+          parti = global_scase.partinfo+i;
           parti->file_size = 0;
           if(parti->skipload==0)load_particles = 1;
         }
         if(load_particles==1){
           LoadAllPartFilesMT(LOAD_ALL_PART_FILES);
-          for(i = 0; i<npartinfo; i++){
+          for(i = 0; i<global_scase.npartinfo; i++){
             partdata *parti;
 
-            parti = partinfo+i;
+            parti = global_scase.partinfo+i;
             if(parti->file_size>0){
               have_particles = 1;
               break;
@@ -4431,14 +4431,14 @@ void ZoneMenu(int value){
     if(scriptoutstream!=NULL){
       zonedata *zonei;
 
-      zonei = zoneinfo + value;
+      zonei = global_scase.zoneinfo + value;
       fprintf(scriptoutstream,"LOADFILE\n");
       fprintf(scriptoutstream," %s\n",zonei->file);
     }
     ReadZone(value,LOAD,&errorcode);
   }
   else{
-    for(i=0;i<nzoneinfo;i++){
+    for(i=0;i<global_scase.nzoneinfo;i++){
       ReadZone(i,UNLOAD,&errorcode);
     }
   }
@@ -4459,19 +4459,19 @@ void UnloadVSliceMenu(int value){
   else if(value==UNLOAD_ALL){
     int lastslice=0;
 
-    for(i = slicecoll.nvsliceinfo-1; i>=0; i--){
+    for(i = global_scase.slicecoll.nvsliceinfo-1; i>=0; i--){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo+i;
+      vslicei = global_scase.slicecoll.vsliceinfo+i;
       if(vslicei->loaded==1){
         lastslice = i;
         break;
       }
     }
-    for(i=0;i<slicecoll.nvsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo+i;
+      vslicei = global_scase.slicecoll.vsliceinfo+i;
       if(vslicei->loaded==1){
         if(lastslice==i){
           ReadVSlice(i, ALL_FRAMES, NULL, UNLOAD, SET_SLICECOLOR, &errorcode);
@@ -4498,10 +4498,10 @@ void UnloadBoundaryMenu(int value){
     ReadBoundary(value,UNLOAD,&errorcode);
   }
   else{
-    for(i=0;i<npatchinfo;i++){
+    for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
 
-      patchi = patchinfo+i;
+      patchi = global_scase.patchinfo+i;
       if(patchi->filetype_label==NULL||strcmp(patchi->filetype_label, "INCLUDE_GEOM")!=0){
         ReadBoundary(i,UNLOAD,&errorcode);
       }
@@ -4520,7 +4520,7 @@ void UnloadPlot3dMenu(int value){
     ReadPlot3D("",value,UNLOAD,&errorcode);
   }
   else{
-    for(i=0;i<nplot3dinfo;i++){
+    for(i=0;i<global_scase.nplot3dinfo;i++){
       ReadPlot3D("",i,UNLOAD,&errorcode);
     }
   }
@@ -4538,19 +4538,19 @@ FILE_SIZE LoadVSliceMenu2(int value){
   if(value==UNLOAD_ALL){
     int lastslice=0;
 
-    for(i=slicecoll.nvsliceinfo-1;i>=0;i--){
+    for(i=global_scase.slicecoll.nvsliceinfo-1;i>=0;i--){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo + i;
+      vslicei = global_scase.slicecoll.vsliceinfo + i;
       if(vslicei->loaded==1){
         lastslice = i;
         break;
       }
     }
-    for(i=0;i<slicecoll.nvsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo + i;
+      vslicei = global_scase.slicecoll.vsliceinfo + i;
       if(vslicei->loaded==1){
         if(lastslice==i){
           ReadVSlice(i,ALL_FRAMES, NULL,  UNLOAD, SET_SLICECOLOR, &errorcode);
@@ -4570,7 +4570,7 @@ FILE_SIZE LoadVSliceMenu2(int value){
     slicedata *slicei;
 
     return_filesize = ReadVSlice(value, ALL_FRAMES, NULL, LOAD, SET_SLICECOLOR, &errorcode);
-    vslicei = slicecoll.vsliceinfo + value;
+    vslicei = global_scase.slicecoll.vsliceinfo + value;
     slicei = vslicei->val;
     if(script_multivslice==0&&slicei!=NULL&&scriptoutstream!=NULL){
       fprintf(scriptoutstream,"LOADVSLICEM\n");
@@ -4596,27 +4596,27 @@ FILE_SIZE LoadVSliceMenu2(int value){
     submenutype=value/4;
     dir=value%4;
     submenutype=subvslice_menuindex[submenutype];
-    vslicei = slicecoll.vsliceinfo + submenutype;
-    slicei = slicecoll.sliceinfo + vslicei->ival;
+    vslicei = global_scase.slicecoll.vsliceinfo + submenutype;
+    slicei = global_scase.slicecoll.sliceinfo + vslicei->ival;
     submenulabel = slicei->label.longlabel;
     START_TIMER(load_time);
 
-    for(i = slicecoll.nvsliceinfo-1; i>=0; i--){
+    for(i = global_scase.slicecoll.nvsliceinfo-1; i>=0; i--){
       char *longlabel;
 
-      vslicei = slicecoll.vsliceinfo+i;
-      slicei = slicecoll.sliceinfo+vslicei->ival;
+      vslicei = global_scase.slicecoll.vsliceinfo+i;
+      slicei = global_scase.slicecoll.sliceinfo+vslicei->ival;
       longlabel = slicei->label.longlabel;
       if(strcmp(longlabel, submenulabel)!=0)continue;
       if(dir!=0&&dir!=slicei->idir)continue;
       lastslice = i;
       break;
     }
-    for(i=0;i<slicecoll.nvsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
       char *longlabel;
 
-      vslicei = slicecoll.vsliceinfo + i;
-      slicei=slicecoll.sliceinfo + vslicei->ival;
+      vslicei = global_scase.slicecoll.vsliceinfo + i;
+      slicei=global_scase.slicecoll.sliceinfo + vslicei->ival;
       longlabel = slicei->label.longlabel;
       if(strcmp(longlabel,submenulabel)!=0)continue;
       if(dir!=0&&dir!=slicei->idir)continue;
@@ -4665,7 +4665,7 @@ void UnloadSliceMenu(int value){
   if(value>=0){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+value;
+    slicei = global_scase.slicecoll.sliceinfo+value;
 
     if(slicei->slice_filetype==SLICE_GEOM){
       ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0, &errorcode);
@@ -4679,10 +4679,10 @@ void UnloadSliceMenu(int value){
   }
   else{
     if(value==UNLOAD_ALL){
-      for(i=0;i<slicecoll.nsliceinfo;i++){
+      for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo+i;
+        slicei = global_scase.slicecoll.sliceinfo+i;
         if(slicei->slice_filetype == SLICE_GEOM){
           ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0, &errorcode);
         }
@@ -4690,10 +4690,10 @@ void UnloadSliceMenu(int value){
           ReadSlice("",i, ALL_FRAMES, NULL, UNLOAD,DEFER_SLICECOLOR,&errorcode);
         }
       }
-      for(i=0;i<npatchinfo;i++){
+      for(i=0;i<global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->filetype_label!=NULL&&strcmp(patchi->filetype_label, "INCLUDE_GEOM")==0){
           UnloadBoundaryMenu(i);
         }
@@ -4709,7 +4709,7 @@ void UnloadMultiVSliceMenu(int value){
   multivslicedata *mvslicei;
 
   if(value>=0){
-    mvslicei = slicecoll.multivsliceinfo + value;
+    mvslicei = global_scase.slicecoll.multivsliceinfo + value;
     for(i=0;i<mvslicei->nvslices;i++){
       UnloadSliceMenu(mvslicei->ivslices[i]);
     }
@@ -4726,7 +4726,7 @@ void UnloadMultiSliceMenu(int value){
   multislicedata *mslicei;
 
   if(value>=0){
-    mslicei = slicecoll.multisliceinfo + value;
+    mslicei = global_scase.slicecoll.multisliceinfo + value;
     for(i=0;i<mslicei->nslices;i++){
       UnloadSliceMenu(mslicei->islices[i]);
     }
@@ -4751,7 +4751,7 @@ void ShowVolsmoke3DMenu(int value){
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo + value;
+    meshi = global_scase.meshescoll.meshinfo + value;
     vr = meshi->volrenderinfo;
     if(vr->fireslice!=NULL||vr->smokeslice!=NULL){
       if(vr->loaded==1){
@@ -4770,11 +4770,11 @@ void ShowVolsmoke3DMenu(int value){
     else if(value==TOGGLE_VOLSMOKE){  // show all
       show_volsmokefiles=1-show_volsmokefiles;
     }
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       volrenderdata *vr;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       vr = meshi->volrenderinfo;
       if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
       if(vr->loaded==1){
@@ -4797,11 +4797,11 @@ void UnLoadVolsmoke3DMenu(int value){
   updatemenu=1;
   if(value<0){
     if(value==UNLOAD_ALL){
-      for(i=0;i<nmeshes;i++){
+      for(i=0;i<global_scase.meshescoll.nmeshes;i++){
         meshdata *meshi;
         volrenderdata *vr;
 
-        meshi = meshinfo + i;
+        meshi = global_scase.meshescoll.meshinfo + i;
         vr = meshi->volrenderinfo;
         if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
         if(vr->loaded==1){
@@ -4814,7 +4814,7 @@ void UnLoadVolsmoke3DMenu(int value){
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo + value;
+    meshi = global_scase.meshescoll.meshinfo + value;
     vr = meshi->volrenderinfo;
     if(vr->fireslice!=NULL||vr->smokeslice!=NULL){
       UnloadVolsmokeAllFrames(vr);
@@ -4835,7 +4835,7 @@ void UnLoadSmoke3DMenu(int value){
     UnloadAllSmoke3D(value);
   }
   else{
-    UnloadSmoke3D(smoke3dcoll.smoke3dinfo + value);
+    UnloadSmoke3D(global_scase.smoke3dcoll.smoke3dinfo + value);
     SmokeWrapup();
   }
 }
@@ -4857,19 +4857,19 @@ FILE_SIZE LoadSmoke3D(int type, int frame, int *count, float *time_value){
   FILE_SIZE load_size=0;
 
   if(load_only_when_unloaded == 0){
-    for(i = smoke3dcoll.nsmoke3dinfo - 1; i >= 0; i--){
+    for(i = global_scase.smoke3dcoll.nsmoke3dinfo - 1; i >= 0; i--){
       smoke3ddata *smoke3di;
 
-      smoke3di = smoke3dcoll.smoke3dinfo + i;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
       if(smoke3di->loaded==1&&IsSmokeType(smoke3di, type) == 1){
         ReadSmoke3D(ALL_SMOKE_FRAMES, i, UNLOAD, FIRST_TIME, &errorcode);
       }
     }
   }
-  for(i = smoke3dcoll.nsmoke3dinfo-1; i>=0; i--){
+  for(i = global_scase.smoke3dcoll.nsmoke3dinfo-1; i>=0; i--){
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo+i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo+i;
     IF_NOT_USEMESH_CONTINUE(smoke3di->loaded,smoke3di->blocknumber);
     if(IsSmokeType(smoke3di, type) == 1){
     last_smoke = i;
@@ -4877,10 +4877,10 @@ FILE_SIZE LoadSmoke3D(int type, int frame, int *count, float *time_value){
     }
   }
   smoke3d_compression_type = COMPRESSED_UNKNOWN;
-  for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
+  for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     IF_NOT_USEMESH_CONTINUE(smoke3di->loaded,smoke3di->blocknumber);
     if(IsSmokeType(smoke3di, type) == 1){
       file_count++;
@@ -4922,22 +4922,22 @@ void LoadSmoke3DMenu(int value){
     if(scriptoutstream!=NULL){
       char *file;
 
-      file = smoke3dcoll.smoke3dinfo[value].file;
+      file = global_scase.smoke3dcoll.smoke3dinfo[value].file;
       fprintf(scriptoutstream,"LOADFILE\n");
       fprintf(scriptoutstream," %s\n",file);
     }
     if(scriptoutstream==NULL||script_defer_loading==0){
       smoke3ddata *smoke3di;
 
-      smoke3di = smoke3dcoll.smoke3dinfo + value;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + value;
       smoke3di->finalize = 1;
       if(smoke3di->extinct>0.0){ // only load one smoke type at a time
         int j, add_blank=0;
 
-        for(j = 0; j<smoke3dcoll.nsmoke3dinfo; j++){
+        for(j = 0; j<global_scase.smoke3dcoll.nsmoke3dinfo; j++){
           smoke3ddata *smoke3dj;
 
-          smoke3dj = smoke3dcoll.smoke3dinfo+j;
+          smoke3dj = global_scase.smoke3dcoll.smoke3dinfo+j;
           if(smoke3dj->loaded==1&&smoke3dj->extinct>0.0&&smoke3di->type!=smoke3dj->type){
             PRINTF("Unloading %s(%s)\n", smoke3dj->file, smoke3dj->label.shortlabel);
             ReadSmoke3D(ALL_SMOKE_FRAMES, j, UNLOAD, FIRST_TIME, &errorcode);
@@ -4956,7 +4956,7 @@ void LoadSmoke3DMenu(int value){
     }
   }
   else if(value==UNLOAD_ALL){
-    for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
+    for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
       ReadSmoke3D(ALL_SMOKE_FRAMES, i, UNLOAD, FIRST_TIME, &errorcode);
     }
   }
@@ -4964,20 +4964,20 @@ void LoadSmoke3DMenu(int value){
     GLUIShowBoundsDialog(DLG_3DSMOKE);
   }
   else if(value ==MENU_SMOKE_FILE_SIZES){
-    if(nsmoke3dtypes>0){
+    if(global_scase.smoke3dcoll.nsmoke3dtypes>0){
       int ii;
 
       PRINTF("3D smoke file sizes:\n");
-      for(ii = 0; ii<nsmoke3dtypes; ii++){
+      for(ii = 0; ii<global_scase.smoke3dcoll.nsmoke3dtypes; ii++){
         FILE_SIZE total_size;
         char *smoke_type;
 
         total_size=0;
         smoke_type = NULL;
-        for(i = 0; i < smoke3dcoll.nsmoke3dinfo; i++){
+        for(i = 0; i < global_scase.smoke3dcoll.nsmoke3dinfo; i++){
           smoke3ddata *smoke3di;
 
-          smoke3di = smoke3dcoll.smoke3dinfo + i;
+          smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
           if(smoke3di->type == ii){
             total_size += GetFileSizeSMV(smoke3di->reg_file);
             smoke_type = smoke3di->label.longlabel;
@@ -5009,7 +5009,7 @@ void LoadSmoke3DMenu(int value){
     smoke3ddata *smoke3di;
 
     value = -(value + 100);
-    smoke3di = smoke3dtypes[value].smoke3d;
+    smoke3di = global_scase.smoke3dcoll.smoke3dtypes[value].smoke3d;
     if(scriptoutstream!=NULL){
       fprintf(scriptoutstream,"LOAD3DSMOKE\n");
       fprintf(scriptoutstream," %s\n",smoke3di->label.longlabel);
@@ -5018,10 +5018,10 @@ void LoadSmoke3DMenu(int value){
       if(smoke3di->extinct>0.0){ // only load one smoke type at a time
         int j, add_blank=0;
 
-        for(j = 0; j<smoke3dcoll.nsmoke3dinfo; j++){
+        for(j = 0; j<global_scase.smoke3dcoll.nsmoke3dinfo; j++){
           smoke3ddata *smoke3dj;
 
-          smoke3dj = smoke3dcoll.smoke3dinfo+j;
+          smoke3dj = global_scase.smoke3dcoll.smoke3dinfo+j;
           if(smoke3dj->loaded==1&&smoke3dj->extinct>0.0&&smoke3di->type!=smoke3dj->type){
             PRINTF("Unloading %s(%s)\n", smoke3dj->file, smoke3dj->label.shortlabel);
             ReadSmoke3D(ALL_SMOKE_FRAMES, j, UNLOAD, FIRST_TIME, &errorcode);
@@ -5055,7 +5055,7 @@ void LoadSmoke3DMenu(int value){
 
 int AnySmoke(void){
 
-  if(smoke3dcoll.nsmoke3dinfo>0)return 1;
+  if(global_scase.smoke3dcoll.nsmoke3dinfo>0)return 1;
   return 0;
 }
 
@@ -5064,8 +5064,8 @@ int AnySmoke(void){
 int AnySlices(const char *type){
   int i;
 
-  for(i=0;i<slicecoll.nsliceinfo;i++){
-    if(STRCMP(slicecoll.sliceinfo[i].label.longlabel,type)==0)return 1;
+  for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
+    if(STRCMP(global_scase.slicecoll.sliceinfo[i].label.longlabel,type)==0)return 1;
   }
   return 0;
 }
@@ -5078,7 +5078,7 @@ FILE_SIZE LoadSlicei(int set_slicecolor, int value, int time_frame, float *time_
   FILE_SIZE return_filesize=0;
 
   SNIFF_ERRORS("LoadSlicei: start");
-  slicei = slicecoll.sliceinfo + value;
+  slicei = global_scase.slicecoll.sliceinfo + value;
   slicei->loading=1;
   if(script_multislice == 0 && scriptoutstream != NULL){
     fprintf(scriptoutstream, "LOADSLICEM\n");
@@ -5107,12 +5107,12 @@ FILE_SIZE LoadAllSliceFiles(int last_slice, char *submenulabel, int dir, int *fc
   int i, file_count=0, errorcode;
   FILE_SIZE load_size = 0;
 
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     char *longlabel;
     int set_slicecolor;
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     longlabel = slicei->label.longlabel;
     if(strcmp(longlabel, submenulabel)!=0)continue;
     if(dir!=0&&dir!=slicei->idir)continue;
@@ -5157,8 +5157,8 @@ void LoadSliceMenu(int value){
 #endif
 
       case UNLOAD_ALL:
-        for(i=0;i<slicecoll.nsliceinfo;i++){
-          slicei = slicecoll.sliceinfo + i;
+        for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
+          slicei = global_scase.slicecoll.sliceinfo + i;
           if(slicei->loaded == 1){
             if(slicei->slice_filetype == SLICE_GEOM){
               ReadGeomData(slicei->patchgeom, slicei, UNLOAD, ALL_FRAMES, NULL, 0, &errorcode);
@@ -5185,15 +5185,15 @@ void LoadSliceMenu(int value){
         value = -(1000 + value);
         submenutype=value/4;
         submenutype=subslice_menuindex[submenutype];
-        slicei = slicecoll.sliceinfo + submenutype;
+        slicei = global_scase.slicecoll.sliceinfo + submenutype;
 #ifndef pp_SLICEFRAME
         submenulabel = slicei->label.longlabel;
         dir=value%4;
-        last_slice = slicecoll.nsliceinfo - 1;
-        for(i = slicecoll.nsliceinfo-1; i>=0; i--){
+        last_slice = global_scase.slicecoll.nsliceinfo - 1;
+        for(i = global_scase.slicecoll.nsliceinfo-1; i>=0; i--){
           char *longlabel;
 
-          slicei = slicecoll.sliceinfo + i;
+          slicei = global_scase.slicecoll.sliceinfo + i;
           longlabel = slicei->label.longlabel;
           if(strcmp(longlabel, submenulabel) != 0)continue;
           if(dir != 0 && dir != slicei->idir)continue;
@@ -5227,12 +5227,12 @@ void LoadMultiVSliceMenu(int value){
   if(value>=0){
     multivslicedata *mvslicei;
 
-    mvslicei = slicecoll.multivsliceinfo + value;
+    mvslicei = global_scase.slicecoll.multivsliceinfo + value;
     if(scriptoutstream!=NULL){
       if(mvslicei->nvslices>0){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + mvslicei->ivslices[0];
+        slicei = global_scase.slicecoll.sliceinfo + mvslicei->ivslices[0];
         fprintf(scriptoutstream,"LOADVSLICE\n");
         fprintf(scriptoutstream," %s\n",slicei->label.longlabel);
         fprintf(scriptoutstream," %i %f\n",slicei->idir,slicei->position_orig);
@@ -5243,8 +5243,8 @@ void LoadMultiVSliceMenu(int value){
       char *longlabel=NULL;
       vslicedata *vslice1;
 
-      vslice1 = slicecoll.vsliceinfo+mvslicei->ivslices[0];
-      if(vslice1->ival>=0)longlabel = slicecoll.sliceinfo[vslice1->ival].label.longlabel;
+      vslice1 = global_scase.slicecoll.vsliceinfo+mvslicei->ivslices[0];
+      if(vslice1->ival>=0)longlabel = global_scase.slicecoll.sliceinfo[vslice1->ival].label.longlabel;
       UnloadAllSliceFiles(longlabel); // unload all vector slices except for the type being loaded now
       if(load_only_when_unloaded == 0){
         for(i = 0; i < mvslicei->nvslices; i++){
@@ -5256,14 +5256,14 @@ void LoadMultiVSliceMenu(int value){
       for(i = 0; i<mvslicei->nvslices; i++){
         vslicedata *vslicei;
 
-        vslicei = slicecoll.vsliceinfo+mvslicei->ivslices[i];
+        vslicei = global_scase.slicecoll.vsliceinfo+mvslicei->ivslices[i];
         vslicei->finalize = 0;
       }
       for(i = mvslicei->nvslices-1; i>=0; i--){
         vslicedata *vslicei;
 
-        vslicei = slicecoll.vsliceinfo+mvslicei->ivslices[i];
-        IF_NOT_USEMESH_CONTINUE(vslicei->loaded,slicecoll.sliceinfo[vslicei->ival].blocknumber);
+        vslicei = global_scase.slicecoll.vsliceinfo+mvslicei->ivslices[i];
+        IF_NOT_USEMESH_CONTINUE(vslicei->loaded,global_scase.slicecoll.sliceinfo[vslicei->ival].blocknumber);
         if(vslicei->skip==0&&vslicei->loaded==0){
           vslicei->finalize = 1;
           break;
@@ -5272,8 +5272,8 @@ void LoadMultiVSliceMenu(int value){
       for(i = 0; i<mvslicei->nvslices; i++){
         vslicedata *vslicei;
 
-        vslicei = slicecoll.vsliceinfo + mvslicei->ivslices[i];
-        IF_NOT_USEMESH_CONTINUE(vslicei->loaded,slicecoll.sliceinfo[vslicei->ival].blocknumber);
+        vslicei = global_scase.slicecoll.vsliceinfo + mvslicei->ivslices[i];
+        IF_NOT_USEMESH_CONTINUE(vslicei->loaded,global_scase.slicecoll.sliceinfo[vslicei->ival].blocknumber);
         if(vslicei->skip==0&&vslicei->loaded==0){
 #ifdef pp_SLICEFRAME
           LoadVSliceMenu2(mvslicei->ivslices[i]);
@@ -5301,18 +5301,18 @@ void LoadMultiVSliceMenu(int value){
     dir=value%4;
     submenutype=msubvslice_menuindex[submenutype];
 
-    slicei = slicecoll.sliceinfo + submenutype;
+    slicei = global_scase.slicecoll.sliceinfo + submenutype;
     submenulabel = slicei->label.longlabel;
     START_TIMER(load_time);
-    for(i = 0; i<slicecoll.nmultivsliceinfo; i++){
+    for(i = 0; i<global_scase.slicecoll.nmultivsliceinfo; i++){
       char *longlabel;
       multivslicedata *mvslicei;
       slicedata *slicej;
       vslicedata *vslicej;
 
-      mvslicei = slicecoll.multivsliceinfo + i;
-      vslicej = slicecoll.vsliceinfo + mvslicei->ivslices[0];
-      slicej = slicecoll.sliceinfo+vslicej->ival;
+      mvslicei = global_scase.slicecoll.multivsliceinfo + i;
+      vslicej = global_scase.slicecoll.vsliceinfo + mvslicei->ivslices[0];
+      slicej = global_scase.slicecoll.sliceinfo+vslicej->ival;
       longlabel = slicej->label.longlabel;
       if(strcmp(longlabel,submenulabel)!=0)continue;
       if(dir!=0&&dir!=slicej->idir)continue;
@@ -5384,7 +5384,7 @@ FILE_SIZE LoadAllMSlicesMT(int last_slice, multislicedata *mslicei, int *fcount)
     slicedata *slicei;
     int set_slicecolor;
 
-    slicei = slicecoll.sliceinfo + mslicei->islices[i];
+    slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[i];
     set_slicecolor = DEFER_SLICECOLOR;
     IF_NOT_USEMESH_CONTINUE(slicei->loaded,slicei->blocknumber);
 
@@ -5431,12 +5431,12 @@ void LoadMultiSliceMenu(int value){
   if(value>=0){
     multislicedata *mslicei;
 
-    mslicei = slicecoll.multisliceinfo + value;
+    mslicei = global_scase.slicecoll.multisliceinfo + value;
     if(scriptoutstream!=NULL){
       if(mslicei->nslices>0){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + mslicei->islices[0];
+        slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[0];
         fprintf(scriptoutstream,"LOADSLICE\n");
         fprintf(scriptoutstream," %s\n",slicei->label.longlabel);
         fprintf(scriptoutstream," %i %f\n",slicei->idir,slicei->position_orig);
@@ -5449,7 +5449,7 @@ void LoadMultiSliceMenu(int value){
 
       char *longlabel;
 
-      longlabel = slicecoll.sliceinfo[mslicei->islices[0]].label.longlabel;
+      longlabel = global_scase.slicecoll.sliceinfo[mslicei->islices[0]].label.longlabel;
       UnloadAllSliceFiles(longlabel); // unload all slice and vector slices not of type 'longlabel'
       if(load_only_when_unloaded == 0){ // unload slice being loaded if it is already loaded and of the same type
         for(i = 0;i<mslicei->nslices; i++){
@@ -5460,7 +5460,7 @@ void LoadMultiSliceMenu(int value){
       for(i = mslicei->nslices-1; i >=0; i--){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + mslicei->islices[i];
+        slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[i];
         IF_NOT_USEMESH_CONTINUE(slicei->loaded,slicei->blocknumber);
         if(slicei->slice_filetype==SLICE_TERRAIN&&slicei->have_agl_data==0)continue;
         if(slicei->skipdup== 0){
@@ -5471,7 +5471,7 @@ void LoadMultiSliceMenu(int value){
       for(i = 0; i < mslicei->nslices; i++){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + mslicei->islices[i];
+        slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[i];
         if(slicei->skipdup== 1 && slicei->loaded == 1){
           UnloadSliceMenu(mslicei->islices[i]);
         }
@@ -5510,13 +5510,13 @@ void LoadMultiSliceMenu(int value){
     submenutype=value/4;
     dir=value%4;
     submenutype=msubslice_menuindex[submenutype];
-    slicei = slicecoll.sliceinfo + submenutype;
+    slicei = global_scase.slicecoll.sliceinfo + submenutype;
     submenulabel = slicei->label.longlabel;
     START_TIMER(load_time);
-    for(i = 0; i<slicecoll.nsliceinfo; i++){
+    for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
       char *longlabel;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
       if(slicei->skipdup== 1)continue;
       longlabel = slicei->label.longlabel;
       if(strcmp(longlabel,submenulabel)!=0)continue;
@@ -5619,12 +5619,12 @@ void LoadAllMultiSliceMenu(void){
   char *label;
 
   label = slicebounds_cpp[sliceload_boundtype].label;
-  for(i = 0; i < slicecoll.nmultisliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nmultisliceinfo; i++){
     multislicedata *mslicei;
     slicedata *slicei;
 
-    mslicei = slicecoll.multisliceinfo + i;
-    slicei = slicecoll.sliceinfo + mslicei->islices[0];
+    mslicei = global_scase.slicecoll.multisliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + mslicei->islices[0];
     if(slicei->volslice == 1)continue;
     if(sliceload_dir == 0 && slicei->idir != 1)continue;
     if(sliceload_dir == 1 && slicei->idir != 2)continue;
@@ -5643,14 +5643,14 @@ void LoadAllMultiVSliceMenu(void){
   char *label;
 
   label = slicebounds_cpp[sliceload_boundtype].label;
-  for(i = 0; i < slicecoll.nmultivsliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nmultivsliceinfo; i++){
     multivslicedata *mvslicei;
     slicedata *slicei;
     vslicedata *vslicei;
 
-    mvslicei = slicecoll.multivsliceinfo + i;
-    vslicei = slicecoll.vsliceinfo + mvslicei->ivslices[0];
-    slicei = slicecoll.sliceinfo + vslicei->ival;
+    mvslicei = global_scase.slicecoll.multivsliceinfo + i;
+    vslicei = global_scase.slicecoll.vsliceinfo + mvslicei->ivslices[0];
+    slicei = global_scase.slicecoll.sliceinfo + vslicei->ival;
     if(slicei->volslice == 1)continue;
     if(sliceload_dir == 0 && slicei->idir != 1)continue;
     if(sliceload_dir == 1 && slicei->idir != 2)continue;
@@ -5676,10 +5676,10 @@ void Plot3DListMenu(int value){
   }
   if(nplot3dtimelist>1)delta_time = (plot3dtimelist[1]-plot3dtimelist[0])/2.0;
 
-  for(i = 0; i < nplot3dinfo; i++){
+  for(i = 0; i < global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     plot3di->loadnow = 0;
     if(
       load_only_when_unloaded == 0 &&
@@ -5689,10 +5689,10 @@ void Plot3DListMenu(int value){
       ReadPlot3D("", i, UNLOAD, &errorcode);
     }
   }
-  for(i = 0; i < nplot3dinfo; i++){
+  for(i = 0; i < global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     IF_NOT_USEMESH_CONTINUE(plot3di->loaded,plot3di->blocknumber);
     if(ABS(plot3di->time-plot3dtimelist[value])<delta_time){
       if(plot3di->loaded==0){
@@ -5709,10 +5709,10 @@ void Plot3DListMenu(int value){
     }
   }
   SetLoadedPlot3DBounds();
-  for(i = nplot3dinfo-1; i>=0; i--){
+  for(i = global_scase.nplot3dinfo-1; i>=0; i--){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->loadnow==0)continue;
     plot3di->finalize = 1;
     break;
@@ -5721,11 +5721,11 @@ void Plot3DListMenu(int value){
   int file_count=0;
   float plot3d_timer;
   START_TIMER(plot3d_timer);
-  for(i=0;i<nplot3dinfo;i++){
+  for(i=0;i<global_scase.nplot3dinfo;i++){
     int errorcode;
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     if(plot3di->loadnow==0)continue;
     total_plot3d_filesize += ReadPlot3D(plot3di->file, i, LOAD, &errorcode);
     file_count++;
@@ -5755,21 +5755,21 @@ int LoadAllPlot3D(float time){
   int errorcode;
   int count=0;
 
-  for(i = 0; i < nplot3dinfo; i++){
-    if(plot3dinfo[i].loaded == 1){
+  for(i = 0; i < global_scase.nplot3dinfo; i++){
+    if(global_scase.plot3dinfo[i].loaded == 1){
       ReadPlot3D("", i, UNLOAD, &errorcode);
     }
   }
-  for(i = 0; i < nplot3dinfo; i++){
+  for(i = 0; i < global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     plot3di->finalize = 0;
   }
-  for(i = nplot3dinfo - 1; i >=0; i--){
+  for(i = global_scase.nplot3dinfo - 1; i >=0; i--){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     if(ABS(plot3di->time - time) < 0.5){
       plot3di->finalize = 1;
       break;
@@ -5779,12 +5779,12 @@ int LoadAllPlot3D(float time){
   int file_count=0;
   float plot3d_timer;
   START_TIMER(plot3d_timer);
-  for(i = 0; i < nplot3dinfo; i++){
+  for(i = 0; i < global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     if(ABS(plot3di->time - time) > 0.5)continue;;
-    total_plot3d_filesize += ReadPlot3D(plot3di->file, plot3di - plot3dinfo, LOAD, &errorcode);
+    total_plot3d_filesize += ReadPlot3D(plot3di->file, plot3di - global_scase.plot3dinfo, LOAD, &errorcode);
     file_count++;
     if(errorcode==0)count++;
   }
@@ -5810,22 +5810,22 @@ void LoadPlot3dMenu(int value){
     if(scriptoutstream!=NULL&&loadplot3dall==0){
       fprintf(scriptoutstream,"LOADPLOT3D\n");
       fprintf(scriptoutstream," %i %f\n",
-        plot3dinfo[value].blocknumber+1,plot3dinfo[value].time);
+        global_scase.plot3dinfo[value].blocknumber+1,global_scase.plot3dinfo[value].time);
     }
     if(scriptoutstream==NULL||script_defer_loading==0){
-      for(i = 0;i < nplot3dinfo;i++){
+      for(i = 0;i < global_scase.nplot3dinfo;i++){
         plot3ddata *plot3di;
 
-        plot3di = plot3dinfo + i;
+        plot3di = global_scase.plot3dinfo + i;
         plot3di->loadnow = 0;
       }
-      plot3dinfo[value].loadnow = 1;
+      global_scase.plot3dinfo[value].loadnow = 1;
       SetLoadedPlot3DBounds();
-      plot3dinfo[value].finalize = 1;
-      for(i = 0; i < nplot3dinfo; i++){
+      global_scase.plot3dinfo[value].finalize = 1;
+      for(i = 0; i < global_scase.nplot3dinfo; i++){
         plot3ddata *plot3di;
 
-        plot3di = plot3dinfo + i;
+        plot3di = global_scase.plot3dinfo + i;
         if(plot3di->loaded == 1){
           if(
             load_only_when_unloaded == 0 ||
@@ -5841,7 +5841,7 @@ void LoadPlot3dMenu(int value){
       for(i = 0;i < 1;i++){
         plot3ddata *plot3di;
 
-        plot3di = plot3dinfo + value;
+        plot3di = global_scase.plot3dinfo + value;
         IF_NOT_USEMESH_CONTINUE(plot3di->loaded, plot3di->blocknumber);
         total_plot3d_filesize += ReadPlot3D(plot3di->file, value, LOAD, &errorcode);
         file_count++;
@@ -5856,44 +5856,44 @@ void LoadPlot3dMenu(int value){
     }
   }
   else if(value==RELOAD_ALL){
-    for(i = 0; i<nplot3dinfo; i++){
+    for(i = 0; i<global_scase.nplot3dinfo; i++){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo+i;
+      plot3di = global_scase.plot3dinfo+i;
       plot3di->loadnow = 0;
       plot3di->finalize = 0;
       if(plot3di->loaded==1){
         plot3di->loadnow = 1;
       }
     }
-    for(i = nplot3dinfo - 1; i >= 0; i--){
+    for(i = global_scase.nplot3dinfo - 1; i >= 0; i--){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
       if(plot3di->loadnow == 1){
         plot3di->finalize = 1;
         break;
       }
     }
     SetLoadedPlot3DBounds();
-    for(i = 0; i<nplot3dinfo; i++){
+    for(i = 0; i<global_scase.nplot3dinfo; i++){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
       if(plot3di->loaded==1){
-        ReadPlot3D("", plot3di-plot3dinfo, UNLOAD, &errorcode);
+        ReadPlot3D("", plot3di-global_scase.plot3dinfo, UNLOAD, &errorcode);
       }
     }
     FILE_SIZE total_plot3d_filesize = 0;
     int file_count=0;
     float plot3d_timer;
     START_TIMER(plot3d_timer);
-    for(i = 0; i<nplot3dinfo; i++){
+    for(i = 0; i<global_scase.nplot3dinfo; i++){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
       if(plot3di->loadnow == 1){
-        total_plot3d_filesize += ReadPlot3D(plot3di->file, plot3di-plot3dinfo, LOAD, &errorcode);
+        total_plot3d_filesize += ReadPlot3D(plot3di->file, plot3di-global_scase.plot3dinfo, LOAD, &errorcode);
         file_count++;
       }
     }
@@ -5906,7 +5906,7 @@ void LoadPlot3dMenu(int value){
     }
   }
   else if(value==UNLOAD_ALL){
-    for(i=0;i<nplot3dinfo;i++){
+    for(i=0;i<global_scase.nplot3dinfo;i++){
       ReadPlot3D("",i,UNLOAD,&errorcode);
     }
   }
@@ -5936,7 +5936,7 @@ FILE_SIZE LoadIsoI(int value){
   START_TIMER(total_time);
   THREADcontrol(isosurface_threads, THREAD_JOIN);
   ReadIsoFile=1;
-  isoi = isoinfo + value;
+  isoi = global_scase.isoinfo + value;
   file=isoi->file;
   isoi->loading=1;
   if(script_iso==0&&scriptoutstream!=NULL){
@@ -5966,40 +5966,40 @@ void LoadAllIsos(int iso_type){
   float load_time=0.0;
 
   if(load_only_when_unloaded == 0){
-    for(i = 0; i < nisoinfo; i++){
+    for(i = 0; i < global_scase.nisoinfo; i++){
       isodata *isoi;
 
-      isoi = isoinfo + i;
+      isoi = global_scase.isoinfo + i;
       if(iso_type == isoi->type&&isoi->blocknumber >= 0){
         meshdata *meshi;
 
-        meshi = meshinfo + isoi->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + isoi->blocknumber;
         UnloadIso(meshi);
       }
     }
   }
   START_TIMER(load_time);
   CancelUpdateTriangles();
-  for(i = 0;i < nisoinfo;i++){
+  for(i = 0;i < global_scase.nisoinfo;i++){
     isodata *isoi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     isoi->finalize = 0;
   }
-  for(i = nisoinfo-1;i>=0;i--){
+  for(i = global_scase.nisoinfo-1;i>=0;i--){
     isodata *isoi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     IF_NOT_USEMESH_CONTINUE(isoi->loaded, isoi->blocknumber);
     if(iso_type==isoi->type){
       isoi->finalize = 1;
       break;
     }
   }
-  for(i = 0; i < nisoinfo; i++){
+  for(i = 0; i < global_scase.nisoinfo; i++){
     isodata *isoi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     IF_NOT_USEMESH_CONTINUE(isoi->loaded,isoi->blocknumber);
     if(iso_type==isoi->type){
 #ifdef pp_ISOFRAME
@@ -6028,10 +6028,10 @@ void LoadIsoMenu(int value){
   GLUTSETCURSOR(GLUT_CURSOR_WAIT);
   if(value>=0){
     if(load_only_when_unloaded == 0){
-      for(i = 0;i < nisoinfo;i++){
+      for(i = 0;i < global_scase.nisoinfo;i++){
         isodata *isoi;
 
-        isoi = isoinfo + i;
+        isoi = global_scase.isoinfo + i;
         isoi->finalize = 0;
         if(isoi->loaded == 1)ReadIso("", i, UNLOAD, NULL, &errorcode);
       }
@@ -6039,17 +6039,17 @@ void LoadIsoMenu(int value){
     for(i=0;i<1;i++){
       isodata *isoi;
 
-      isoi = isoinfo + value;
+      isoi = global_scase.isoinfo + value;
       isoi->finalize = 1;
       IF_NOT_USEMESH_CONTINUE(isoi->loaded,isoi->blocknumber);
       LoadIsoI(value);
     }
   }
   if(value==-1){
-    for(i=0;i<nisoinfo;i++){
+    for(i=0;i<global_scase.nisoinfo;i++){
       isodata *isoi;
 
-      isoi = isoinfo + i;
+      isoi = global_scase.isoinfo + i;
       if(isoi->loaded==1)ReadIso("",i,UNLOAD,NULL,&errorcode);
     }
   }
@@ -6061,7 +6061,7 @@ void LoadIsoMenu(int value){
     isodata *isoi;
 
     ii = -(value + 10);
-    isoi = isoinfo + ii;
+    isoi = global_scase.isoinfo + ii;
     if(scriptoutstream!=NULL){
       script_iso=1;
       fprintf(scriptoutstream,"LOADISO\n");
@@ -6097,10 +6097,10 @@ void LoadBoundaryMenu(int value){
   GLUTSETCURSOR(GLUT_CURSOR_WAIT);
   if(value>=0){
     if(load_only_when_unloaded == 0){
-      for(i = 0;i < npatchinfo;i++){
+      for(i = 0;i < global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->loaded == 1){
           ReadBoundary(i, UNLOAD, &errorcode);
         }
@@ -6109,7 +6109,7 @@ void LoadBoundaryMenu(int value){
     if(scriptoutstream!=NULL){
       patchdata *patchi;
 
-      patchi = patchinfo + value;
+      patchi = global_scase.patchinfo + value;
       fprintf(scriptoutstream,"// LOADFILE\n");
       fprintf(scriptoutstream,"//  %s\n",patchi->file);
       fprintf(scriptoutstream, "LOADBOUNDARYM\n");
@@ -6120,7 +6120,7 @@ void LoadBoundaryMenu(int value){
       for(i = 0;i < 1;i++){
         patchdata *patchi;
 
-        patchi = patchinfo + value;
+        patchi = global_scase.patchinfo + value;
         IF_NOT_USEMESH_CONTINUE(patchi->loaded, patchi->blocknumber);
         THREADcontrol(compress_threads, THREAD_LOCK);
         SetLoadedPatchBounds(&value, 1);
@@ -6136,7 +6136,7 @@ void LoadBoundaryMenu(int value){
     patchdata *patchj;
 
     value = -(value + 10);
-    patchj = patchinfo + value;
+    patchj = global_scase.patchinfo + value;
     if(scriptoutstream!=NULL){
       fprintf(scriptoutstream,"LOADBOUNDARY\n");
       fprintf(scriptoutstream," %s\n",patchj->label.longlabel);
@@ -6151,10 +6151,10 @@ void LoadBoundaryMenu(int value){
       START_TIMER(load_time);
 
       // only perform wrapup operations when loading last boundary file
-      for(i = 0; i<npatchinfo;i++){
+      for(i = 0; i<global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo+i;
+        patchi = global_scase.patchinfo+i;
         patchi->finalize = 0;
         if(patchi->loaded == 1
           && load_only_when_unloaded == 0
@@ -6164,22 +6164,22 @@ void LoadBoundaryMenu(int value){
       }
       int *list=NULL, nlist=0;
 
-      NewMemory((void **)&list,npatchinfo*sizeof(int));
+      NewMemory((void **)&list,global_scase.npatchinfo*sizeof(int));
       nlist=0;
-      for(i = 0; i<npatchinfo;i++){
+      for(i = 0; i<global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo+i;
+        patchi = global_scase.patchinfo+i;
         if(InPatchList(patchj, patchi)==1){
           list[nlist++]=i;
         }
       }
       SetLoadedPatchBounds(list, nlist);
       FREEMEMORY(list);
-      for(i = npatchinfo-1; i>=0; i--){
+      for(i = global_scase.npatchinfo-1; i>=0; i--){
         patchdata *patchi;
 
-        patchi = patchinfo+i;
+        patchi = global_scase.patchinfo+i;
         IF_NOT_USEMESH_CONTINUE(patchi->loaded,patchi->blocknumber);
         if(FileExistsOrig(patchi->reg_file) == NO)continue;
         if(InPatchList(patchj, patchi)==1){
@@ -6189,10 +6189,10 @@ void LoadBoundaryMenu(int value){
           break;
         }
       }
-      for(i=0;i<npatchinfo;i++){
+      for(i=0;i<global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         IF_NOT_USEMESH_CONTINUE(patchi->loaded,patchi->blocknumber);
         if(InPatchList(patchj, patchi)==1){
           THREADcontrol(compress_threads, THREAD_LOCK);
@@ -6264,10 +6264,10 @@ void LoadBoundaryMenu(int value){
       }
       break;
     default:
-      for(i=0;i<npatchinfo;i++){
+      for(i=0;i<global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo+i;
+        patchi = global_scase.patchinfo+i;
         if(patchi->filetype_label==NULL||strcmp(patchi->filetype_label, "INCLUDE_GEOM")!=0){
           ReadBoundary(i, UNLOAD, &errorcode);
         }
@@ -6326,7 +6326,7 @@ void ShowInternalBlockages(void){
     GeometryMenu(17 + TERRAIN_HIDDEN);
   }
   updatemenu = 1;
-  updatefaces = 1;
+  global_scase.updatefaces = 1;
   updatefacelists = 1;
 }
 
@@ -6340,12 +6340,12 @@ void ShowBoundaryMenu(int value){
     patchdata *patchj;
     int i;
 
-    patchj = patchinfo + value-1000;
+    patchj = global_scase.patchinfo + value-1000;
     patchj->display = 1 - patchj->display;
-    for(i=0;i<npatchinfo;i++){
+    for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
 
-      patchi = patchinfo + i;
+      patchi = global_scase.patchinfo + i;
       if(patchi->loaded == 0)continue;
       if(strcmp(patchi->label.longlabel,patchj->label.longlabel)==0)patchi->display=patchj->display;
     }
@@ -6367,7 +6367,7 @@ void ShowBoundaryMenu(int value){
       ShowBoundaryMenu(HIDE_EXTERIOR_WALL_MENU);
     }
     updatefacelists = 1;
-    updatefaces = 1;
+    global_scase.updatefaces = 1;
     ShowInternalBlockages();
     update_patch_vis = 1;
   }
@@ -6381,12 +6381,12 @@ void ShowBoundaryMenu(int value){
       else{
         val = 0;
       }
-      for(i = 0;i < npatchinfo;i++){
+      for(i = 0;i < global_scase.npatchinfo;i++){
         int n;
 
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->loaded == 0)continue;
         for(n = 0;n < patchi->npatches;n++){
           patchfacedata *pfi;
@@ -6408,11 +6408,11 @@ void ShowBoundaryMenu(int value){
       hide_all_interior_patch_data    = show_all_interior_patch_data;
       show_all_interior_patch_data    = 1 - show_all_interior_patch_data;
       vis_boundary_type[INTERIORwall] = show_all_interior_patch_data;
-      for(i = 0;i < npatchinfo;i++){
+      for(i = 0;i < global_scase.npatchinfo;i++){
         patchdata *patchi;
         int n;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->loaded == 0)continue;
         for(n = 0;n < patchi->npatches;n++){
           patchfacedata *pfi;
@@ -6434,12 +6434,12 @@ void ShowBoundaryMenu(int value){
     if(value==INI_EXTERIORwallmenu){
       int i;
 
-      for(i = 0;i < npatchinfo;i++){
+      for(i = 0;i < global_scase.npatchinfo;i++){
         int n;
 
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->loaded == 0)continue;
         for(n = 0;n < patchi->npatches;n++){
           patchfacedata *pfi;
@@ -6455,11 +6455,11 @@ void ShowBoundaryMenu(int value){
       int i;
 
       value = -(value + 2); /* map xxxwallmenu to xxxwall */
-      for(i = 0;i < npatchinfo;i++){
+      for(i = 0;i < global_scase.npatchinfo;i++){
         patchdata *patchi;
         int n;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->loaded == 0)continue;
         for(n = 0;n < patchi->npatches;n++){
           patchfacedata *pfi;
@@ -6486,7 +6486,7 @@ void VentMenu(int value){
     visVents=1;
     visOpenVents=1;
     visDummyVents=1;
-    visOtherVents=1;
+    global_scase.visOtherVents=1;
     visCircularVents=VENT_CIRCLE;
     break;
   case MENU_VENT_OPEN:
@@ -6500,24 +6500,24 @@ void VentMenu(int value){
     break;
   case MENU_VENT_TWOINTERIOR:
      show_bothsides_int=1-show_bothsides_int;
-     updatefaces=1;
+     global_scase.updatefaces=1;
      break;
   case MENU_VENT_TWOEXTERIOR:
      show_bothsides_ext = 1 - show_bothsides_ext;
-     updatefaces=1;
+     global_scase.updatefaces=1;
      break;
   case MENU_VENT_TRANSPARENT:
      show_transparent_vents=1-show_transparent_vents;
-     updatefaces=1;
+     global_scase.updatefaces=1;
      break;
   case MENU_VENT_OTHER:
-     visOtherVents=1-visOtherVents;
+     global_scase.visOtherVents=1-global_scase.visOtherVents;
      break;
    case HIDE_ALL_VENTS: // Hide all vents
      visVents=0;
      visOpenVents=0;
      visDummyVents=0;
-     visOtherVents=0;
+     global_scase.visOtherVents=0;
      visCircularVents=VENT_HIDE;
      break;
    case MENU_VENT_CIRCLE:
@@ -6664,11 +6664,11 @@ void BlockageMenu(int value){
   if(value==ANIMATE_BLOCKAGES){
     animate_blockages = 1 - animate_blockages;
     if(animate_blockages==1){
-      tourcoll.tourinfo->display = 0;
+      global_scase.tourcoll.tourinfo->display = 0;
       show_avatar = 0;
     }
     if(animate_blockages==0){
-      tourcoll.tourinfo->display = 1;
+      global_scase.tourcoll.tourinfo->display = 1;
     }
     TourMenu(0);
     updatemenu = 1;
@@ -6703,7 +6703,7 @@ void BlockageMenu(int value){
       break;
     case visBLOCKOutlineColor:
       outline_color_flag = 1 - outline_color_flag;
-      updatefaces=1;
+      global_scase.updatefaces=1;
       break;
     case visBLOCKOnlyOutline:
       if(outline_state!=OUTLINE_ONLY){
@@ -6798,13 +6798,13 @@ void BlockageMenu(int value){
    case visBLOCKHide:
    case visBLOCKSolidOutline:
      visBlocks=value;
-     if(value==visBLOCKSolidOutline||visBLOCKold==visBLOCKSolidOutline)updatefaces=1;
+     if(value==visBLOCKSolidOutline||visBLOCKold==visBLOCKSolidOutline)global_scase.updatefaces=1;
      GLUIUpdateTrainerOutline();
      break;
    case BLOCKlocation_grid:
    case BLOCKlocation_exact:
    case BLOCKlocation_cad:
-     if(NCADGeom(cadgeomcoll) == 0){
+     if(NCADGeom(&global_scase.cadgeomcoll) == 0){
        if(value == BLOCKlocation_grid){
          blocklocation_menu = BLOCKlocation_exact;
        }
@@ -6826,10 +6826,10 @@ void BlockageMenu(int value){
    default:
      if(value<0){
        value=-value-1;
-       if(value>=0&&value<=npropinfo-1){
+       if(value>=0&&value<=global_scase.propcoll.npropinfo-1){
          propdata *propi;
 
-         propi = propinfo + value;
+         propi = global_scase.propcoll.propinfo + value;
          propi->blockvis=1-propi->blockvis;
        }
      }
@@ -6918,16 +6918,16 @@ void TitleMenu(int value){
 void ShowADeviceType(void){
   int i;
 
-  for(i=0;i<objectscoll->nobject_defs;i++){
+  for(i=0;i<global_scase.objectscoll.nobject_defs;i++){
     sv_object *obj_typei;
 
-    obj_typei = objectscoll->object_defs[i];
+    obj_typei = global_scase.objectscoll.object_defs[i];
     if(obj_typei->used_by_device==1&&obj_typei->visible==1)return;
   }
-  for(i=0;i<objectscoll->nobject_defs;i++){
+  for(i=0;i<global_scase.objectscoll.nobject_defs;i++){
     sv_object *obj_typei;
 
-    obj_typei = objectscoll->object_defs[i];
+    obj_typei = global_scase.objectscoll.object_defs[i];
     if(obj_typei->used_by_device==1){
       obj_typei->visible=1;
       return;
@@ -6945,16 +6945,16 @@ void DeviceTypeMenu(int val){
 /* ------------------ ShowDevicesMenu ------------------------ */
 
 void ShowDevicesMenu(int value){
-  if(value==MENU_DUMMY||ndeviceinfo<=0)return;
+  if(value==MENU_DUMMY||global_scase.devicecoll.ndeviceinfo<=0)return;
   updatemenu = 1;
   GLUTPOSTREDISPLAY;
   if(value==MENU_DEVICES_SHOWALL||value==MENU_DEVICES_HIDEALL){
     int i;
 
-    for(i=0; i<ndeviceinfo; i++){
+    for(i=0; i<global_scase.devicecoll.ndeviceinfo; i++){
       devicedata *devicei;
 
-      devicei = deviceinfo + i;
+      devicei = global_scase.devicecoll.deviceinfo + i;
       if(value==MENU_DEVICES_SHOWALL){
         devicei->show = 1;
       }
@@ -6968,11 +6968,11 @@ void ShowDevicesMenu(int value){
     int ival, itype;
     devicedata *devicei;
 
-    if(value >= 3 * ndeviceinfo)return;
-    ival = value % ndeviceinfo;
-    itype = value / ndeviceinfo;
+    if(value >= 3 * global_scase.devicecoll.ndeviceinfo)return;
+    ival = value % global_scase.devicecoll.ndeviceinfo;
+    itype = value / global_scase.devicecoll.ndeviceinfo;
 
-    devicei = deviceinfo + ival;
+    devicei = global_scase.devicecoll.deviceinfo + ival;
     //             0 <= value <   ndeviceinfo : toggle
     //   ndeviceinfo <= value < 2*ndeviceinfo : show
     // 2*ndeviceinfo <= value < 3*ndeviceinfo : hide
@@ -6988,8 +6988,8 @@ void ShowObjectsMenu(int value){
   sv_object *objecti;
   int i;
 
-  if(value>=0&&value<objectscoll->nobject_defs){
-    objecti = objectscoll->object_defs[value];
+  if(value>=0&&value<global_scase.objectscoll.nobject_defs){
+    objecti = global_scase.objectscoll.object_defs[value];
     objecti->visible = 1 - objecti->visible;
     if(showdevice_val==1||vis_device_plot!=DEVICE_PLOT_HIDDEN){
       update_times = 1;
@@ -7002,14 +7002,14 @@ void ShowObjectsMenu(int value){
     show_missing_objects = 1 - show_missing_objects;
   }
   else if(value==OBJECT_SHOWALL){
-    for(i=0;i<objectscoll->nobject_defs;i++){
-      objecti = objectscoll->object_defs[i];
+    for(i=0;i<global_scase.objectscoll.nobject_defs;i++){
+      objecti = global_scase.objectscoll.object_defs[i];
       objecti->visible=1;
     }
   }
   else if(value==OBJECT_HIDEALL){
-    for(i=0;i<objectscoll->nobject_defs;i++){
-      objecti = objectscoll->object_defs[i];
+    for(i=0;i<global_scase.objectscoll.nobject_defs;i++){
+      objecti = global_scase.objectscoll.object_defs[i];
       objecti->visible=0;
     }
   }
@@ -7103,8 +7103,8 @@ void TerrainGeomShowMenu(int value){
   if(value>=0){
     texturedata *texti;
 
-    if(value>=0&&value<nterrain_textures){
-      texti = terrain_textures+value;
+    if(value>=0&&value<global_scase.terrain_texture_coll.nterrain_textures){
+      texti = global_scase.terrain_texture_coll.terrain_textures+value;
       texti->display = 1-texti->display;
       GLUIUpdateTerrainTexture(value);
     }
@@ -7229,7 +7229,7 @@ void ZoneShowMenu(int value){
       visVentMFlow=0;
     }
     break;
-#define VISVENTFLOW     if((nzhvents>0&&visVentHFlow==1)||(nzvvents>0&&visVentVFlow==1)||(nzmvents>0&&visVentMFlow==1)){\
+#define VISVENTFLOW     if((global_scase.nzhvents>0&&visVentHFlow==1)||(global_scase.nzvvents>0&&visVentVFlow==1)||(global_scase.nzmvents>0&&visVentMFlow==1)){\
       visVentFlow = 1;\
     }\
     else{\
@@ -7284,10 +7284,10 @@ void ZoneShowMenu(int value){
 int GetHVACConnectState(int index){
   int i;
 
-  for(i = 0;i < hvaccoll.nhvacconnectinfo;i++){
+  for(i = 0;i < global_scase.hvaccoll.nhvacconnectinfo;i++){
     hvacconnectdata *hi;
 
-    hi = hvaccoll.hvacconnectinfo + i;
+    hi = global_scase.hvaccoll.hvacconnectinfo + i;
     if(hi->index == index)return hi->display;
   }
   return 1;
@@ -7308,16 +7308,16 @@ void HVACConnectMenu(int var){
   hvac_show_networks    = 0;
   hvac_show_connections = 1;
   if(var >= 0){
-    hvaccoll.hvacconnectinfo[var].display = 1 - hvaccoll.hvacconnectinfo[var].display;
+    global_scase.hvaccoll.hvacconnectinfo[var].display = 1 - global_scase.hvaccoll.hvacconnectinfo[var].display;
   }
   else if(var == MENU_HVAC_SHOWALL_CONNECTIONS){
-    for(i = 0;i < hvaccoll.nhvacconnectinfo;i++){
-      hvaccoll.hvacconnectinfo[i].display = 1;
+    for(i = 0;i < global_scase.hvaccoll.nhvacconnectinfo;i++){
+      global_scase.hvaccoll.hvacconnectinfo[i].display = 1;
     }
   }
   else if(var == MENU_HVAC_HIDEALL_CONNECTIONS){
-    for(i = 0;i < hvaccoll.nhvacconnectinfo;i++){
-      hvaccoll.hvacconnectinfo[i].display = 0;
+    for(i = 0;i < global_scase.hvaccoll.nhvacconnectinfo;i++){
+      global_scase.hvaccoll.hvacconnectinfo[i].display = 0;
     }
   }
   updatemenu = 1;
@@ -7339,27 +7339,27 @@ void HVACNetworkMenu(int value){
   }
   hvac_show_networks    = 1;
   hvac_show_connections = 0;
-  if(value>=0&&value<hvaccoll.nhvacinfo){
+  if(value>=0&&value<global_scase.hvaccoll.nhvacinfo){
     hvacdata *hvaci;
 
-    hvaci = hvaccoll.hvacinfo + value;
+    hvaci = global_scase.hvaccoll.hvacinfo + value;
     hvaci->display = 1 - hvaci->display;
   }
   else{
     switch(value){
     case MENU_HVAC_SHOWALL_NETWORKS:
-      for(i = 0; i < hvaccoll.nhvacinfo; i++){
+      for(i = 0; i < global_scase.hvaccoll.nhvacinfo; i++){
         hvacdata *hvaci;
 
-        hvaci = hvaccoll.hvacinfo + i;
+        hvaci = global_scase.hvaccoll.hvacinfo + i;
         hvaci->display = 1;
       }
       break;
     case MENU_HVAC_HIDEALL_NETWORKS:
-      for(i = 0; i < hvaccoll.nhvacinfo; i++){
+      for(i = 0; i < global_scase.hvaccoll.nhvacinfo; i++){
         hvacdata *hvaci;
 
-        hvaci = hvaccoll.hvacinfo + i;
+        hvaci = global_scase.hvaccoll.hvacinfo + i;
         hvaci->display = 0;
       }
       break;
@@ -7378,14 +7378,14 @@ void SetHVACNodeValIndex(int value){
   int i, return_val;
 
   return_val = -1;
-  if(hvaccoll.hvacnodevalsinfo == NULL){
-    hvaccoll.hvacnodevar_index = return_val;
+  if(global_scase.hvaccoll.hvacnodevalsinfo == NULL){
+    global_scase.hvaccoll.hvacnodevar_index = return_val;
     return;
   }
-  for(i = 0;i < hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
+  for(i = 0;i < global_scase.hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
     hvacvaldata *hi;
 
-    hi = hvaccoll.hvacnodevalsinfo->node_vars + i;
+    hi = global_scase.hvaccoll.hvacnodevalsinfo->node_vars + i;
     if(value == i){
       hi->vis = 1 - hi->vis;
       if(hi->vis == 1)return_val = i;
@@ -7394,7 +7394,7 @@ void SetHVACNodeValIndex(int value){
       hi->vis = 0;
     }
   }
-  hvaccoll.hvacnodevar_index = return_val;
+  global_scase.hvaccoll.hvacnodevar_index = return_val;
 }
 
 /* ------------------ SetAllHVACDucts ------------------------ */
@@ -7402,19 +7402,19 @@ void SetHVACNodeValIndex(int value){
 void SetHVACDuct(void){
   int i;
 
-  hvaccoll.hvacductvalsinfo->duct_vars[0].vis = 1;
-  for(i = 1;i < hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
+  global_scase.hvaccoll.hvacductvalsinfo->duct_vars[0].vis = 1;
+  for(i = 1;i < global_scase.hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
     hvacvaldata *hi;
 
-    hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
+    hi = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + i;
      hi->vis = 0;
   }
-  hvaccoll.hvacductvar_index = 0;
-  if(IsHVACVisible(&hvaccoll)==0){
-    for(i = 0; i < hvaccoll.nhvacinfo; i++){
+  global_scase.hvaccoll.hvacductvar_index = 0;
+  if(IsHVACVisible(&global_scase.hvaccoll)==0){
+    for(i = 0; i < global_scase.hvaccoll.nhvacinfo; i++){
       hvacdata *hvaci;
 
-      hvaci = hvaccoll.hvacinfo + i;
+      hvaci = global_scase.hvaccoll.hvacinfo + i;
       hvaci->display = 1;
     }
   }
@@ -7426,14 +7426,14 @@ void SetHVACDuctValIndex(int value){
   int i, return_val;
 
   return_val = -1;
-  if(hvaccoll.hvacductvalsinfo == NULL){
-    hvaccoll.hvacductvar_index = return_val;
+  if(global_scase.hvaccoll.hvacductvalsinfo == NULL){
+    global_scase.hvaccoll.hvacductvar_index = return_val;
     return;
   }
-  for(i = 0;i < hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
+  for(i = 0;i < global_scase.hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
     hvacvaldata *hi;
 
-    hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
+    hi = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + i;
     if(value == i){
       hi->vis = 1 - hi->vis;
       if(hi->vis == 1)return_val = i;
@@ -7442,7 +7442,7 @@ void SetHVACDuctValIndex(int value){
       hi->vis = 0;
     }
   }
-  hvaccoll.hvacductvar_index = return_val;
+  global_scase.hvaccoll.hvacductvar_index = return_val;
 }
 
 /* ------------------ HVACNodeValueMenu ------------------------ */
@@ -7450,18 +7450,18 @@ void SetHVACDuctValIndex(int value){
 void HVACNodeValueMenu(int value){
   int i;
 
-  if(hvaccoll.hvacductvalsinfo->times==NULL){
+  if(global_scase.hvaccoll.hvacductvalsinfo->times==NULL){
     ReadHVACData(LOAD);
   }
   SetHVACNodeValIndex(value);
   plotstate = GetPlotState(DYNAMIC_PLOTS);
   UpdateTimes();
-  if(hvaccoll.hvacductvar_index >= 0 || hvaccoll.hvacnodevar_index >= 0){
-    if(IsHVACVisible(&hvaccoll)==0){
-      for(i = 0; i < hvaccoll.nhvacinfo; i++){
+  if(global_scase.hvaccoll.hvacductvar_index >= 0 || global_scase.hvaccoll.hvacnodevar_index >= 0){
+    if(IsHVACVisible(&global_scase.hvaccoll)==0){
+      for(i = 0; i < global_scase.hvaccoll.nhvacinfo; i++){
         hvacdata *hvaci;
 
-        hvaci = hvaccoll.hvacinfo + i;
+        hvaci = global_scase.hvaccoll.hvacinfo + i;
         hvaci->display = 1;
       }
     }
@@ -7478,18 +7478,18 @@ void HVACNodeValueMenu(int value){
 void HVACDuctValueMenu(int value){
   int i;
 
-  if(hvaccoll.hvacductvalsinfo->times==NULL){
+  if(global_scase.hvaccoll.hvacductvalsinfo->times==NULL){
     ReadHVACData(LOAD);
   }
   SetHVACDuctValIndex(value);
   plotstate = GetPlotState(DYNAMIC_PLOTS);
   UpdateTimes();
-  if(hvaccoll.hvacductvar_index >= 0 || hvaccoll.hvacnodevar_index >= 0){
-    if(IsHVACVisible(&hvaccoll)==0){
-      for(i = 0; i < hvaccoll.nhvacinfo; i++){
+  if(global_scase.hvaccoll.hvacductvar_index >= 0 || global_scase.hvaccoll.hvacnodevar_index >= 0){
+    if(IsHVACVisible(&global_scase.hvaccoll)==0){
+      for(i = 0; i < global_scase.hvaccoll.nhvacinfo; i++){
         hvacdata *hvaci;
 
-        hvaci = hvaccoll.hvacinfo + i;
+        hvaci = global_scase.hvaccoll.hvacinfo + i;
         hvaci->display = 1;
       }
     }
@@ -7582,12 +7582,12 @@ void HVACMenu(int value){
       assert(FFALSE);
       break;
   }
-  for(i = 0; i < hvaccoll.nhvacinfo; i++){
+  for(i = 0; i < global_scase.hvaccoll.nhvacinfo; i++){
     char *labelsave;
     hvacdata *hvaci;
     int display;
 
-    hvaci = hvaccoll.hvacinfo + i;
+    hvaci = global_scase.hvaccoll.hvacinfo + i;
     labelsave = hvaci->network_name;
     display   = hvaci->display;
     memcpy(hvaci, glui_hvac, sizeof(hvacdata));
@@ -7610,10 +7610,10 @@ void ToggleMetroMode(void){
 int HaveBoundaryArrival(void){
   int i;
 
-  for(i = 0; i < npatchinfo; i++){
+  for(i = 0; i < global_scase.npatchinfo; i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->loaded == 1 && patchi->display == 1 && strcmp(patchi->label.shortlabel, "t_a") == 0){
       return 1;
     }
@@ -7627,7 +7627,7 @@ void GeometryMenu(int value){
 
   switch(value){
   case GEOM_Outline:
-    if(isZoneFireModel==0)visFrame=1-visFrame;
+    if(global_scase.isZoneFireModel==0)visFrame=1-visFrame;
     break;
   case 5:
     visFloor=1-visFloor;
@@ -7649,21 +7649,21 @@ void GeometryMenu(int value){
       from_read_boundary = 0;
       if(HaveBoundaryArrival() == 1)break;
     }
-    visTerrainType = value-17;
+    global_scase.visTerrainType = value-17;
     GLUIUpdateTerrain();
-    if(visTerrainType == TERRAIN_HIDDEN){
-      if(visOtherVents!=visOtherVentsSAVE){
-        visOtherVents=visOtherVentsSAVE;
+    if(global_scase.visTerrainType == TERRAIN_HIDDEN){
+      if(global_scase.visOtherVents!=global_scase.visOtherVentsSAVE){
+        global_scase.visOtherVents=global_scase.visOtherVentsSAVE;
       }
     }
     else{
-      if(visOtherVents!=0){
-        visOtherVentsSAVE=visOtherVents;
-        visOtherVents=0;
+      if(global_scase.visOtherVents!=0){
+        global_scase.visOtherVentsSAVE=global_scase.visOtherVents;
+        global_scase.visOtherVents=0;
       }
       BlockageMenu(visBLOCKHide);
     }
-    if(visTerrainType==TERRAIN_SURFACE){
+    if(global_scase.visTerrainType==TERRAIN_SURFACE){
       planar_terrain_slice=0;
     }
     else{
@@ -7671,7 +7671,7 @@ void GeometryMenu(int value){
     }
     break;
   case GEOM_ShowAll:
-    if(isZoneFireModel)visFrame=1;
+    if(global_scase.isZoneFireModel)visFrame=1;
     show_faces_shaded=1;
     visFloor = 1;
     visFrame = 1;
@@ -7737,13 +7737,13 @@ void GeometryMainMenu(int value){
 int GetNumActiveDevices(void){
   int num_activedevices = 0;
 
-  if(objectscoll->nobject_defs > 0){
+  if(global_scase.objectscoll.nobject_defs > 0){
     int i;
 
-    for(i = 0; i < objectscoll->nobject_defs; i++){
+    for(i = 0; i < global_scase.objectscoll.nobject_defs; i++){
       sv_object *obj_typei;
 
-      obj_typei = objectscoll->object_defs[i];
+      obj_typei = global_scase.objectscoll.object_defs[i];
       if(obj_typei->used_by_device == 1)num_activedevices++;
     }
   }
@@ -7756,10 +7756,10 @@ int GetNTotalVents(void){
   int ntotal_vents = 0;
   int i;
 
-  for(i = 0; i < nmeshes; i++){
+  for(i = 0; i < global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     ntotal_vents += meshi->nvents;
   }
   return ntotal_vents;
@@ -7770,11 +7770,11 @@ int GetNTotalVents(void){
 int IsBoundaryType(int type){
   int i;
 
-  for(i = 0; i < npatchinfo; i++){
+  for(i = 0; i < global_scase.npatchinfo; i++){
     patchdata *patchi;
     int n;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     for(n = 0; n < patchi->npatches; n++){
       patchfacedata *pfi;
 
@@ -7790,10 +7790,10 @@ int IsBoundaryType(int type){
 void IsoLoadState(isodata *isoi, int  *load_state){
   int i, total=0, loaded=0;
 
-  for(i=0; i<nisoinfo; i++){
+  for(i=0; i<global_scase.nisoinfo; i++){
     isodata *isoii;
 
-    isoii = isoinfo + i;
+    isoii = global_scase.isoinfo + i;
     if(strcmp(isoi->surface_label.longlabel, isoii->surface_label.longlabel)!=0)continue;
     total++;
     if(isoii->loaded==1)loaded++;
@@ -7816,10 +7816,10 @@ void IsoLoadState(isodata *isoi, int  *load_state){
 void PatchLoadState(patchdata *patchi, int  *load_state){
   int i, total=0, loaded=0;
 
-  for(i=0; i<npatchinfo; i++){
+  for(i=0; i<global_scase.npatchinfo; i++){
     patchdata *patchii;
 
-    patchii = patchinfo + i;
+    patchii = global_scase.patchinfo + i;
     if(strcmp(patchi->label.longlabel, patchii->label.longlabel)!=0)continue;
     total++;
     if(patchii->loaded==1)loaded++;
@@ -7842,10 +7842,10 @@ void PatchLoadState(patchdata *patchi, int  *load_state){
 void Plot3DLoadState(float time, int  *load_state){
   int i, total=0, loaded=0;
 
-  for(i=0; i<nplot3dinfo; i++){
+  for(i=0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo + i;
+    plot3di = global_scase.plot3dinfo + i;
     if(ABS(plot3di->time-time)>0.1)continue;
     total++;
     if(plot3di->loaded==1)loaded++;
@@ -7868,10 +7868,10 @@ void Plot3DLoadState(float time, int  *load_state){
 void PartLoadState(int  *load_state){
   int i, total=0, loaded=0;
 
-  for(i=0; i<npartinfo; i++){
+  for(i=0; i<global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     total++;
     if(parti->loaded==1)loaded++;
   }
@@ -7915,22 +7915,22 @@ void InitShowSliceMenu(int *showhideslicemenuptr, int patchgeom_slice_showhide){
 
       if(nsliceloaded>0){
         glutAddMenuEntry(_("Show in:"), MENU_DUMMY);
-        if(show_slice_in_obst==ONLY_IN_GAS){
+        if(global_scase.show_slice_in_obst==ONLY_IN_GAS){
           glutAddMenuEntry(_("  *gas"), MENU_SHOWSLICE_IN_GAS);
           glutAddMenuEntry(_("  solid"), MENU_SHOWSLICE_IN_SOLID);
           glutAddMenuEntry(_("  gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
         }
-        if(show_slice_in_obst==GAS_AND_SOLID){
+        if(global_scase.show_slice_in_obst==GAS_AND_SOLID){
           glutAddMenuEntry(_("  gas"), MENU_SHOWSLICE_IN_GAS);
           glutAddMenuEntry(_("  solid"), MENU_SHOWSLICE_IN_SOLID);
           glutAddMenuEntry(_("  *gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
         }
-        if(show_slice_in_obst==ONLY_IN_SOLID){
+        if(global_scase.show_slice_in_obst==ONLY_IN_SOLID){
           glutAddMenuEntry(_("  gas"), MENU_SHOWSLICE_IN_GAS);
           glutAddMenuEntry(_("  *solid"), MENU_SHOWSLICE_IN_SOLID);
           glutAddMenuEntry(_("  gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
         }
-        if(show_slice_in_obst==NEITHER_GAS_NOR_SOLID){
+        if(global_scase.show_slice_in_obst==NEITHER_GAS_NOR_SOLID){
           glutAddMenuEntry(_("  gas"), MENU_SHOWSLICE_IN_GAS);
           glutAddMenuEntry(_("  solid"), MENU_SHOWSLICE_IN_SOLID);
           glutAddMenuEntry(_("  gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
@@ -7968,14 +7968,14 @@ void InitShowMultiSliceMenu(int *showmultislicemenuptr, int showhideslicemenu, i
 
     CREATEMENU(showmultislicemenu, ShowMultiSliceMenu);
     *showmultislicemenuptr = showmultislicemenu;
-    for(i = 0; i<slicecoll.nmultisliceinfo; i++){
+    for(i = 0; i<global_scase.slicecoll.nmultisliceinfo; i++){
       slicedata *sd;
       char menulabel[1024];
       multislicedata *mslicei;
 
-      mslicei = slicecoll.multisliceinfo+i;
+      mslicei = global_scase.slicecoll.multisliceinfo+i;
       if(mslicei->loaded==0)continue;
-      sd = slicecoll.sliceinfo+mslicei->islices[0];
+      sd = global_scase.slicecoll.sliceinfo+mslicei->islices[0];
       STRCPY(menulabel, "");
       if(plotstate==DYNAMIC_PLOTS&&mslicei->display!=0&&sd->slicefile_labelindex==slicefile_labelindex){
         if(mslicei->display==1){
@@ -7993,11 +7993,11 @@ void InitShowMultiSliceMenu(int *showmultislicemenuptr, int showhideslicemenu, i
       glutAddMenuEntry(menulabel, i);
     }
     // loaded geometry slice entries
-    for(ii = 0; ii<npatchinfo; ii++){
+    for(ii = 0; ii<global_scase.npatchinfo; ii++){
       patchdata *patchi;
 
       i = patchorderindex[ii];
-      patchi = patchinfo+i;
+      patchi = global_scase.patchinfo+i;
       if(patchi->loaded==1&&patchi->filetype_label!=NULL&&strcmp(patchi->filetype_label, "INCLUDE_GEOM")==0){
         if(patchim1==NULL||strcmp(patchi->label.longlabel, patchim1->label.longlabel)!=0){
           char mlabel[128];
@@ -8012,22 +8012,22 @@ void InitShowMultiSliceMenu(int *showmultislicemenuptr, int showhideslicemenu, i
     }
     if(nsliceloaded>0){
       glutAddMenuEntry(_("  Show in:"), MENU_DUMMY);
-      if(show_slice_in_obst==ONLY_IN_GAS){
+      if(global_scase.show_slice_in_obst==ONLY_IN_GAS){
         glutAddMenuEntry(_("    *gas"), MENU_SHOWSLICE_IN_GAS);
         glutAddMenuEntry(_("    solid"), MENU_SHOWSLICE_IN_SOLID);
         glutAddMenuEntry(_("    gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
       }
-      if(show_slice_in_obst==GAS_AND_SOLID){
+      if(global_scase.show_slice_in_obst==GAS_AND_SOLID){
         glutAddMenuEntry(_("    gas"), MENU_SHOWSLICE_IN_GAS);
         glutAddMenuEntry(_("    solid"), MENU_SHOWSLICE_IN_SOLID);
         glutAddMenuEntry(_("    *gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
       }
-      if(show_slice_in_obst==ONLY_IN_SOLID){
+      if(global_scase.show_slice_in_obst==ONLY_IN_SOLID){
         glutAddMenuEntry(_("    gas"), MENU_SHOWSLICE_IN_GAS);
         glutAddMenuEntry(_("    *solid"), MENU_SHOWSLICE_IN_SOLID);
         glutAddMenuEntry(_("    gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
       }
-      if(show_slice_in_obst==NEITHER_GAS_NOR_SOLID){
+      if(global_scase.show_slice_in_obst==NEITHER_GAS_NOR_SOLID){
         glutAddMenuEntry(_("  gas"), MENU_SHOWSLICE_IN_GAS);
         glutAddMenuEntry(_("  solid"), MENU_SHOWSLICE_IN_SOLID);
         glutAddMenuEntry(_("  gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
@@ -8048,20 +8048,20 @@ void InitUnloadSliceMenu(int *unloadslicemenuptr){
 
   CREATEMENU(unloadslicemenu,UnloadSliceMenu);
   *unloadslicemenuptr = unloadslicemenu;
-  for(i=0;i<slicecoll.nsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
     slicedata *sd;
     char menulabel[1024];
 
-    sd = slicecoll.sliceinfo + sliceorderindex[i];
+    sd = global_scase.slicecoll.sliceinfo + global_scase.sliceorderindex[i];
     if(sd->loaded==1){
       STRCPY(menulabel,sd->menulabel2);
-      glutAddMenuEntry(menulabel,sliceorderindex[i]);
+      glutAddMenuEntry(menulabel,global_scase.sliceorderindex[i]);
     }
   }
-  for(i = 0;i<npatchinfo;i++){
+  for(i = 0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==1&&patchi->filetype_label!=NULL&&strcmp(patchi->filetype_label, "INCLUDE_GEOM")==0){
       glutAddMenuEntry(patchi->label.longlabel, -3-i);
       geom_slice_loaded++;
@@ -8138,18 +8138,18 @@ void InitUnloadMultiSliceMenu(int *unloadmultislicemenuptr){
   CREATEMENU(unloadmultislicemenu, UnloadMultiSliceMenu);
   *unloadmultislicemenuptr = unloadmultislicemenu;
 
-  for(i = 0; i<slicecoll.nmultisliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nmultisliceinfo; i++){
     multislicedata *mslicei;
 
-    mslicei = slicecoll.multisliceinfo+i;
+    mslicei = global_scase.slicecoll.multisliceinfo+i;
     if(mslicei->loaded!=0){
       glutAddMenuEntry(mslicei->menulabel2, i);
     }
   }
-  for(i = 0; i<npatchinfo; i++){
+  for(i = 0; i<global_scase.npatchinfo; i++){
     patchdata *patchi;
 
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==1&&patchi->filetype_label!=NULL&&strcmp(patchi->filetype_label, "INCLUDE_GEOM")==0){
       glutAddMenuEntry(patchi->label.longlabel, -3-i);
     }
@@ -8165,11 +8165,11 @@ void InitLoadMultiSubMenu(int **loadsubmslicemenuptr, int *nmultisliceloadedptr)
 
   nmultisliceloaded = 0;
   nloadsubmslicemenu = 1;
-  for(i = 1;i<slicecoll.nmultisliceinfo;i++){
+  for(i = 1;i<global_scase.slicecoll.nmultisliceinfo;i++){
     slicedata *sd, *sdim1;
 
-    sd = slicecoll.sliceinfo+(slicecoll.multisliceinfo+i)->islices[0];
-    sdim1 = slicecoll.sliceinfo+(slicecoll.multisliceinfo+i-1)->islices[0];
+    sd = global_scase.slicecoll.sliceinfo+(global_scase.slicecoll.multisliceinfo+i)->islices[0];
+    sdim1 = global_scase.slicecoll.sliceinfo+(global_scase.slicecoll.multisliceinfo+i-1)->islices[0];
     if(strcmp(sd->label.longlabel, sdim1->label.longlabel)!=0)nloadsubmslicemenu++;
   }
   loadsubmslicemenu = *loadsubmslicemenuptr;
@@ -8179,17 +8179,17 @@ void InitLoadMultiSubMenu(int **loadsubmslicemenuptr, int *nmultisliceloadedptr)
     loadsubmslicemenu[i] = 0;
   }
   nloadsubmslicemenu = 0;
-  for(i = 0;i<slicecoll.nmultisliceinfo;i++){
+  for(i = 0;i<global_scase.slicecoll.nmultisliceinfo;i++){
     slicedata *sd, *sdim1;
     char menulabel[1024];
     multislicedata *mslicei,*msliceim1;
 
     if(i>0){
-      msliceim1 = slicecoll.multisliceinfo+i-1;
-      sdim1 = slicecoll.sliceinfo+msliceim1->islices[0];
+      msliceim1 = global_scase.slicecoll.multisliceinfo+i-1;
+      sdim1 = global_scase.slicecoll.sliceinfo+msliceim1->islices[0];
     }
-    mslicei = slicecoll.multisliceinfo+i;
-    sd = slicecoll.sliceinfo+mslicei->islices[0];
+    mslicei = global_scase.slicecoll.multisliceinfo+i;
+    sd = global_scase.slicecoll.sliceinfo+mslicei->islices[0];
 
     if(i==0||strcmp(sd->label.longlabel, sdim1->label.longlabel)!=0){
       msubslice_menuindex[nloadsubmslicemenu]=mslicei->islices[0];
@@ -8269,19 +8269,19 @@ int CompareSubSliceMenu(const void *arg1, const void *arg2){
 void InitSubSliceMenuInfo(){
   int i;
 
-  if(slicecoll.nsliceinfo == 0 || subslicemenuinfo != NULL)return;
+  if(global_scase.slicecoll.nsliceinfo == 0 || subslicemenuinfo != NULL)return;
   INIT_PRINT_TIMER(subslicemenu_timer);
-  NewMemory((void **)&subslicemenuinfo, slicecoll.nsliceinfo * sizeof(subslicemenudata));
+  NewMemory((void **)&subslicemenuinfo, global_scase.slicecoll.nsliceinfo * sizeof(subslicemenudata));
   nsubslicex = 0;
   nsubslicey = 0;
   nsubslicez = 0;
   nsubslicexyz = 0;
-  for(i = 0;i<slicecoll.nmultisliceinfo;i++){
+  for(i = 0;i<global_scase.slicecoll.nmultisliceinfo;i++){
     slicedata *sd, *sdim1;
     subslicemenudata *si;
 
-    sd = slicecoll.sliceinfo+(slicecoll.multisliceinfo+i)->islices[0];
-    if(i>0)sdim1 = slicecoll.sliceinfo+(slicecoll.multisliceinfo+i-1)->islices[0];
+    sd = global_scase.slicecoll.sliceinfo+(global_scase.slicecoll.multisliceinfo+i)->islices[0];
+    if(i>0)sdim1 = global_scase.slicecoll.sliceinfo+(global_scase.slicecoll.multisliceinfo+i-1)->islices[0];
 
     if(i==0||strcmp(sd->label.longlabel, sdim1->label.longlabel)!=0){
       si = subslicemenuinfo + nsubslicemenuinfo;
@@ -8329,24 +8329,24 @@ void InitSubSliceMenuInfo(){
 void InitSubVectorSliceMenuInfo(){
   int i;
 
-  if(slicecoll.nmultivsliceinfo == 0 || subvectorslicemenuinfo != NULL)return;
+  if(global_scase.slicecoll.nmultivsliceinfo == 0 || subvectorslicemenuinfo != NULL)return;
   INIT_PRINT_TIMER(subvectorslicemenu_timer);
-  NewMemory((void **)&subvectorslicemenuinfo, slicecoll.nmultivsliceinfo * sizeof(subslicemenudata));
+  NewMemory((void **)&subvectorslicemenuinfo, global_scase.slicecoll.nmultivsliceinfo * sizeof(subslicemenudata));
   nsubvectorslicex = 0;
   nsubvectorslicey = 0;
   nsubvectorslicez = 0;
   nsubvectorslicexyz = 0;
-  for(i = 0; i<slicecoll.nmultivsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nmultivsliceinfo; i++){
     vslicedata *vi, *vim1;
     slicedata *si, *sim1;
     subslicemenudata *vd;
 
-    vi = slicecoll.vsliceinfo+(slicecoll.multivsliceinfo+i)->ivslices[0];
-    si = slicecoll.sliceinfo+vi->ival;
+    vi = global_scase.slicecoll.vsliceinfo+(global_scase.slicecoll.multivsliceinfo+i)->ivslices[0];
+    si = global_scase.slicecoll.sliceinfo+vi->ival;
 
     if(i>0){
-      vim1 = slicecoll.vsliceinfo+(slicecoll.multivsliceinfo+i-1)->ivslices[0];
-      sim1 = slicecoll.sliceinfo+vim1->ival;
+      vim1 = global_scase.slicecoll.vsliceinfo+(global_scase.slicecoll.multivsliceinfo+i-1)->ivslices[0];
+      sim1 = global_scase.slicecoll.sliceinfo+vim1->ival;
     }
     if(i==0||(i>0&&strcmp(si->label.longlabel, sim1->label.longlabel)!=0)){
       vd = subvectorslicemenuinfo + nsubvectorslicemenuinfo;
@@ -8498,11 +8498,11 @@ void InitLoadMultiSliceMenu(int *loadmultislicemenuptr, int *loadsubmslicemenu, 
   CREATEMENU(loadmultislicemenu, LoadMultiSliceMenu);
   *loadmultislicemenuptr = loadmultislicemenu;
   nloadsubmslicemenu = 0;
-  for(i = 0;i<slicecoll.nmultisliceinfo;i++){
+  for(i = 0;i<global_scase.slicecoll.nmultisliceinfo;i++){
     slicedata *sd, *sdim1;
 
-    sd = slicecoll.sliceinfo+(slicecoll.multisliceinfo+i)->islices[0];
-    if(i>0)sdim1 = slicecoll.sliceinfo+(slicecoll.multisliceinfo+i-1)->islices[0];
+    sd = global_scase.slicecoll.sliceinfo+(global_scase.slicecoll.multisliceinfo+i)->islices[0];
+    if(i>0)sdim1 = global_scase.slicecoll.sliceinfo+(global_scase.slicecoll.multisliceinfo+i-1)->islices[0];
 
     if(i==0||strcmp(sd->label.longlabel, sdim1->label.longlabel)!=0){
       char mlabel[1024];
@@ -8512,20 +8512,20 @@ void InitLoadMultiSliceMenu(int *loadmultislicemenuptr, int *loadsubmslicemenu, 
       nloadsubmslicemenu++;
     }
   }
-  if(nmeshes>0){
+  if(global_scase.meshescoll.nmeshes>0){
     int ii;
 
     iloadsubpatchmenu_s = 0;
-    for(ii = 0;ii<npatchinfo;ii++){
+    for(ii = 0;ii<global_scase.npatchinfo;ii++){
       int im1;
       patchdata *patchi, *patchim1;
 
       i = patchorderindex[ii];
       if(ii>0){
         im1 = patchorderindex[ii-1];
-        patchim1 = patchinfo+im1;
+        patchim1 = global_scase.patchinfo+im1;
       }
-      patchi = patchinfo+i;
+      patchi = global_scase.patchinfo+i;
       if(ii==0||strcmp(patchi->menulabel_base, patchim1->menulabel_base)!=0){
         if(nsubpatchmenus_s[iloadsubpatchmenu_s]>0){
           GLUTADDSUBMENU(patchi->menulabel_base, loadsubpatchmenu_s[iloadsubpatchmenu_s]);
@@ -8541,7 +8541,7 @@ void InitLoadMultiSliceMenu(int *loadmultislicemenuptr, int *loadsubmslicemenu, 
     if(nsubslicez>0)GLUTADDSUBMENU("Load all z slices",     loadsubslicezmenu);
     if(nsubslicexyz>0)GLUTADDSUBMENU("Load all x,y,z slices", loadsubslicexyzmenu);
   }
-  if(slicecoll.nmultisliceinfo>0)glutAddMenuEntry("-", MENU_DUMMY);
+  if(global_scase.slicecoll.nmultisliceinfo>0)glutAddMenuEntry("-", MENU_DUMMY);
 
   GLUTADDSUBMENU(_("Skip"), sliceskipmenu);
   if(sortslices == 1){
@@ -8590,12 +8590,12 @@ void InitUnloadVSLiceMenu(int *unloadvslicemenuptr){
 
   CREATEMENU(unloadvslicemenu,UnloadVSliceMenu);
   *unloadvslicemenuptr = unloadvslicemenu;
-  for(ii=0;ii<slicecoll.nvsliceinfo;ii++){
+  for(ii=0;ii<global_scase.slicecoll.nvsliceinfo;ii++){
     vslicedata *vd;
     int i;
 
-    i = vsliceorderindex[ii];
-    vd = slicecoll.vsliceinfo + i;
+    i = global_scase.vsliceorderindex[ii];
+    vd = global_scase.slicecoll.vsliceinfo + i;
     if(vd->loaded==0)continue;
     glutAddMenuEntry(vd->menulabel2,i);
   }
@@ -8646,10 +8646,10 @@ void InitMultiVectorUnloadSliceMenu(int *unloadmultivslicemenuptr){
 
   CREATEMENU(unloadmultivslicemenu, UnloadMultiVSliceMenu);
   *unloadmultivslicemenuptr = unloadmultivslicemenu;
-  for(i = 0; i<slicecoll.nmultivsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nmultivsliceinfo; i++){
     multivslicedata *mvslicei;
 
-    mvslicei = slicecoll.multivsliceinfo+i;
+    mvslicei = global_scase.slicecoll.multivsliceinfo+i;
     if(mvslicei->loaded!=0){
       glutAddMenuEntry(mvslicei->menulabel2, i);
     }
@@ -8666,14 +8666,14 @@ void InitMultiVectorSubMenu(int **loadsubmvslicemenuptr){
 
 
   nloadsubmvslicemenu = 1;
-  for(i = 1; i<slicecoll.nmultivsliceinfo; i++){
+  for(i = 1; i<global_scase.slicecoll.nmultivsliceinfo; i++){
     vslicedata *vi, *vim1;
     slicedata *si, *sim1;
 
-    vi = slicecoll.vsliceinfo+(slicecoll.multivsliceinfo+i)->ivslices[0];
-    vim1 = slicecoll.vsliceinfo+(slicecoll.multivsliceinfo+i-1)->ivslices[0];
-    si = slicecoll.sliceinfo+vi->ival;
-    sim1 = slicecoll.sliceinfo+vim1->ival;
+    vi = global_scase.slicecoll.vsliceinfo+(global_scase.slicecoll.multivsliceinfo+i)->ivslices[0];
+    vim1 = global_scase.slicecoll.vsliceinfo+(global_scase.slicecoll.multivsliceinfo+i-1)->ivslices[0];
+    si = global_scase.slicecoll.sliceinfo+vi->ival;
+    sim1 = global_scase.slicecoll.sliceinfo+vim1->ival;
     if(strcmp(si->label.longlabel, sim1->label.longlabel)!=0){
       nloadsubmvslicemenu++;
     }
@@ -8686,20 +8686,20 @@ void InitMultiVectorSubMenu(int **loadsubmvslicemenuptr){
   }
 
   nloadsubmvslicemenu = 0;
-  for(i = 0; i<slicecoll.nmultivsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nmultivsliceinfo; i++){
     vslicedata *vi, *vim1;
     slicedata *si, *sim1;
     char menulabel[1024];
     multivslicedata *mvslicei;
 
-    mvslicei = slicecoll.multivsliceinfo+i;
+    mvslicei = global_scase.slicecoll.multivsliceinfo+i;
 
     if(i>0){
-      vim1 = slicecoll.vsliceinfo+(slicecoll.multivsliceinfo+i-1)->ivslices[0];
-      sim1 = slicecoll.sliceinfo+vim1->ival;
+      vim1 = global_scase.slicecoll.vsliceinfo+(global_scase.slicecoll.multivsliceinfo+i-1)->ivslices[0];
+      sim1 = global_scase.slicecoll.sliceinfo+vim1->ival;
     }
-    vi = slicecoll.vsliceinfo+mvslicei->ivslices[0];
-    si = slicecoll.sliceinfo+vi->ival;
+    vi = global_scase.slicecoll.vsliceinfo+mvslicei->ivslices[0];
+    si = global_scase.slicecoll.sliceinfo+vi->ival;
     if(i==0||strcmp(si->label.longlabel, sim1->label.longlabel)!=0){
       CREATEMENU(loadsubmvslicemenu[nloadsubmvslicemenu], LoadMultiVSliceMenu);
       msubvslice_menuindex[nloadsubmvslicemenu] = vi->ival;
@@ -8790,15 +8790,15 @@ void InitMultiVectorLoadMenu(int *loadmultivslicemenuptr, int *loadsubmvslicemen
   nloadsubmvslicemenu = 0;
   CREATEMENU(loadmultivslicemenu, LoadMultiVSliceMenu);
   *loadmultivslicemenuptr = loadmultivslicemenu;
-  for(i = 0; i<slicecoll.nmultivsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nmultivsliceinfo; i++){
     vslicedata *vi, *vim1;
     slicedata *si, *sim1;
 
-    vi = slicecoll.vsliceinfo+(slicecoll.multivsliceinfo+i)->ivslices[0];
-    si = slicecoll.sliceinfo+vi->ival;
+    vi = global_scase.slicecoll.vsliceinfo+(global_scase.slicecoll.multivsliceinfo+i)->ivslices[0];
+    si = global_scase.slicecoll.sliceinfo+vi->ival;
     if(i>0){
-      vim1 = slicecoll.vsliceinfo+(slicecoll.multivsliceinfo+i-1)->ivslices[0];
-      sim1 = slicecoll.sliceinfo+vim1->ival;
+      vim1 = global_scase.slicecoll.vsliceinfo+(global_scase.slicecoll.multivsliceinfo+i-1)->ivslices[0];
+      sim1 = global_scase.slicecoll.sliceinfo+vim1->ival;
     }
     if(i==0||(i>0&&strcmp(si->label.longlabel, sim1->label.longlabel)!=0)){
       char mlabel[1024];
@@ -8838,7 +8838,7 @@ void InitPatchSubMenus(int **loadsubpatchmenu_sptr, int **nsubpatchmenus_sptr){
 
   have_geom_slice_menus=0;
   nloadsubpatchmenu_s = 0;
-  for(ii = 0;ii<npatchinfo;ii++){
+  for(ii = 0;ii<global_scase.npatchinfo;ii++){
     int im1;
     patchdata *patchi, *patchim1;
     int i;
@@ -8846,9 +8846,9 @@ void InitPatchSubMenus(int **loadsubpatchmenu_sptr, int **nsubpatchmenus_sptr){
     i = patchorderindex[ii];
     if(ii>0){
       im1 = patchorderindex[ii-1];
-      patchim1 = patchinfo+im1;
+      patchim1 = global_scase.patchinfo+im1;
     }
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(ii==0||strcmp(patchi->menulabel_base, patchim1->menulabel_base)!=0){
       nloadsubpatchmenu_s++;
     }
@@ -8871,16 +8871,16 @@ void InitPatchSubMenus(int **loadsubpatchmenu_sptr, int **nsubpatchmenus_sptr){
   }
 
   iloadsubpatchmenu_s = 0;
-  for(ii = 0;ii<npatchinfo;ii++){
+  for(ii = 0;ii<global_scase.npatchinfo;ii++){
     int im1, i;
     patchdata *patchi, *patchim1;
 
     i = patchorderindex[ii];
     if(ii>0){
       im1 = patchorderindex[ii-1];
-      patchim1 = patchinfo+im1;
+      patchim1 = global_scase.patchinfo+im1;
     }
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(ii==0||strcmp(patchi->menulabel_base, patchim1->menulabel_base)!=0){
       CREATEMENU(loadsubpatchmenu_s[iloadsubpatchmenu_s], LoadBoundaryMenu);
       iloadsubpatchmenu_s++;
@@ -9056,11 +9056,11 @@ static int menu_count=0;
   }
   nmenus = 0;
 
-  for(i=0;i<slicecoll.nmultisliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nmultisliceinfo;i++){
     multislicedata *mslicei;
     int j;
 
-    mslicei = slicecoll.multisliceinfo + i;
+    mslicei = global_scase.slicecoll.multisliceinfo + i;
     mslicei->loaded=0;
     mslicei->display=0;
     mslicei->loadable = 0;
@@ -9068,8 +9068,8 @@ static int menu_count=0;
       slicedata *sd;
       meshdata *meshi;
 
-      sd = slicecoll.sliceinfo + mslicei->islices[j];
-      meshi = meshinfo + sd->blocknumber;
+      sd = global_scase.slicecoll.sliceinfo + mslicei->islices[j];
+      meshi = global_scase.meshescoll.meshinfo + sd->blocknumber;
       if(meshi->use == 1)mslicei->loadable = 1;
       if(sd->loaded==1)mslicei->loaded++;
       if(sd->display==1)mslicei->display++;
@@ -9087,11 +9087,11 @@ static int menu_count=0;
       mslicei->display=1;
     }
   }
-  for(i=0;i<slicecoll.nmultivsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nmultivsliceinfo;i++){
     multivslicedata *mvslicei;
     int j;
 
-    mvslicei = slicecoll.multivsliceinfo + i;
+    mvslicei = global_scase.slicecoll.multivsliceinfo + i;
     mvslicei->loaded   = 0;
     mvslicei->display  = 0;
     mvslicei->loadable = 0;
@@ -9100,9 +9100,9 @@ static int menu_count=0;
       meshdata *meshi;
       slicedata *valslice;
 
-      vd = slicecoll.vsliceinfo + mvslicei->ivslices[j];
-      valslice = slicecoll.sliceinfo + vd->ival;
-      meshi = meshinfo + valslice->blocknumber;
+      vd = global_scase.slicecoll.vsliceinfo + mvslicei->ivslices[j];
+      valslice = global_scase.slicecoll.sliceinfo + vd->ival;
+      meshi = global_scase.meshescoll.meshinfo + valslice->blocknumber;
       if(meshi->use==1)mvslicei->loadable = 1;
       if(vd->loaded==1)mvslicei->loaded++;
       if(vd->display==1)mvslicei->display++;
@@ -9144,10 +9144,10 @@ static int menu_count=0;
   }
 
   patchgeom_slice_showhide = 0;
-  for(i=0;i<npatchinfo;i++){
+  for(i=0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==1){
       if(patchi->filetype_label!=NULL&&strcmp(patchi->filetype_label, "INCLUDE_GEOM")==0){
         patchgeom_slice_showhide = 1;
@@ -9156,7 +9156,7 @@ static int menu_count=0;
   }
 
 /* --------------------------------patch menu -------------------------- */
-  if(npatchinfo>0){
+  if(global_scase.npatchinfo>0){
     int ii;
     char menulabel[1024];
     int next_total=0;
@@ -9213,10 +9213,10 @@ static int menu_count=0;
     if(npatchloaded>0){
       patchdata *patchi=NULL, *patchim1=NULL;
 
-      for(ii = 0;ii<npatchinfo;ii++){
+      for(ii = 0;ii<global_scase.npatchinfo;ii++){
 
         i = patchorderindex[ii];
-        patchi = patchinfo+i;
+        patchi = global_scase.patchinfo+i;
         if(patchi->loaded==0)continue;
         if(patchi->filetype_label!=NULL&&strcmp(patchi->filetype_label, "INCLUDE_GEOM")==0)continue;
         if(ii>0){
@@ -9254,19 +9254,19 @@ static int menu_count=0;
     {
       int local_do_threshold=0;
 
-      for(i = 0;i<npatchinfo;i++){
+      for(i = 0;i<global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo+i;
+        patchi = global_scase.patchinfo+i;
         if(patchi->loaded==0)continue;
         if(patchi->filetype_label!=NULL&&strcmp(patchi->filetype_label, "INCLUDE_GEOM")==0)continue;
         npatchloaded++;
       }
-      for(ii=0;ii<npatchinfo;ii++){
+      for(ii=0;ii<global_scase.npatchinfo;ii++){
         patchdata *patchi;
 
         i = patchorderindex[ii];
-        patchi = patchinfo+i;
+        patchi = global_scase.patchinfo+i;
         if(patchi->loaded==0)continue;
         if(activate_threshold==1){
           if(
@@ -9291,12 +9291,12 @@ static int menu_count=0;
   /* --------------------------------terrain menu -------------------------- */
 
 
-  if(nterrain_textures>0){
+  if(global_scase.terrain_texture_coll.nterrain_textures>0){
     CREATEMENU(terrain_geom_showmenu, TerrainGeomShowMenu);
-    for(i = 0; i<nterrain_textures; i++){
+    for(i = 0; i<global_scase.terrain_texture_coll.nterrain_textures; i++){
       texturedata *texti;
 
-      texti = terrain_textures+i;
+      texti = global_scase.terrain_texture_coll.terrain_textures+i;
       if(texti->loaded==1){
         char tlabel[256];
 
@@ -9351,7 +9351,7 @@ static int menu_count=0;
     glutAddMenuEntry(_("   Outside FDS domain"), GEOMETRY_OUTSIDE_DOMAIN);
   }
   glutAddMenuEntry("-", GEOMETRY_DUMMY);
-  if(nterrain_textures>0){
+  if(global_scase.terrain_texture_coll.nterrain_textures>0){
     GLUTADDSUBMENU(_("Terrain images"), terrain_geom_showmenu);
   }
   if(terrain_nindices>0){
@@ -9391,7 +9391,7 @@ static int menu_count=0;
 
   CREATEMENU(blockagemenu,BlockageMenu);
   glutAddMenuEntry(_("View Method:"),MENU_DUMMY);
-  if(tourcoll.tourinfo!=NULL&&have_animate_blockages == 1){
+  if(global_scase.tourcoll.tourinfo!=NULL&&have_animate_blockages == 1){
     if(animate_blockages == 1)glutAddMenuEntry(_("   *Animate blockages"), ANIMATE_BLOCKAGES);
     if(animate_blockages==0)glutAddMenuEntry(_("   Animate blockages"),    ANIMATE_BLOCKAGES);
   }
@@ -9427,7 +9427,7 @@ static int menu_count=0;
   else{
     glutAddMenuEntry(_("   Outline added"),visBLOCKAddOutline);
   }
-  if(NCADGeom(cadgeomcoll)>0){
+  if(NCADGeom(&global_scase.cadgeomcoll)>0){
     if(viscadopaque==1){
       glutAddMenuEntry(_("   *Cad surface drawn opaque"),visCADOpaque);
     }
@@ -9460,10 +9460,10 @@ static int menu_count=0;
   {
     int nblockprop=0;
 
-    for(i=0;i<npropinfo;i++){
+    for(i=0;i<global_scase.propcoll.npropinfo;i++){
       propdata *propi;
 
-      propi = propinfo + i;
+      propi = global_scase.propcoll.propinfo + i;
       if(propi->inblockage==1)nblockprop++;
     }
     if(nblockprop>0){
@@ -9471,10 +9471,10 @@ static int menu_count=0;
 
       glutAddMenuEntry("-",MENU_DUMMY);
       glutAddMenuEntry(_("Show/Hide blockage types:"),MENU_DUMMY);
-      for(i=0;i<npropinfo;i++){
+      for(i=0;i<global_scase.propcoll.npropinfo;i++){
         propdata *propi;
 
-        propi = propinfo + i;
+        propi = global_scase.propcoll.propinfo + i;
         if(propi->inblockage==1){
           strcpy(propmenulabel,"    ");
           if(propi->blockvis==1)strcat(propmenulabel,"*");
@@ -9487,20 +9487,20 @@ static int menu_count=0;
 
 /* --------------------------------level menu -------------------------- */
 
-  if(nplot3dinfo>0){
+  if(global_scase.nplot3dinfo>0){
     CREATEMENU(levelmenu,LevelMenu);
-    for(i=1;i<nrgb-1;i++){
+    for(i=1;i<global_scase.nrgb-1;i++){
       if(colorlabeliso!=NULL){
         char *colorlabel;
         char levellabel2[256];
 
-        colorlabel=&colorlabeliso[plotn-1][nrgb-2-i][0];
+        colorlabel=&colorlabeliso[plotn-1][global_scase.nrgb-2-i][0];
         strcpy(levellabel2,"");
-        if(plotiso[plotn-1]==nrgb-2-i&&visiso==1){
+        if(plotiso[plotn-1]==global_scase.nrgb-2-i&&visiso==1){
           strcat(levellabel2,"*");
         }
         strcat(levellabel2,colorlabel);
-        glutAddMenuEntry(levellabel2,nrgb-2-i);
+        glutAddMenuEntry(levellabel2,global_scase.nrgb-2-i);
       }
       else{
         char chari[20];
@@ -9518,14 +9518,14 @@ static int menu_count=0;
 
 /* --------------------------------static variable menu -------------------------- */
 
-  if(nplot3dinfo>0){
+  if(global_scase.nplot3dinfo>0){
     int n;
 
     CREATEMENU(staticvariablemenu,StaticVariableMenu);
     for(n=0;n<numplot3dvars;n++){
       char *p3label;
 
-      p3label = plot3dinfo[0].label[n].shortlabel;
+      p3label = global_scase.plot3dinfo[0].label[n].shortlabel;
       if(plotn-1==n){
         char menulabel[1024];
 
@@ -9541,14 +9541,14 @@ static int menu_count=0;
 
 /* --------------------------------iso variable menu -------------------------- */
 
-  if(nplot3dinfo>0){
+  if(global_scase.nplot3dinfo>0){
     int n;
 
     CREATEMENU(isovariablemenu,IsoVariableMenu);
     for(n=0;n<numplot3dvars;n++){
       char *p3label;
 
-      p3label = plot3dinfo[0].label[n].shortlabel;
+      p3label = global_scase.plot3dinfo[0].label[n].shortlabel;
       if(plotn-1==n&&visiso==1){
         char menulabel[1024];
 
@@ -9563,7 +9563,7 @@ static int menu_count=0;
   }
 
 /* --------------------------------iso surface menu -------------------------- */
-  if(nplot3dinfo>0){
+  if(global_scase.nplot3dinfo>0){
     CREATEMENU(isosurfacetypemenu,IsoSurfaceTypeMenu);
     if(p3dsurfacesmooth==1&&p3dsurfacetype==SURFACE_SOLID){
       glutAddMenuEntry(_("*Smooth"),MENU_SURFACE_SMOOTH);
@@ -9591,7 +9591,7 @@ static int menu_count=0;
 
 /* --------------------------------vector skip menu -------------------------- */
 
-  if(nplot3dinfo>0){
+  if(global_scase.nplot3dinfo>0){
     CREATEMENU(vectorskipmenu,VectorSkipMenu);
     if(visVector==1)glutAddMenuEntry(_("*Show"),MENU_VECTOR_SHOW);
     if(visVector!=1)glutAddMenuEntry(_("Show"),MENU_VECTOR_SHOW);
@@ -9611,14 +9611,14 @@ static int menu_count=0;
 
     CREATEMENU(textureshowmenu,TextureShowMenu);
     ntextures_used=0;
-    for(i=0;i<ntextureinfo;i++){
+    for(i=0;i<global_scase.texture_coll.ntextureinfo;i++){
       texturedata *texti;
       char menulabel[1024];
 
-      texti = textureinfo + i;
+      texti = global_scase.texture_coll.textureinfo + i;
       if(texti->loaded == 0 || texti->used == 0)continue;
-      if(terrain_textures != NULL){
-        if(texti >= terrain_textures && texti < terrain_textures + nterrain_textures)continue;
+      if(global_scase.terrain_texture_coll.terrain_textures != NULL){
+        if(texti >= global_scase.terrain_texture_coll.terrain_textures && texti < global_scase.terrain_texture_coll.terrain_textures + global_scase.terrain_texture_coll.nterrain_textures)continue;
       }
       ntextures_used++;
       if(texti->display==1){
@@ -9639,7 +9639,7 @@ static int menu_count=0;
   }
 
 /* --------------------------------Plot3d Show menu -------------------------- */
-  if(nplot3dinfo>0){
+  if(global_scase.nplot3dinfo>0){
     CREATEMENU(staticslicemenu,Plot3DShowMenu);
     GLUTADDSUBMENU(_("Solution variable"),staticvariablemenu);
     if(visz_all==1)glutAddMenuEntry(_("*xy plane"), MENU_PLOT3D_Z);
@@ -9664,9 +9664,9 @@ static int menu_count=0;
       plot3ddata *plot3di;
       char menulabel[1024];
 
-      for(ii = 0;ii<nplot3dinfo;ii++){
+      for(ii = 0;ii<global_scase.nplot3dinfo;ii++){
         i = plot3dorderindex[ii];
-        plot3di = plot3dinfo+i;
+        plot3di = global_scase.plot3dinfo+i;
         if(plot3di->loaded==0)continue;
         strcpy(menulabel, "");
         if(show_plot3dfiles==1)strcat(menulabel, "*");
@@ -9767,25 +9767,25 @@ static int menu_count=0;
       if(visOpenVents == 1)glutAddMenuEntry(_("*Open"), MENU_VENT_OPEN);
       if(visOpenVents == 0)glutAddMenuEntry(_("Open"), MENU_VENT_OPEN);
     }
-    if(ndummyvents>0){
+    if(global_scase.ndummyvents>0){
       if(visDummyVents == 1)glutAddMenuEntry(_("*Exterior"), MENU_VENT_EXTERIOR);
       if(visDummyVents == 0)glutAddMenuEntry(_("Exterior"), MENU_VENT_EXTERIOR);
     }
-    if(ncvents>0){
+    if(global_scase.ncvents>0){
       if(visCircularVents!=VENT_HIDE)GLUTADDSUBMENU(_("*Circular"),circularventmenu);
       if(visCircularVents==VENT_HIDE)GLUTADDSUBMENU(_("Circular"),circularventmenu);
     }
-    if(GetNTotalVents()>nopenvents+ndummyvents){
-      if(visOtherVents == 1)glutAddMenuEntry(_("*Other"), MENU_VENT_OTHER);
-      if(visOtherVents == 0)glutAddMenuEntry(_("Other"), MENU_VENT_OTHER);
+    if(GetNTotalVents()>nopenvents+global_scase.ndummyvents){
+      if(global_scase.visOtherVents == 1)glutAddMenuEntry(_("*Other"), MENU_VENT_OTHER);
+      if(global_scase.visOtherVents == 0)glutAddMenuEntry(_("Other"), MENU_VENT_OTHER);
     }
-    if(visOpenVents==1&&visDummyVents==1&&visOtherVents==1){
+    if(visOpenVents==1&&visDummyVents==1&&global_scase.visOtherVents==1){
       glutAddMenuEntry(_("*Show all"),SHOW_ALL_VENTS);
     }
     else{
       glutAddMenuEntry(_("Show all"),SHOW_ALL_VENTS);
     }
-    if(visOpenVents==0&&visDummyVents==0&&visOtherVents==0){
+    if(visOpenVents==0&&visDummyVents==0&&global_scase.visOtherVents==0){
       glutAddMenuEntry(_("*Hide all"),HIDE_ALL_VENTS);
     }
     else{
@@ -9813,30 +9813,30 @@ static int menu_count=0;
   CREATEMENU(terrain_obst_showmenu, GeometryMenu);
   if(terrain_showonly_top==1)glutAddMenuEntry(_("*Show only top surface"), 17 + TERRAIN_TOP);
   if(terrain_showonly_top==0)glutAddMenuEntry(_("Show only top surface"),  17 + TERRAIN_TOP);
-  if(visTerrainType==TERRAIN_SURFACE)glutAddMenuEntry(_("*3D surface"),17+TERRAIN_SURFACE);
-  if(visTerrainType!=TERRAIN_SURFACE)glutAddMenuEntry(_("3D surface"),17+TERRAIN_SURFACE);
-  if(terrain_textures!=NULL){ // &&terrain_texture->loaded==1
-    if(visTerrainType==TERRAIN_IMAGE)glutAddMenuEntry(_("*Image"),17+TERRAIN_IMAGE);
-    if(visTerrainType!=TERRAIN_IMAGE)glutAddMenuEntry(_("Image"),17+TERRAIN_IMAGE);
+  if(global_scase.visTerrainType==TERRAIN_SURFACE)glutAddMenuEntry(_("*3D surface"),17+TERRAIN_SURFACE);
+  if(global_scase.visTerrainType!=TERRAIN_SURFACE)glutAddMenuEntry(_("3D surface"),17+TERRAIN_SURFACE);
+  if(global_scase.terrain_texture_coll.terrain_textures!=NULL){ // &&terrain_texture->loaded==1
+    if(global_scase.visTerrainType==TERRAIN_IMAGE)glutAddMenuEntry(_("*Image"),17+TERRAIN_IMAGE);
+    if(global_scase.visTerrainType!=TERRAIN_IMAGE)glutAddMenuEntry(_("Image"),17+TERRAIN_IMAGE);
   }
-  if(visTerrainType==TERRAIN_HIDDEN)glutAddMenuEntry(_("*Hidden"),17+TERRAIN_HIDDEN);
-  if(visTerrainType!=TERRAIN_HIDDEN)glutAddMenuEntry(_("Hidden"),17+TERRAIN_HIDDEN);
+  if(global_scase.visTerrainType==TERRAIN_HIDDEN)glutAddMenuEntry(_("*Hidden"),17+TERRAIN_HIDDEN);
+  if(global_scase.visTerrainType!=TERRAIN_HIDDEN)glutAddMenuEntry(_("Hidden"),17+TERRAIN_HIDDEN);
 
-  if(objectscoll->nobject_defs>0){
+  if(global_scase.objectscoll.nobject_defs>0){
     int multiprop;
 
     multiprop=0;
-    for(i=0;i<npropinfo;i++){
+    for(i=0;i<global_scase.propcoll.npropinfo;i++){
       propdata *propi;
 
-      propi = propinfo + i;
+      propi = global_scase.propcoll.propinfo + i;
       if(propi->nsmokeview_ids>1)multiprop=1;
     }
     if(multiprop==1){
-      for(i=0;i<npropinfo;i++){
+      for(i=0;i<global_scase.propcoll.npropinfo;i++){
         propdata *propi;
 
-        propi = propinfo + i;
+        propi = global_scase.propcoll.propinfo + i;
         CREATEMENU(propi->menu_id,PropMenu);
         if(propi->nsmokeview_ids>1){
           int jj;
@@ -9848,15 +9848,15 @@ static int menu_count=0;
               strcat(menulabel,"*");
             }
             strcat(menulabel,propi->smokeview_ids[jj]);
-            glutAddMenuEntry(menulabel,jj*npropinfo+i);
+            glutAddMenuEntry(menulabel,jj*global_scase.propcoll.npropinfo+i);
           }
         }
       }
       CREATEMENU(propmenu,PropMenu);
-      for(i=0;i<npropinfo;i++){
+      for(i=0;i<global_scase.propcoll.npropinfo;i++){
         propdata *propi;
 
-        propi = propinfo + i;
+        propi = global_scase.propcoll.propinfo + i;
         if(propi->nsmokeview_ids>1){
           GLUTADDSUBMENU(propi->label,propi->menu_id);
         }
@@ -9901,12 +9901,12 @@ static int menu_count=0;
       glutAddMenuEntry(qlabel, i);
     }
   }
-  if(objectscoll->nobject_defs>0||hrrptr!=NULL){
+  if(global_scase.objectscoll.nobject_defs>0||hrrptr!=NULL){
     CREATEMENU(showobjectsplotmenu,ShowObjectsMenu);
     if(ndevicetypes>0){
       GLUTADDSUBMENU(_("quantity"),devicetypemenu);
     }
-    if(objectscoll->nobject_defs>0){
+    if(global_scase.objectscoll.nobject_defs>0){
       if(vis_device_plot==DEVICE_PLOT_SHOW_ALL)glutAddMenuEntry(      "*All devices",           OBJECT_PLOT_SHOW_ALL);
       if(vis_device_plot!=DEVICE_PLOT_SHOW_ALL)glutAddMenuEntry(      "All devices",            OBJECT_PLOT_SHOW_ALL);
       if(vis_device_plot==DEVICE_PLOT_SHOW_SELECTED)glutAddMenuEntry( "*Selected devices",      OBJECT_PLOT_SHOW_SELECTED);
@@ -9921,16 +9921,16 @@ static int menu_count=0;
     if(showdevice_val==0)glutAddMenuEntry(_("Show values"),  OBJECT_VALUES);
     glutAddMenuEntry(_("Settings..."), MENU_DEVICE_SETTINGS);
   }
-  if(objectscoll->nobject_defs>0){
-    if(ndeviceinfo > 0){
+  if(global_scase.objectscoll.nobject_defs>0){
+    if(global_scase.devicecoll.ndeviceinfo > 0){
       int showall=1, hideall=1;
 
       CREATEMENU(showdevicesmenu, ShowDevicesMenu);
-      for(i = 0; i < ndeviceinfo; i++){
+      for(i = 0; i < global_scase.devicecoll.ndeviceinfo; i++){
         devicedata *devicei;
         char devicelabel[256];
 
-        devicei = deviceinfo + i;
+        devicei = global_scase.devicecoll.deviceinfo + i;
         strcpy(devicelabel, "");
         if(devicei->show==1){
           strcat(devicelabel,"*");
@@ -9950,10 +9950,10 @@ static int menu_count=0;
     }
 
     CREATEMENU(showobjectsmenu,ShowObjectsMenu);
-    for(i=0;i<objectscoll->nobject_defs;i++){
+    for(i=0;i<global_scase.objectscoll.nobject_defs;i++){
       sv_object *obj_typei;
 
-      obj_typei = objectscoll->object_defs[i];
+      obj_typei = global_scase.objectscoll.object_defs[i];
       if(obj_typei->used_by_device==1){
         char obj_menu[256];
 
@@ -9965,11 +9965,11 @@ static int menu_count=0;
         glutAddMenuEntry(obj_menu,i);
       }
     }
-    if(have_missing_objects == 1&&isZoneFireModel==0){
+    if(global_scase.have_missing_objects == 1&&global_scase.isZoneFireModel==0){
       if(show_missing_objects==1)glutAddMenuEntry(_("*undefined"),OBJECT_MISSING);
       if(show_missing_objects == 0)glutAddMenuEntry(_("undefined"),OBJECT_MISSING);
     }
-    if(ndeviceinfo>0){
+    if(global_scase.devicecoll.ndeviceinfo>0){
       glutAddMenuEntry("-",MENU_DUMMY);
       if(select_device==1){
         glutAddMenuEntry(_("*Select"),OBJECT_SELECT);
@@ -9980,7 +9980,7 @@ static int menu_count=0;
     }
     if(object_outlines==0)glutAddMenuEntry(_("Outline"),OBJECT_OUTLINE);
     if(object_outlines==1)glutAddMenuEntry(_("*Outline"),OBJECT_OUTLINE);
-    if(have_object_box==1){
+    if(global_scase.have_object_box==1){
       if(object_box==0)glutAddMenuEntry(_("Show XB"), OBJECT_BOX);
       if(object_box==1)glutAddMenuEntry(_("*Show XB"), OBJECT_BOX);
     }
@@ -9992,7 +9992,7 @@ static int menu_count=0;
     else{
       glutAddMenuEntry(_("Show orientation"),OBJECT_ORIENTATION);
     }
-    if(have_beam == 1){
+    if(global_scase.have_beam == 1){
       if(showbeam_as_line == 1){
         glutAddMenuEntry(_("*Show beam as line"), OBJECT_SHOWBEAM);
       }
@@ -10001,11 +10001,11 @@ static int menu_count=0;
       }
     }
     glutAddMenuEntry("-",MENU_DUMMY);
-    if(ndeviceinfo > 0){
+    if(global_scase.devicecoll.ndeviceinfo > 0){
       GLUTADDSUBMENU(_("Show/Hide devices"), showdevicesmenu);
     }
     GLUTADDSUBMENU(_("Segments"),spheresegmentmenu);
-    if(objectscoll->nobject_defs>0&&ndeviceinfo>0){
+    if(global_scase.objectscoll.nobject_defs>0&&global_scase.devicecoll.ndeviceinfo>0){
       glutAddMenuEntry("-",MENU_DUMMY);
       GLUTADDSUBMENU(_("Plot data"),showobjectsplotmenu);
     }
@@ -10015,11 +10015,11 @@ static int menu_count=0;
 
   /* --------------------------------hvac menu -------------------------- */
 
-  if(hvaccoll.nhvacinfo > 0){
+  if(global_scase.hvaccoll.nhvacinfo > 0){
     int show_all_networks=1;
     int hide_all_networks=1;
 
-    if(hvaccoll.nhvacconnectinfo > 0){
+    if(global_scase.hvaccoll.nhvacconnectinfo > 0){
       int show_all_connections=1;
       int hide_all_connections=1;
 
@@ -10031,11 +10031,11 @@ static int menu_count=0;
         glutAddMenuEntry("connection view",  MENU_HVAC_CONNECTION_VIEW);
       }
       glutAddMenuEntry("-", MENU_HVAC_SHOW_NODE_IGNORE);
-      for(i=0;i<hvaccoll.nhvacconnectinfo;i++){
+      for(i=0;i<global_scase.hvaccoll.nhvacconnectinfo;i++){
         char label[32];
         hvacconnectdata *hi;
 
-        hi = hvaccoll.hvacconnectinfo + i;
+        hi = global_scase.hvaccoll.hvacconnectinfo + i;
 
         if(hi->display==1){
           sprintf(label, "*%i", hi->index);
@@ -10061,7 +10061,7 @@ static int menu_count=0;
       }
     }
 
-    if(hvaccoll.nhvaccomponents > 0){
+    if(global_scase.hvaccoll.nhvaccomponents > 0){
       CREATEMENU(showcomponentmenu, HVACMenu);
       if(glui_hvac->show_component == 0){
         glutAddMenuEntry("*text",   MENU_HVAC_SHOW_COMPONENT_TEXT);
@@ -10080,7 +10080,7 @@ static int menu_count=0;
       }
     }
 
-    if(hvaccoll.nhvacfilters > 0){
+    if(global_scase.hvaccoll.nhvacfilters > 0){
       CREATEMENU(showfiltermenu, HVACMenu);
       if(glui_hvac->show_filters == 0){
         glutAddMenuEntry("*text", MENU_HVAC_SHOW_FILTER_TEXT);
@@ -10100,7 +10100,7 @@ static int menu_count=0;
     }
 
     CREATEMENU(hvacnetworkmenu, HVACNetworkMenu);
-    if(hvaccoll.nhvacinfo>1){
+    if(global_scase.hvaccoll.nhvacinfo>1){
       if(hvac_show_networks==1){
         glutAddMenuEntry("*network view", MENU_HVAC_NETWORK_VIEW);
       }
@@ -10109,11 +10109,11 @@ static int menu_count=0;
       }
       glutAddMenuEntry("-", MENU_HVAC_SHOW_NODE_IGNORE);
     }
-    for(i = 0; i < hvaccoll.nhvacinfo; i++){
+    for(i = 0; i < global_scase.hvaccoll.nhvacinfo; i++){
       hvacdata *hvaci;
       char label[256];
 
-      hvaci = hvaccoll.hvacinfo + i;
+      hvaci = global_scase.hvaccoll.hvacinfo + i;
       strcpy(label, "");
       if(hvaci->display == 1){
         strcat(label, "*");
@@ -10125,7 +10125,7 @@ static int menu_count=0;
       strcat(label, hvaci->network_name);
       glutAddMenuEntry(label, i);
     }
-    if(hvaccoll.nhvacinfo > 1){
+    if(global_scase.hvaccoll.nhvacinfo > 1){
       if(show_all_networks == 1){
         glutAddMenuEntry("*show all", MENU_HVAC_SHOWALL_NETWORKS);
       }
@@ -10141,34 +10141,34 @@ static int menu_count=0;
     }
     int doit_ducts=0, doit_nodes=0;
 
-    if(hvaccoll.hvacductvalsinfo != NULL&&hvaccoll.hvacductvalsinfo->n_duct_vars>0)doit_ducts = 1;
-    if(hvaccoll.hvacnodevalsinfo != NULL&&hvaccoll.hvacnodevalsinfo->n_node_vars>0)doit_nodes = 1;
+    if(global_scase.hvaccoll.hvacductvalsinfo != NULL&&global_scase.hvaccoll.hvacductvalsinfo->n_duct_vars>0)doit_ducts = 1;
+    if(global_scase.hvaccoll.hvacnodevalsinfo != NULL&&global_scase.hvaccoll.hvacnodevalsinfo->n_node_vars>0)doit_nodes = 1;
     if(doit_nodes==1){
       CREATEMENU(hvacnodevaluemenu, HVACNodeValueMenu);
-      for(i = 0;i < hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
+      for(i = 0;i < global_scase.hvaccoll.hvacnodevalsinfo->n_node_vars;i++){
         char label[255], *labeli;
         hvacvaldata *hi;
 
-        hi = hvaccoll.hvacnodevalsinfo->node_vars + i;
+        hi = global_scase.hvaccoll.hvacnodevalsinfo->node_vars + i;
 
         labeli = hi->label.longlabel;
         strcpy(label, "");
-        if(hvaccoll.hvacnodevar_index == i)strcat(label, "*");
+        if(global_scase.hvaccoll.hvacnodevar_index == i)strcat(label, "*");
         strcat(label, labeli);
         glutAddMenuEntry(label, i);
       }
     }
     if(doit_ducts==1){
       CREATEMENU(hvacductvaluemenu, HVACDuctValueMenu);
-      for(i = 0;i < hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
+      for(i = 0;i < global_scase.hvaccoll.hvacductvalsinfo->n_duct_vars;i++){
         char label[255], *labeli;
         hvacvaldata *hi;
 
-        hi = hvaccoll.hvacductvalsinfo->duct_vars + i;
+        hi = global_scase.hvaccoll.hvacductvalsinfo->duct_vars + i;
 
         labeli = hi->label.longlabel;
         strcpy(label, "");
-        if(hvaccoll.hvacductvar_index == i)strcat(label, "*");
+        if(global_scase.hvaccoll.hvacductvar_index == i)strcat(label, "*");
         strcat(label, labeli);
         glutAddMenuEntry(label, i);
       }
@@ -10184,7 +10184,7 @@ static int menu_count=0;
     CREATEMENU(hvacmenu, HVACMenu);
     if(doit_ducts==1||doit_nodes==1)GLUTADDSUBMENU(_("Values"), hvacvaluemenu);
     GLUTADDSUBMENU(_("Networks"), hvacnetworkmenu);
-    if(hvaccoll.nhvacconnectinfo > 0){
+    if(global_scase.hvaccoll.nhvacconnectinfo > 0){
       GLUTADDSUBMENU(_("Connections"), connectivitymenu);
     }
     glutAddMenuEntry("Ducts", MENU_HVAC_SHOW_NODE_IGNORE);
@@ -10194,7 +10194,7 @@ static int menu_count=0;
     else{
       glutAddMenuEntry("   IDs", MENU_HVAC_SHOW_DUCT_IDS);
     }
-    if(hvaccoll.nhvaccomponents > 0){
+    if(global_scase.hvaccoll.nhvaccomponents > 0){
       GLUTADDSUBMENU(_(  "   Components"), showcomponentmenu);
     }
     glutAddMenuEntry("Nodes", MENU_HVAC_SHOW_NODE_IGNORE);
@@ -10204,7 +10204,7 @@ static int menu_count=0;
     else{
       glutAddMenuEntry("   IDs", MENU_HVAC_SHOW_NODE_IDS);
     }
-    if(hvaccoll.nhvacfilters > 0){
+    if(global_scase.hvaccoll.nhvacfilters > 0){
       GLUTADDSUBMENU(_("   Filters"), showfiltermenu);
     }
     glutAddMenuEntry("-", MENU_HVAC_SHOW_NODE_IGNORE);
@@ -10227,11 +10227,11 @@ static int menu_count=0;
 
   CREATEMENU(geometrymenu,GeometryMainMenu);
   if(ntotal_blockages>0)GLUTADDSUBMENU(_("Obstacles"),blockagemenu);
-  if(ngeominfo>0){
+  if(global_scase.ngeominfo>0){
     GLUTADDSUBMENU(_("Immersed"), immersedmenu);
   }
   if(GetNTotalVents()>0)GLUTADDSUBMENU(_("Surfaces"), ventmenu);
-  if(nrooms > 0){
+  if(global_scase.nrooms > 0){
     if(visCompartments == 1){
       glutAddMenuEntry(_("*Compartments"), GEOM_Compartments);
     }
@@ -10239,7 +10239,7 @@ static int menu_count=0;
       glutAddMenuEntry(_("Compartments"), GEOM_Compartments);
     }
   }
-  if(nzvents > 0){
+  if(global_scase.nzvents > 0){
     if(visVents == 1){
       glutAddMenuEntry(_("*Vents"), GEOM_Vents);
     }
@@ -10248,7 +10248,7 @@ static int menu_count=0;
     }
   }
   GLUTADDSUBMENU(_("Grid"),gridslicemenu);
-  if(isZoneFireModel==0){
+  if(global_scase.isZoneFireModel==0){
     if(visFrame==1)glutAddMenuEntry(_("*Outline"), GEOM_Outline);
     if(visFrame==0)glutAddMenuEntry(_("Outline"), GEOM_Outline);
   }
@@ -10259,7 +10259,7 @@ static int menu_count=0;
   if(show_geom_boundingbox != SHOW_BOUNDING_BOX_ALWAYS)glutAddMenuEntry(_("bounding box(always)"), GEOM_BOUNDING_BOX_ALWAYS);
   if(show_geom_boundingbox == SHOW_BOUNDING_BOX_MOUSE_DOWN)glutAddMenuEntry(_("*bounding box(mouse down)"), GEOM_BOUNDING_BOX_MOUSE_DOWN);
   if(show_geom_boundingbox != SHOW_BOUNDING_BOX_MOUSE_DOWN)glutAddMenuEntry(_("bounding box(mouse down)"), GEOM_BOUNDING_BOX_MOUSE_DOWN);
-  if(NCADGeom(cadgeomcoll) == 0){
+  if(NCADGeom(&global_scase.cadgeomcoll) == 0){
     if(blocklocation == BLOCKlocation_grid){
       glutAddMenuEntry("Locations(*actual,requested)", BLOCKlocation_grid);
     }
@@ -10289,10 +10289,10 @@ static int menu_count=0;
       int showtexturemenu;
 
       showtexturemenu = 0;
-      for(i = 0; i < NCADGeom(cadgeomcoll); i++){
+      for(i = 0; i < NCADGeom(&global_scase.cadgeomcoll); i++){
         int j;
 
-        cd = cadgeomcoll->cadgeominfo + i;
+        cd = global_scase.cadgeomcoll.cadgeominfo + i;
         for(j = 0; j < cd->ncadlookinfo; j++){
           cdi = cd->cadlookinfo + j;
           if(cdi->textureinfo.loaded == 1){
@@ -10351,11 +10351,11 @@ static int menu_count=0;
 
   if(visaxislabels == 1)glutAddMenuEntry(_("*Axis"), MENU_LABEL_axis);
   if(visaxislabels == 0)glutAddMenuEntry(_("Axis"), MENU_LABEL_axis);
-  if(have_northangle==1){
+  if(global_scase.have_northangle==1){
     if(vis_northangle==1)glutAddMenuEntry(_("*North"), MENU_LABEL_northangle);
     if(vis_northangle==0)glutAddMenuEntry(_("North"), MENU_LABEL_northangle);
   }
-  if(ntickinfo>0){
+  if(global_scase.ntickinfo>0){
     if(visFDSticks == 0)glutAddMenuEntry(_("FDS generated ticks"), MENU_LABEL_fdsticks);
     if(visFDSticks == 1)glutAddMenuEntry(_("*FDS generated ticks"), MENU_LABEL_fdsticks);
   }
@@ -10394,7 +10394,7 @@ static int menu_count=0;
   if(visMeshlabel == 0)glutAddMenuEntry(_("Mesh"), MENU_LABEL_meshlabel);
   if(vis_slice_average == 1)glutAddMenuEntry(_("*Slice average"), MENU_LABEL_sliceaverage);
   if(vis_slice_average == 0)glutAddMenuEntry(_("Slice average"), MENU_LABEL_sliceaverage);
-  if(LabelGetNUserLabels(&labelscoll) > 0){
+  if(LabelGetNUserLabels(&global_scase.labelscoll) > 0){
     if(visLabels == 1)glutAddMenuEntry(_("*Text labels"), MENU_LABEL_textlabels);
     if(visLabels == 0)glutAddMenuEntry(_("Text labels"), MENU_LABEL_textlabels);
   }
@@ -10449,7 +10449,7 @@ static int menu_count=0;
 
 /* --------------------------------zone show menu -------------------------- */
 
-  if(nzoneinfo>0&&(ReadZoneFile==1||nzvents>0)){
+  if(global_scase.nzoneinfo>0&&(ReadZoneFile==1||global_scase.nzvents>0)){
     CREATEMENU(zoneshowmenu,ZoneShowMenu);
     glutAddMenuEntry(_("Layers"),MENU_DUMMY);
     glutAddMenuEntry(_("   Representation:"),MENU_DUMMY);
@@ -10529,14 +10529,14 @@ static int menu_count=0;
         glutAddMenuEntry(_("Targets"), MENU_ZONE_TARGETS);
       }
     }
-    if(nzvents>0){
+    if(global_scase.nzvents>0){
       if(visVentFlow==1){
         glutAddMenuEntry(_("*Vent flow"), MENU_ZONE_VENTS);
       }
       else{
         glutAddMenuEntry(_("Vent flow"), MENU_ZONE_VENTS);
       }
-      if(nzhvents>0){
+      if(global_scase.nzhvents>0){
         if(visVentHFlow == 1){
           glutAddMenuEntry(_("   *Horizontal"), MENU_ZONE_HVENTS);
         }
@@ -10566,7 +10566,7 @@ static int menu_count=0;
           }
         }
       }
-      if(nzvvents>0){
+      if(global_scase.nzvvents>0){
         if(visVentVFlow==1){
           glutAddMenuEntry(_("   *Vertical"), MENU_ZONE_VVENTS);
         }
@@ -10574,7 +10574,7 @@ static int menu_count=0;
           glutAddMenuEntry(_("   Vertical"), MENU_ZONE_VVENTS);
         }
       }
-      if(nzmvents>0){
+      if(global_scase.nzmvents>0){
         if(visVentMFlow==1){
           glutAddMenuEntry(_("   *Mechanical"), MENU_ZONE_MVENTS);
         }
@@ -10583,7 +10583,7 @@ static int menu_count=0;
         }
       }
     }
-    if(nfires>0){
+    if(global_scase.nfires>0){
       if(viszonefire==1){
         glutAddMenuEntry(_("*Fires"), MENU_ZONE_FIRES);
       }
@@ -10595,7 +10595,7 @@ static int menu_count=0;
 
   /* --------------------------------particle class show menu -------------------------- */
 
-  if(npartclassinfo>0){
+  if(global_scase.npartclassinfo>0){
     int ntypes;
 
     CREATEMENU(particlestreakshowmenu,ParticleStreakShowMenu);
@@ -10627,8 +10627,8 @@ static int menu_count=0;
 
 // allocate memory for particle property sub-menus
 
-    if(npart5prop*npartclassinfo>0){
-      NewMemory((void **)&particlepropshowsubmenu,npart5prop*npartclassinfo*sizeof(int));
+    if(npart5prop*global_scase.npartclassinfo>0){
+      NewMemory((void **)&particlepropshowsubmenu,npart5prop*global_scase.npartclassinfo*sizeof(int));
     }
 
       ntypes=0;
@@ -10638,12 +10638,12 @@ static int menu_count=0;
 
         propi = part5propinfo + i;
         if(propi->display==0)continue;
-        for(j=0;j<npartclassinfo;j++){
+        for(j=0;j<global_scase.npartclassinfo;j++){
           partclassdata *partclassj;
           char menulabel[1024];
 
           if(propi->class_present[j]==0)continue;
-          partclassj = partclassinfo + j;
+          partclassj = global_scase.partclassinfo + j;
           CREATEMENU(particlepropshowsubmenu[ntypes],ParticlePropShowMenu);
           ntypes++;
           if(propi->class_vis[j]==1){
@@ -10708,7 +10708,7 @@ static int menu_count=0;
                 for(iii=0;iii<propclass->nsmokeview_ids;iii++){
                   int propvalue, showvalue, menuvalue;
 
-                  propvalue = iii*npropinfo + (propclass-propinfo);
+                  propvalue = iii*global_scase.propcoll.npropinfo + (propclass-global_scase.propcoll.propinfo);
                   showvalue = -10-5*j-PART_SMV_DEVICE;
                   menuvalue = (-1-propvalue)*10000 + showvalue;
                   // propvalue = (-menuvalue)/10000-1;
@@ -10759,12 +10759,12 @@ static int menu_count=0;
 
         propi = part5propinfo + i;
         if(propi->display==0)continue;
-        for(j=0;j<npartclassinfo;j++){
+        for(j=0;j<global_scase.npartclassinfo;j++){
           partclassdata *partclassj;
           char menulabel[1024];
 
           if(propi->class_present[j]==0)continue;
-          partclassj = partclassinfo + j;
+          partclassj = global_scase.partclassinfo + j;
           ntypes++;
           if(propi->class_vis[j]==1){
             strcpy(menulabel,"  *");
@@ -10796,17 +10796,17 @@ static int menu_count=0;
 
 /* --------------------------------particle show menu -------------------------- */
 
-  if(npartinfo>0){
+  if(global_scase.npartinfo>0){
     int ii;
     int showall;
 
     CREATEMENU(particleshowmenu,ParticleShowMenu);
-    for(ii=0;ii<npartinfo;ii++){
+    for(ii=0;ii<global_scase.npartinfo;ii++){
       partdata *parti;
       char menulabel[1024];
 
       i = partorderindex[ii];
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
       if(parti->loaded==0)continue;
       STRCPY(menulabel,"");
       if(parti->display==1)STRCAT(menulabel,"*");
@@ -10890,7 +10890,7 @@ static int menu_count=0;
 
 /* --------------------------------iso level menu -------------------------- */
 
-  if(loaded_isomesh!=NULL&&nisoinfo>0&&ReadIsoFile==1){
+  if(loaded_isomesh!=NULL&&global_scase.nisoinfo>0&&ReadIsoFile==1){
     CREATEMENU(isolevelmenu,IsoShowMenu);
     if(loaded_isomesh->nisolevels>0&&loaded_isomesh->showlevels!=NULL){
       int showflag,hideflag;
@@ -10908,7 +10908,7 @@ static int menu_count=0;
           sprintf(levellabel,"%f ",loaded_isomesh->isolevels[i]);
         }
         if(loaded_isomesh->isofilenum!=-1){
-          STRCAT(levellabel,isoinfo[loaded_isomesh->isofilenum].surface_label.unit);
+          STRCAT(levellabel,global_scase.isoinfo[loaded_isomesh->isofilenum].surface_label.unit);
         }
         else{
           STRCAT(levellabel,"");
@@ -10938,7 +10938,7 @@ static int menu_count=0;
 
 /* --------------------------------iso show menu -------------------------- */
 
-    if(nisoinfo>0&&ReadIsoFile==1){
+    if(global_scase.nisoinfo>0&&ReadIsoFile==1){
       meshdata *hmesh;
       isodata *iso2;
 
@@ -10959,16 +10959,16 @@ static int menu_count=0;
       if((visAIso & 2) != 2)glutAddMenuEntry(_("Outline"), MENU_ISOSHOW_OUTLINE);
       if((visAIso & 4) == 4)glutAddMenuEntry(_("*Points"), MENU_ISOSHOW_POINTS);
       if((visAIso & 4) != 4)glutAddMenuEntry(_("Points"), MENU_ISOSHOW_POINTS);
-      hmesh=meshinfo+highlight_mesh;
+      hmesh=global_scase.meshescoll.meshinfo+highlight_mesh;
       if(hmesh->isofilenum!=-1){
         char levellabel[1024];
 
-        STRCPY(levellabel,isoinfo[hmesh->isofilenum].surface_label.shortlabel);
+        STRCPY(levellabel,global_scase.isoinfo[hmesh->isofilenum].surface_label.shortlabel);
         STRCAT(levellabel," ");
         STRCAT(levellabel,_("Levels"));
         GLUTADDSUBMENU(levellabel,isolevelmenu);
       }
-      if(niso_compressed==0){
+      if(global_scase.niso_compressed==0){
         if(smooth_iso_normal == 1)glutAddMenuEntry(_("*Smooth"), MENU_ISOSHOW_SMOOTH);
         if(smooth_iso_normal == 0)glutAddMenuEntry(_("Smooth"), MENU_ISOSHOW_SMOOTH);
       }
@@ -11077,7 +11077,7 @@ static int menu_count=0;
   if(nvsliceloaded==0){
     vd_shown=NULL;
   }
-  if(slicecoll.nvsliceinfo>0&&nvsliceloaded>0){
+  if(global_scase.slicecoll.nvsliceinfo>0&&nvsliceloaded>0){
     CREATEMENU(showvslicemenu,ShowVSliceMenu);
     if(vd_shown!=NULL&&nvsliceloaded!=0){
       char menulabel[1024];
@@ -11085,7 +11085,7 @@ static int menu_count=0;
 
       STRCPY(menulabel, "");
       if(showall_slices==1)STRCAT(menulabel, "*");
-      slice_shown = slicecoll.sliceinfo+vd_shown->ival;
+      slice_shown = global_scase.slicecoll.sliceinfo+vd_shown->ival;
       STRCAT(menulabel, slice_shown->label.longlabel);
       STRCAT(menulabel, ", ");
       STRCAT(menulabel, slice_shown->cdir);
@@ -11096,22 +11096,22 @@ static int menu_count=0;
       glutAddMenuEntry(menulabel,SHOW_ALL);
     }
     glutAddMenuEntry(_("  Show in:"), MENU_DUMMY);
-    if(show_slice_in_obst==ONLY_IN_GAS){
+    if(global_scase.show_slice_in_obst==ONLY_IN_GAS){
       glutAddMenuEntry(_("    *gas"),  MENU_SHOWSLICE_IN_GAS);
       glutAddMenuEntry(_("    solid"), MENU_SHOWSLICE_IN_SOLID);
       glutAddMenuEntry(_("    gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
     }
-    if(show_slice_in_obst==GAS_AND_SOLID){
+    if(global_scase.show_slice_in_obst==GAS_AND_SOLID){
       glutAddMenuEntry(_("    gas"), MENU_SHOWSLICE_IN_GAS);
       glutAddMenuEntry(_("    solid"), MENU_SHOWSLICE_IN_SOLID);
       glutAddMenuEntry(_("    *gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
     }
-    if(show_slice_in_obst==ONLY_IN_SOLID){
+    if(global_scase.show_slice_in_obst==ONLY_IN_SOLID){
       glutAddMenuEntry(_("    gas"), MENU_SHOWSLICE_IN_GAS);
       glutAddMenuEntry(_("    *solid"), MENU_SHOWSLICE_IN_SOLID);
       glutAddMenuEntry(_("    gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
     }
-    if(show_slice_in_obst==NEITHER_GAS_NOR_SOLID){
+    if(global_scase.show_slice_in_obst==NEITHER_GAS_NOR_SOLID){
       glutAddMenuEntry(_("  gas"), MENU_SHOWSLICE_IN_GAS);
       glutAddMenuEntry(_("  solid"), MENU_SHOWSLICE_IN_SOLID);
       glutAddMenuEntry(_("  gas and solid"), MENU_SHOWSLICE_IN_GASANDSOLID);
@@ -11131,10 +11131,10 @@ static int menu_count=0;
 
   CREATEMENU(tourcopymenu, TourCopyMenu);
   glutAddMenuEntry("Path through domain", -1);
-  for(i = 0; i < tourcoll.ntourinfo; i++){
+  for(i = 0; i < global_scase.tourcoll.ntourinfo; i++){
     tourdata *touri;
 
-    touri = tourcoll.tourinfo + i;
+    touri = global_scase.tourcoll.tourinfo + i;
     glutAddMenuEntry(touri->menulabel, i);
   }
 
@@ -11143,14 +11143,14 @@ static int menu_count=0;
   CREATEMENU(tourmenu,TourMenu);
 
   GLUTADDSUBMENU(_("New"),tourcopymenu);
-  if(tourcoll.ntourinfo>0){
+  if(global_scase.tourcoll.ntourinfo>0){
     glutAddMenuEntry("-",MENU_DUMMY);
-    for(i=0;i<tourcoll.ntourinfo;i++){
+    for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
       tourdata *touri;
       int glui_avatar_index_local;
       char menulabel[1024];
 
-      touri =tourcoll. tourinfo + i;
+      touri =global_scase.tourcoll. tourinfo + i;
       if(touri->display==1){
         STRCPY(menulabel,"");
         if(selectedtour_index==i){
@@ -11163,10 +11163,10 @@ static int menu_count=0;
         STRCPY(menulabel,touri->menulabel);
       }
       glui_avatar_index_local = touri->glui_avatar_index;
-      if(glui_avatar_index_local>=0&&glui_avatar_index_local<objectscoll->navatar_types){
+      if(glui_avatar_index_local>=0&&glui_avatar_index_local<global_scase.objectscoll.navatar_types){
         sv_object *avatari;
 
-        avatari=objectscoll->avatar_types[glui_avatar_index_local];
+        avatari=global_scase.objectscoll.avatar_types[glui_avatar_index_local];
         strcat(menulabel,"(");
         strcat(menulabel,avatari->label);
         strcat(menulabel,")");
@@ -11180,7 +11180,7 @@ static int menu_count=0;
       strcpy(menulabel,"");
       if(viewtourfrompath==1)strcat(menulabel,"*");
       strcat(menulabel,"View from ");
-      strcat(menulabel,tourcoll.tourinfo[selectedtour_index].label);
+      strcat(menulabel,global_scase.tourcoll.tourinfo[selectedtour_index].label);
       glutAddMenuEntry(menulabel,MENU_TOUR_VIEWFROMROUTE);
     }
     glutAddMenuEntry("-",MENU_DUMMY);
@@ -11346,11 +11346,11 @@ static int menu_count=0;
   CREATEMENU(showhidemenu,ShowHideMenu);
   GLUTADDSUBMENU(_("Color"), colorbarmenu);
   GLUTADDSUBMENU(_("Geometry"),geometrymenu);
-  if(hvaccoll.nhvacinfo>0)GLUTADDSUBMENU(_("HVAC"), hvacmenu);
-  if(nterraininfo>0&&ngeominfo==0){
+  if(global_scase.hvaccoll.nhvacinfo>0)GLUTADDSUBMENU(_("HVAC"), hvacmenu);
+  if(global_scase.nterraininfo>0&&global_scase.ngeominfo==0){
     GLUTADDSUBMENU(_("Terrain"), terrain_obst_showmenu);
   }
-  if(GetNumActiveDevices()>0||ncvents>0){
+  if(GetNumActiveDevices()>0||global_scase.ncvents>0){
     GLUTADDSUBMENU(_("Devices"), showobjectsmenu);
   }
   GLUTADDSUBMENU(_("Labels"),labelmenu);
@@ -11380,10 +11380,10 @@ static int menu_count=0;
   if(ReadIsoFile==1){
     int niso_loaded=0;
 
-    for(i=0;i<nisoinfo;i++){
+    for(i=0;i<global_scase.nisoinfo;i++){
       isodata *isoi;
 
-      isoi = isoinfo + i;
+      isoi = global_scase.isoinfo + i;
       if(isoi->loaded==1)niso_loaded++;
     }
 
@@ -11411,17 +11411,17 @@ static int menu_count=0;
     }
   }
 
-  if(nzoneinfo>0&&(ReadZoneFile==1||nzvents>0)){
+  if(global_scase.nzoneinfo>0&&(ReadZoneFile==1||global_scase.nzvents>0)){
     showhide_data = 1;
     GLUTADDSUBMENU(_("Zone"), zoneshowmenu);
   }
-  if(objectscoll->nobject_defs>0){
+  if(global_scase.objectscoll.nobject_defs>0){
     int num_activedevices=0;
 
-    for(i = 0; i<objectscoll->nobject_defs; i++){
+    for(i = 0; i<global_scase.objectscoll.nobject_defs; i++){
       sv_object *obj_typei;
 
-      obj_typei = objectscoll->object_defs[i];
+      obj_typei = global_scase.objectscoll.object_defs[i];
       if(obj_typei->used==1)num_activedevices++;
     }
 
@@ -11433,10 +11433,10 @@ static int menu_count=0;
       */
     }
     else{
-      for(i=0;i<objectscoll->nobject_defs;i++){
+      for(i=0;i<global_scase.objectscoll.nobject_defs;i++){
         sv_object *obj_typei;
 
-        obj_typei = objectscoll->object_defs[i];
+        obj_typei = global_scase.objectscoll.object_defs[i];
         if(obj_typei->used==1){
           char obj_menu[256];
 
@@ -11451,9 +11451,9 @@ static int menu_count=0;
       }
     }
   }
-  if(ntc_total>0){
+  if(global_scase.ntc_total>0){
     showhide_data = 1;
-    if(isZoneFireModel==1){
+    if(global_scase.isZoneFireModel==1){
       if(visSensor==1)glutAddMenuEntry(_("*Targets"), MENU_SHOWHIDE_SENSOR);
       if(visSensor==0)glutAddMenuEntry(_("Targets"), MENU_SHOWHIDE_SENSOR);
       if(hasSensorNorm==1){
@@ -11479,7 +11479,7 @@ static int menu_count=0;
   }
   if(titlesafe_offset==0)glutAddMenuEntry(_("Offset window"), MENU_SHOWHIDE_OFFSET);
   if(titlesafe_offset!=0)glutAddMenuEntry(_("*Offset window"),MENU_SHOWHIDE_OFFSET);
-  if(ntextures_loaded_used>nterrain_textures){
+  if(ntextures_loaded_used>global_scase.terrain_texture_coll.nterrain_textures){
     GLUTADDSUBMENU(_("Textures"),textureshowmenu);
   }
 #ifdef pp_MEMPRINT
@@ -11669,7 +11669,7 @@ static int menu_count=0;
   CREATEMENU(filesdialogmenu, DialogMenu);
   glutAddMenuEntry(_("Auto load data files..."), DIALOG_AUTOLOAD);
 #ifdef pp_COMPRESS
-  if(smokezippath!=NULL&&(npatchinfo>0||smoke3dcoll.nsmoke3dinfo>0||slicecoll.nsliceinfo>0)){
+  if(smokezippath!=NULL&&(global_scase.npatchinfo>0||global_scase.smoke3dcoll.nsmoke3dinfo>0||global_scase.slicecoll.nsliceinfo>0)){
 #ifdef pp_DIALOG_SHORTCUTS
     glutAddMenuEntry(_("Compress data files...  ALT z"), DIALOG_SMOKEZIP);
 #else
@@ -11698,7 +11698,7 @@ static int menu_count=0;
   if(showtour_dialog==1)glutAddMenuEntry(_("*Create/modify tours...  ALT t"), DIALOG_TOUR_HIDE);
   if(showtour_dialog==0)glutAddMenuEntry(_("Create/modify tours...  ALT t"), DIALOG_TOUR_SHOW);
   glutAddMenuEntry(_("Edit colorbar...  ALT C"), DIALOG_COLORBAR);
-  if(isZoneFireModel==0 && have_geometry_dialog==1){
+  if(global_scase.isZoneFireModel==0 && have_geometry_dialog==1){
     glutAddMenuEntry(_("Examine geometry...  ALT e"), DIALOG_GEOMETRY);
   }
 #else
@@ -11706,14 +11706,14 @@ static int menu_count=0;
   if(showtour_dialog==1)glutAddMenuEntry(_("*Create/edit tours..."), DIALOG_TOUR_HIDE);
   if(showtour_dialog==0)glutAddMenuEntry(_("Create/edit tours..."), DIALOG_TOUR_SHOW);
   glutAddMenuEntry(_("Edit colorbar...  "), DIALOG_COLORBAR);
-  if(isZoneFireModel == 0 && have_geometry_dialog == 1){
+  if(global_scase.isZoneFireModel == 0 && have_geometry_dialog == 1){
     glutAddMenuEntry(_("Examine geometry...  "), DIALOG_GEOMETRY);
   }
 #endif
-  if(nterraininfo>0&&ngeominfo==0){
+  if(global_scase.nterraininfo>0&&global_scase.ngeominfo==0){
     glutAddMenuEntry(_("Terrain..."), DIALOG_TERRAIN);
   }
-  if(hvaccoll.nhvacinfo > 0){
+  if(global_scase.hvaccoll.nhvacinfo > 0){
     glutAddMenuEntry(_("HVAC settings..."), DIALOG_HVAC);
   }
   if(have_vr==1){
@@ -11729,10 +11729,10 @@ static int menu_count=0;
   /* --------------------------------data dialog menu -------------------------- */
 
   CREATEMENU(datadialogmenu, DialogMenu);
-  if(ndeviceinfo>0&&GetNumActiveDevices()>0){
+  if(global_scase.devicecoll.ndeviceinfo>0&&GetNumActiveDevices()>0){
     glutAddMenuEntry(_("Devices/Objects"), DIALOG_DEVICE);
   }
-  if((ncsvfileinfo>0&&have_ext==0)||(ncsvfileinfo>1&&have_ext==1)){
+  if((global_scase.csvcoll.ncsvfileinfo>0&&have_ext==0)||(global_scase.csvcoll.ncsvfileinfo>1&&have_ext==1)){
     glutAddMenuEntry(_("2D plots"), DIALOG_2DPLOTS);
   }
   glutAddMenuEntry(_("Show/Hide..."), DIALOG_SHOWFILES);
@@ -11892,12 +11892,12 @@ static int menu_count=0;
     strcat(compiler_version_label, " ");
     strcat(compiler_version_label, pp_COMPVER);
     glutAddMenuEntry(compiler_version_label, 1);
-    if(fds_version!=NULL){
-      sprintf(menulabel, "  FDS version: %s", fds_version);
+    if(global_scase.fds_version!=NULL){
+      sprintf(menulabel, "  FDS version: %s", global_scase.fds_version);
       glutAddMenuEntry(menulabel, 1);
     }
-    if(fds_githash!=NULL){
-      sprintf(menulabel,"  FDS build: %s",fds_githash);
+    if(global_scase.fds_githash!=NULL){
+      sprintf(menulabel,"  FDS build: %s",global_scase.fds_githash);
       glutAddMenuEntry(menulabel,1);
     }
 #ifdef pp_GPU
@@ -11991,7 +11991,7 @@ static int menu_count=0;
     glutAddMenuEntry(_("  s,S: increase/decrease interval between adjacent vectors"), MENU_DUMMY);
     glutAddMenuEntry(_("  t: set/unset single time step mode"), MENU_DUMMY);
     glutAddMenuEntry(_("  T: time display between 'Time s' and 'h:m:s'"), MENU_DUMMY);
-    if(cellcenter_slice_active==1){
+    if(global_scase.cellcenter_slice_active==1){
       glutAddMenuEntry(_("     (also, toggles cell center display on/off)"), MENU_DUMMY);
       glutAddMenuEntry(_("  @: display FDS values in cell centered slices"), MENU_DUMMY);
     }
@@ -12023,10 +12023,10 @@ static int menu_count=0;
   glutAddMenuEntry(_("Misc"), MENU_DUMMY);
   glutAddMenuEntry(_("  A: toggle between plot types (device and HRRPUV)"), MENU_DUMMY);
   glutAddMenuEntry(_("  e: toggle between view rotation types: scene centered 2 axis, 1 axis, 3 axis and eye centered"), MENU_DUMMY);
-  if(ntotal_blockages>0||isZoneFireModel==1){
+  if(ntotal_blockages>0||global_scase.isZoneFireModel==1){
     glutAddMenuEntry(_("  g: toggle grid visibility modes"), MENU_DUMMY);
   }
-  if(ndeviceinfo > 0 && GetNumActiveDevices() > 0){
+  if(global_scase.devicecoll.ndeviceinfo > 0 && GetNumActiveDevices() > 0){
     glutAddMenuEntry("  j/ALT j: increase/decrease object size", MENU_DUMMY);
   }
   if(have_cface_normals == CFACE_NORMALS_YES){
@@ -12062,16 +12062,16 @@ static int menu_count=0;
     glutAddMenuEntry(_("  x/y/z: toggle lower x/y/z clip planes"), MENU_DUMMY);
     glutAddMenuEntry(_("  X/Y/Z: toggle upper x/y/z clip planes"), MENU_DUMMY);
   }
-  if(caseini_filename!=NULL&&strlen(caseini_filename)>0){
+  if(global_scase.paths.caseini_filename!=NULL&&strlen(global_scase.paths.caseini_filename)>0){
     char inilabel[512];
 
-    sprintf(inilabel,"  #: save settings to %s",caseini_filename);
+    sprintf(inilabel,"  #: save settings to %s",global_scase.paths.caseini_filename);
     glutAddMenuEntry(inilabel,MENU_DUMMY);
   }
   else{
     glutAddMenuEntry(_("  #: save settings (create casename.ini file)"), MENU_DUMMY);
   }
-  if(ngeominfo){
+  if(global_scase.ngeominfo){
     glutAddMenuEntry(_("  =: toggle vertex selected in examine geometry dialog"), MENU_DUMMY);
     glutAddMenuEntry(_("  Z: toggle rotation center between FDS and FDS+GEOM center"), MENU_DUMMY);
   }
@@ -12128,47 +12128,47 @@ static int menu_count=0;
 
   /* --------------------------------hvac menu -------------------------- */
 
-  if(hvaccoll.nhvacinfo > 0 && hvaccoll.hvacductvalsinfo!=NULL){
+  if(global_scase.hvaccoll.nhvacinfo > 0 && global_scase.hvaccoll.hvacductvalsinfo!=NULL){
     char menulabel[1024];
 
     CREATEMENU(loadhvacmenu, LoadHVACMenu);
     strcpy(menulabel, "");
-    if(hvaccoll.hvacductvalsinfo->times!=NULL)strcat(menulabel, "*");
-    strcat(menulabel, hvaccoll.hvacductvalsinfo->file);
+    if(global_scase.hvaccoll.hvacductvalsinfo->times!=NULL)strcat(menulabel, "*");
+    strcat(menulabel, global_scase.hvaccoll.hvacductvalsinfo->file);
     glutAddMenuEntry(menulabel, MENU_HVAC_LOAD);
     glutAddMenuEntry("Unload",  MENU_HVAC_UNLOAD);
   }
 
   /* --------------------------------particle menu -------------------------- */
 
-  if(npartinfo>0){
+  if(global_scase.npartinfo>0){
     int ii;
     int doit = 0;
 
-    if(nmeshes==1){
+    if(global_scase.meshescoll.nmeshes==1){
       CREATEMENU(particlemenu,LoadParticleMenu);
       doit = 1;
     }
     if(doit == 1){
-      for(ii = 0;ii < npartinfo;ii++){
+      for(ii = 0;ii < global_scase.npartinfo;ii++){
         char menulabel[1024];
 
         i = partorderindex[ii];
-        if(partinfo[i].loaded == 1){
+        if(global_scase.partinfo[i].loaded == 1){
           STRCPY(menulabel, "*");
-          STRCAT(menulabel, partinfo[i].menulabel);
+          STRCAT(menulabel, global_scase.partinfo[i].menulabel);
         }
         else{
-          STRCPY(menulabel, partinfo[i].menulabel);
+          STRCPY(menulabel, global_scase.partinfo[i].menulabel);
         }
         glutAddMenuEntry(menulabel, i);
       }
     }
-    if(nmeshes>1){
+    if(global_scase.meshescoll.nmeshes>1){
       char menulabel[1024];
 
       CREATEMENU(particlemenu,LoadParticleMenu);
-      if(npartinfo > 0){
+      if(global_scase.npartinfo > 0){
         int part_load_state;
 
         PartLoadState(&part_load_state);
@@ -12181,7 +12181,7 @@ static int menu_count=0;
       glutAddMenuEntry("-",MENU_DUMMY);
       if(partfast==1)glutAddMenuEntry(_("*Fast loading"), MENU_PART_PARTFAST);
       if(partfast==0)glutAddMenuEntry(_("Fast loading"), MENU_PART_PARTFAST);
-      if(nmeshes>1){
+      if(global_scase.meshescoll.nmeshes>1){
       }
     }
     glutAddMenuEntry("Particle number/file size", MENU_PART_NUM_FILE_SIZE);
@@ -12190,7 +12190,7 @@ static int menu_count=0;
     glutAddMenuEntry(_("Unload"), MENU_PARTICLE_UNLOAD_ALL);
   }
 
-  if(slicecoll.nvsliceinfo>0){
+  if(global_scase.slicecoll.nvsliceinfo>0){
 
   //*** setup vector slice menus
 
@@ -12218,7 +12218,7 @@ static int menu_count=0;
 
   //*** setup slice menus
 
-  if(slicecoll.nsliceinfo>0||have_geom_slice_menus==1){
+  if(global_scase.slicecoll.nsliceinfo>0||have_geom_slice_menus==1){
     InitUnloadSliceMenu(&unloadslicemenu);
     InitSliceSkipMenu(&sliceskipmenu);
   }
@@ -12250,11 +12250,11 @@ static int menu_count=0;
         strcpy(vlabel,_("3D smoke (Volume rendered)"));
         glutAddMenuEntry(vlabel,UNLOAD_ALL);
       }
-      for(i=0;i<nmeshes;i++){
+      for(i=0;i<global_scase.meshescoll.nmeshes;i++){
         meshdata *meshi;
         volrenderdata *vr;
 
-        meshi = meshinfo + i;
+        meshi = global_scase.meshescoll.meshinfo + i;
         vr = meshi->volrenderinfo;
         if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
         if(vr->loaded==0)continue;
@@ -12277,14 +12277,14 @@ static int menu_count=0;
 
       if(nsmoke3dloaded>0){
         CREATEMENU(unloadsmoke3dmenu,UnLoadSmoke3DMenu);
-        for(i = 0; i<nsmoke3dtypes; i++){
+        for(i = 0; i<global_scase.smoke3dcoll.nsmoke3dtypes; i++){
           int j, doit, is_zlib;
 
           doit = 0;
           is_zlib = 0;
-          for(j = 0; j<smoke3dcoll.nsmoke3dinfo; j++){
-            if(smoke3dcoll.smoke3dinfo[j].loaded==1&&smoke3dcoll.smoke3dinfo[j].type==i){
-              if(smoke3dcoll.smoke3dinfo[j].compression_type == COMPRESSED_ZLIB){
+          for(j = 0; j<global_scase.smoke3dcoll.nsmoke3dinfo; j++){
+            if(global_scase.smoke3dcoll.smoke3dinfo[j].loaded==1&&global_scase.smoke3dcoll.smoke3dinfo[j].type==i){
+              if(global_scase.smoke3dcoll.smoke3dinfo[j].compression_type == COMPRESSED_ZLIB){
                 is_zlib = 1;
               }
               doit = 1;
@@ -12294,7 +12294,7 @@ static int menu_count=0;
           if(doit == 1){
             char smvmenulabel[256];
 
-            strcpy(smvmenulabel, smoke3dtypes[i].longlabel);
+            strcpy(smvmenulabel, global_scase.smoke3dcoll.smoke3dtypes[i].longlabel);
             if(is_zlib == 1){
               strcat(smvmenulabel, "(ZLIB)");
             }
@@ -12303,21 +12303,21 @@ static int menu_count=0;
         }
       }
     {
-      if(smoke3dcoll.nsmoke3dinfo>0){
-        if(nmeshes==1){
+      if(global_scase.smoke3dcoll.nsmoke3dinfo>0){
+        if(global_scase.meshescoll.nmeshes==1){
           CREATEMENU(loadsmoke3dmenu,LoadSmoke3DMenu);
         }
 
         int ii;
-        for(ii = 0; ii<nsmoke3dtypes; ii++){
-          if(nmeshes>1){
-            CREATEMENU(smoke3dtypes[ii].menu_id, LoadSmoke3DMenu);
+        for(ii = 0; ii<global_scase.smoke3dcoll.nsmoke3dtypes; ii++){
+          if(global_scase.meshescoll.nmeshes>1){
+            CREATEMENU(global_scase.smoke3dcoll.smoke3dtypes[ii].menu_id, LoadSmoke3DMenu);
           }
-          for(i = 0; i<smoke3dcoll.nsmoke3dinfo; i++){
+          for(i = 0; i<global_scase.smoke3dcoll.nsmoke3dinfo; i++){
             char menulabel[256];
             smoke3ddata *smoke3di;
 
-            smoke3di = smoke3dcoll.smoke3dinfo+i;
+            smoke3di = global_scase.smoke3dcoll.smoke3dinfo+i;
             if(smoke3di->type!=ii)continue;
             strcpy(menulabel, "");
             if(smoke3di->loaded==1){
@@ -12327,10 +12327,10 @@ static int menu_count=0;
             glutAddMenuEntry(menulabel, i);
           }
         }
-        if(nmeshes>1){
+        if(global_scase.meshescoll.nmeshes>1){
           CREATEMENU(loadsmoke3dmenu,LoadSmoke3DMenu);
           // multi mesh smoke menus items
-          for(ii = 0; ii<nsmoke3dtypes; ii++){
+          for(ii = 0; ii<global_scase.smoke3dcoll.nsmoke3dtypes; ii++){
             int jj;
             int ntotal, nloaded;
             char menulabel[256];
@@ -12339,10 +12339,10 @@ static int menu_count=0;
             ntotal=0;
             nloaded=0;
             is_zlib = 0;
-            for(jj=0;jj<smoke3dcoll.nsmoke3dinfo;jj++){
-              if(smoke3dcoll.smoke3dinfo[jj].type==ii){
-                if(smoke3dcoll.smoke3dinfo[jj].loaded==1)nloaded++;
-                if(smoke3dcoll.smoke3dinfo[jj].compression_type == COMPRESSED_ZLIB){
+            for(jj=0;jj<global_scase.smoke3dcoll.nsmoke3dinfo;jj++){
+              if(global_scase.smoke3dcoll.smoke3dinfo[jj].type==ii){
+                if(global_scase.smoke3dcoll.smoke3dinfo[jj].loaded==1)nloaded++;
+                if(global_scase.smoke3dcoll.smoke3dinfo[jj].compression_type == COMPRESSED_ZLIB){
                   is_zlib = 1;
                 }
                 ntotal++;
@@ -12355,8 +12355,8 @@ static int menu_count=0;
             else if(nloaded>0&&nloaded<ntotal){
               strcat(menulabel, "#");
             }
-            strcat(menulabel, smoke3dtypes[ii].longlabel);
-            strcat(menulabel, smoke3dtypes[ii].smoke3d->cextinct);
+            strcat(menulabel, global_scase.smoke3dcoll.smoke3dtypes[ii].longlabel);
+            strcat(menulabel, global_scase.smoke3dcoll.smoke3dtypes[ii].smoke3d->cextinct);
             if(is_zlib == 1){
               strcat(menulabel, "(ZLIB)");
             }
@@ -12389,19 +12389,19 @@ static int menu_count=0;
 
     /* --------------------------------plot3d menu -------------------------- */
 
-    if(nplot3dinfo>0){
+    if(global_scase.nplot3dinfo>0){
       plot3ddata *plot3dim1, *plot3di;
       char menulabel[1024];
       int ii;
 
       nloadsubplot3dmenu=1;
-      for(ii=1;ii<nplot3dinfo;ii++){
+      for(ii=1;ii<global_scase.nplot3dinfo;ii++){
         int im1;
 
         i = plot3dorderindex[ii];
         im1 = plot3dorderindex[ii-1];
-        plot3di = plot3dinfo + i;
-        plot3dim1 = plot3dinfo + im1;
+        plot3di = global_scase.plot3dinfo + i;
+        plot3dim1 = global_scase.plot3dinfo + im1;
         if(ABS(plot3di->time-plot3dim1->time)>0.1)nloadsubplot3dmenu++;
       }
       NewMemory((void **)&loadsubplot3dmenu,nloadsubplot3dmenu*sizeof(int));
@@ -12411,7 +12411,7 @@ static int menu_count=0;
 
       nloadsubplot3dmenu=0;
       i = plot3dorderindex[0];
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
       CREATEMENU(loadsubplot3dmenu[nloadsubplot3dmenu],LoadPlot3dMenu);
       strcpy(menulabel,"");
       if(plot3di->loaded==1){
@@ -12421,13 +12421,13 @@ static int menu_count=0;
       glutAddMenuEntry(menulabel,i);
       nloadsubplot3dmenu++;
 
-      for(ii=1;ii<nplot3dinfo;ii++){
+      for(ii=1;ii<global_scase.nplot3dinfo;ii++){
         int im1;
 
         i = plot3dorderindex[ii];
         im1 = plot3dorderindex[ii-1];
-        plot3di = plot3dinfo + i;
-        plot3dim1 = plot3dinfo + im1;
+        plot3di = global_scase.plot3dinfo + i;
+        plot3dim1 = global_scase.plot3dinfo + im1;
         if(ABS(plot3di->time-plot3dim1->time)>0.1){
           CREATEMENU(loadsubplot3dmenu[nloadsubplot3dmenu],LoadPlot3dMenu);
           nloadsubplot3dmenu++;
@@ -12442,11 +12442,11 @@ static int menu_count=0;
       nloadsubplot3dmenu=0;
       nloadsubplot3dmenu=0;
       CREATEMENU(loadplot3dmenu,LoadPlot3dMenu);
-      for(ii=0;ii<nplot3dinfo;ii++){
+      for(ii=0;ii<global_scase.nplot3dinfo;ii++){
         int im1;
 
         i = plot3dorderindex[ii];
-        plot3di = plot3dinfo + i;
+        plot3di = global_scase.plot3dinfo + i;
         if(ii==0){
           int plot3d_load_state;
           char prefix[3];
@@ -12460,7 +12460,7 @@ static int menu_count=0;
           sprintf(menulabel,"  %s%f", prefix, plot3di->time);
           TrimZeros(menulabel);
           strcat(menulabel," s");
-          if(nmeshes>1){
+          if(global_scase.meshescoll.nmeshes>1){
             glutAddMenuEntry(menulabel,-100000+nloadsubplot3dmenu);
           }
           else{
@@ -12478,8 +12478,8 @@ static int menu_count=0;
 
           i = plot3dorderindex[ii];
           im1 = plot3dorderindex[ii-1];
-          plot3di = plot3dinfo + i;
-          plot3dim1 = plot3dinfo + im1;
+          plot3di = global_scase.plot3dinfo + i;
+          plot3dim1 = global_scase.plot3dinfo + im1;
           if(strcmp(plot3di->longlabel,plot3dim1->longlabel)!=0){
             glutAddMenuEntry(plot3di->longlabel,MENU_PLOT3D_DUMMY);
           }
@@ -12493,7 +12493,7 @@ static int menu_count=0;
             sprintf(menulabel,"  %s%f",prefix, plot3di->time);
             TrimZeros(menulabel);
             strcat(menulabel," s");
-            if(nmeshes>1){
+            if(global_scase.meshescoll.nmeshes>1){
               glutAddMenuEntry(menulabel,-100000+nloadsubplot3dmenu);
             }
             else{
@@ -12507,7 +12507,7 @@ static int menu_count=0;
             nloadsubplot3dmenu++;
           }
         }
-        if(ii==nplot3dinfo-1){
+        if(ii==global_scase.nplot3dinfo-1){
           glutAddMenuEntry("-", MENU_PLOT3D_DUMMY);
           glutAddMenuEntry(_("Settings..."), MENU_PLOT3D_SETTINGS);
           glutAddMenuEntry(_("Unload"), UNLOAD_ALL);
@@ -12517,16 +12517,16 @@ static int menu_count=0;
 
 /* --------------------------------load patch menu -------------------------- */
 
-    if(npatchinfo>0){
+    if(global_scase.npatchinfo>0){
       int ii;
 
       nloadpatchsubmenus=0;
 
-      if(nmeshes>1&&loadpatchsubmenus==NULL){
-        NewMemory((void **)&loadpatchsubmenus,npatchinfo*sizeof(int));
+      if(global_scase.meshescoll.nmeshes>1&&loadpatchsubmenus==NULL){
+        NewMemory((void **)&loadpatchsubmenus,global_scase.npatchinfo*sizeof(int));
       }
 
-      if(nmeshes>1){
+      if(global_scase.meshescoll.nmeshes>1){
         CREATEMENU(loadpatchsubmenus[nloadpatchsubmenus],LoadBoundaryMenu);
         nloadpatchsubmenus++;
       }
@@ -12534,15 +12534,15 @@ static int menu_count=0;
         CREATEMENU(loadpatchmenu,LoadBoundaryMenu);
       }
 
-      for(ii=0;ii<npatchinfo;ii++){
+      for(ii=0;ii<global_scase.npatchinfo;ii++){
         patchdata *patchim1, *patchi;
         char menulabel[1024];
 
         i = patchorderindex[ii];
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(ii>0){
-          patchim1 = patchinfo + patchorderindex[ii-1];
-          if(nmeshes>1&&strcmp(patchim1->label.longlabel,patchi->label.longlabel)!=0){
+          patchim1 = global_scase.patchinfo + patchorderindex[ii-1];
+          if(global_scase.meshescoll.nmeshes>1&&strcmp(patchim1->label.longlabel,patchi->label.longlabel)!=0){
             CREATEMENU(loadpatchsubmenus[nloadpatchsubmenus],LoadBoundaryMenu);
             nloadpatchsubmenus++;
           }
@@ -12582,21 +12582,21 @@ static int menu_count=0;
           glutAddMenuEntry(_("  keep coarse"), MENU_KEEP_COARSE);
         }
       }
-      if(nmeshes>1){
+      if(global_scase.meshescoll.nmeshes>1){
 
 // count patch submenus
 
         nloadsubpatchmenu_b=0;
-        for(ii=0;ii<npatchinfo;ii++){
+        for(ii=0;ii<global_scase.npatchinfo;ii++){
           int im1;
           patchdata *patchi, *patchim1;
 
           i = patchorderindex[ii];
           if(ii>0){
             im1 = patchorderindex[ii-1];
-            patchim1=patchinfo + im1;
+            patchim1=global_scase.patchinfo + im1;
           }
-          patchi = patchinfo + i;
+          patchi = global_scase.patchinfo + i;
           if(ii==0||strcmp(patchi->menulabel_base,patchim1->menulabel_base)!=0){
             nloadsubpatchmenu_b++;
           }
@@ -12614,16 +12614,16 @@ static int menu_count=0;
         }
 
         iloadsubpatchmenu_b=0;
-        for(ii=0;ii<npatchinfo;ii++){
+        for(ii=0;ii<global_scase.npatchinfo;ii++){
           int im1;
           patchdata *patchi, *patchim1;
 
           i = patchorderindex[ii];
           if(ii>0){
             im1 = patchorderindex[ii-1];
-            patchim1=patchinfo + im1;
+            patchim1=global_scase.patchinfo + im1;
           }
-          patchi = patchinfo + i;
+          patchi = global_scase.patchinfo + i;
           if(ii==0||strcmp(patchi->menulabel_base,patchim1->menulabel_base)!=0){
             CREATEMENU(loadsubpatchmenu_b[iloadsubpatchmenu_b],LoadBoundaryMenu);
             iloadsubpatchmenu_b++;
@@ -12646,16 +12646,16 @@ static int menu_count=0;
 
         CREATEMENU(loadpatchmenu,LoadBoundaryMenu);
         iloadsubpatchmenu_b=0;
-        for(ii=0;ii<npatchinfo;ii++){
+        for(ii=0;ii<global_scase.npatchinfo;ii++){
           int im1;
           patchdata *patchi, *patchim1;
 
           i = patchorderindex[ii];
           if(ii>0){
             im1 = patchorderindex[ii-1];
-            patchim1=patchinfo + im1;
+            patchim1=global_scase.patchinfo + im1;
           }
-          patchi = patchinfo + i;
+          patchi = global_scase.patchinfo + i;
           if(ii==0||strcmp(patchi->menulabel_base,patchim1->menulabel_base)!=0){
             int nsubmenus;
 
@@ -12693,12 +12693,12 @@ static int menu_count=0;
 
 /* --------------------------------load iso menu -------------------------- */
 
-    if(nisoinfo>0){
+    if(global_scase.nisoinfo>0){
       int ii;
 
-      if(nisoinfo>0){
+      if(global_scase.nisoinfo>0){
         if(isosubmenus==NULL){
-          NewMemory((void **)&isosubmenus,nisoinfo*sizeof(int));
+          NewMemory((void **)&isosubmenus,global_scase.nisoinfo*sizeof(int));
         }
         nisosubmenus=0;
 
@@ -12706,28 +12706,28 @@ static int menu_count=0;
         nisosubmenus++;
       }
 
-      if(nmeshes==1){
+      if(global_scase.meshescoll.nmeshes==1){
         CREATEMENU(loadisomenu,LoadIsoMenu);
       }
-      for(ii=0;ii<nisoinfo;ii++){
+      for(ii=0;ii<global_scase.nisoinfo;ii++){
         isodata *iso1, *iso2;
         char menulabel[1024];
 
         i = isoorderindex[ii];
         if(ii>0){
-          iso1 = isoinfo + isoorderindex[ii-1];
-          iso2 = isoinfo + isoorderindex[ii];
-          if(nmeshes>1&&strcmp(iso1->surface_label.longlabel,iso2->surface_label.longlabel)!=0){
+          iso1 = global_scase.isoinfo + isoorderindex[ii-1];
+          iso2 = global_scase.isoinfo + isoorderindex[ii];
+          if(global_scase.meshescoll.nmeshes>1&&strcmp(iso1->surface_label.longlabel,iso2->surface_label.longlabel)!=0){
             CREATEMENU(isosubmenus[nisosubmenus],LoadIsoMenu);
             nisosubmenus++;
           }
         }
-        if(isoinfo[i].loaded==1){
+        if(global_scase.isoinfo[i].loaded==1){
           STRCPY(menulabel,"*");
-          STRCAT(menulabel,isoinfo[i].menulabel);
+          STRCAT(menulabel,global_scase.isoinfo[i].menulabel);
         }
         else{
-          STRCPY(menulabel,isoinfo[i].menulabel);
+          STRCPY(menulabel,global_scase.isoinfo[i].menulabel);
         }
         glutAddMenuEntry(menulabel,i);
       }
@@ -12736,15 +12736,15 @@ static int menu_count=0;
         int useitem;
         isodata *isoi, *isoj;
 
-        if(nmeshes>1){
+        if(global_scase.meshescoll.nmeshes>1){
           CREATEMENU(loadisomenu,LoadIsoMenu);
-          for(i=0;i<nisoinfo;i++){
+          for(i=0;i<global_scase.nisoinfo;i++){
             int j;
 
             useitem=i;
-            isoi = isoinfo + i;
+            isoi = global_scase.isoinfo + i;
             for(j=0;j<i;j++){
-              isoj = isoinfo + j;
+              isoj = global_scase.isoinfo + j;
               if(strcmp(isoi->surface_label.longlabel,isoj->surface_label.longlabel)==0){
                 useitem=-1;
                 break;
@@ -12771,14 +12771,14 @@ static int menu_count=0;
 
 /* --------------------------------zone menu -------------------------- */
 
-    if(nzoneinfo>0){
+    if(global_scase.nzoneinfo>0){
       CREATEMENU(zonemenu,ZoneMenu);
-      for(i=0;i<nzoneinfo;i++){
+      for(i=0;i<global_scase.nzoneinfo;i++){
         zonedata *zonei;
         char menulabel[1024];
         int n;
 
-        zonei = zoneinfo + i;
+        zonei = global_scase.zoneinfo + i;
         STRCPY(menulabel, "");
         if(zonei->loaded==1)STRCAT(menulabel,"*");
         STRCAT(menulabel,zonei->file);
@@ -12796,7 +12796,7 @@ static int menu_count=0;
 /* -------------------------------- compress menu -------------------------- */
 
 #ifdef pp_COMPRESS
-    if(smokezippath != NULL && (npatchinfo > 0 || smoke3dcoll.nsmoke3dinfo > 0 || slicecoll.nsliceinfo > 0)){
+    if(smokezippath != NULL && (global_scase.npatchinfo > 0 || global_scase.smoke3dcoll.nsmoke3dinfo > 0 || global_scase.slicecoll.nsliceinfo > 0)){
     CREATEMENU(compressmenu,CompressMenu);
     glutAddMenuEntry(_("Compression options"),MENU_DUMMY);  // -c
     if(overwrite_all==1){
@@ -12832,8 +12832,8 @@ static int menu_count=0;
     }
     if(n_inifiles>0){
       CREATEMENU(inisubmenu,IniSubMenu);
-      if(caseini_filename!=NULL&&FILE_EXISTS(caseini_filename)==YES){
-        glutAddMenuEntry(caseini_filename,MENU_READCASEINI);
+      if(global_scase.paths.caseini_filename!=NULL&&FILE_EXISTS(global_scase.paths.caseini_filename)==YES){
+        glutAddMenuEntry(global_scase.paths.caseini_filename,MENU_READCASEINI);
       }
       for(inifile=first_inifile.next;inifile->next!=NULL;inifile=inifile->next){
         if(inifile->file!=NULL&&FILE_EXISTS(inifile->file)==YES){
@@ -12858,7 +12858,7 @@ static int menu_count=0;
     }
     char *global_ini_path = GetSystemIniPath();
     char *user_ini_path = GetUserIniPath();
-    if( n_inifiles>0||FILE_EXISTS(user_ini_path)==YES||FILE_EXISTS(caseini_filename)==YES||FILE_EXISTS(global_ini_path)==YES){
+    if( n_inifiles>0||FILE_EXISTS(user_ini_path)==YES||FILE_EXISTS(global_scase.paths.caseini_filename)==YES||FILE_EXISTS(global_ini_path)==YES){
       if(n_inifiles==0){
         glutAddMenuEntry(_("Read ini files"),MENU_READINI);
       }
@@ -12875,14 +12875,14 @@ static int menu_count=0;
       char caselabel[255];
 
       STRCPY(caselabel,_("Save settings (this case - "));
-      STRCAT(caselabel,caseini_filename);
+      STRCAT(caselabel,global_scase.paths.caseini_filename);
       STRCAT(caselabel, ")");
 
       glutAddMenuEntry(caselabel,MENU_WRITECASEINI);
     }
 
     glutAddMenuEntry("-", MENU_DUMMY);
-    if(ndeviceinfo>0){
+    if(global_scase.devicecoll.ndeviceinfo>0){
       glutAddMenuEntry(_("Read .svo files"),MENU_READSVO);
     }
     glutAddMenuEntry("Save settings (all cases - smokeview.ini)", MENU_WRITEINI);
@@ -12998,7 +12998,7 @@ static int menu_count=0;
 
       // 3d smoke
 
-      if(smoke3dcoll.nsmoke3dinfo>0){
+      if(global_scase.smoke3dcoll.nsmoke3dinfo>0){
         strcpy(loadmenulabel,_("3D smoke"));
         if(tload_step > 1){
           sprintf(steplabel,"/Skip %i",tload_skip);
@@ -13018,7 +13018,7 @@ static int menu_count=0;
 
       // terrain
 
-      if(manual_terrain==1&&nterraininfo>0){
+      if(global_scase.manual_terrain==1&&global_scase.nterraininfo>0){
  //       GLUTADDSUBMENU(_("Terrain"),loadterrainmenu);
       }
 
@@ -13032,7 +13032,7 @@ static int menu_count=0;
         }
         GLUTADDSUBMENU(loadmenulabel, loadmultislicemenu);
       }
-      else if(slicecoll.nsliceinfo > 0){
+      else if(global_scase.slicecoll.nsliceinfo > 0){
         strcpy(loadmenulabel, "Slice");
         if(tload_step > 1){
           sprintf(steplabel, "/Skip %i", tload_skip);
@@ -13051,7 +13051,7 @@ static int menu_count=0;
         }
         GLUTADDSUBMENU(loadmenulabel,loadmultivslicemenu);
       }
-      else if(slicecoll.nvsliceinfo>0){
+      else if(global_scase.slicecoll.nvsliceinfo>0){
         strcpy(loadmenulabel,_("Vector slice"));
         if(tload_step > 1){
           sprintf(steplabel,"/Skip %i",tload_skip);
@@ -13062,7 +13062,7 @@ static int menu_count=0;
 
       // isosurface
 
-      if(nisoinfo>0){
+      if(global_scase.nisoinfo>0){
         strcpy(loadmenulabel,"Isosurface");
         if(tload_step > 1){
           sprintf(steplabel,"/Skip %i",tload_skip);
@@ -13073,7 +13073,7 @@ static int menu_count=0;
 
       // boundary
 
-      if(npatchinfo>0){
+      if(global_scase.npatchinfo>0){
         strcpy(loadmenulabel,"Boundary");
         if(tload_step > 1){
           sprintf(steplabel,"/Skip %i",tload_skip);
@@ -13084,7 +13084,7 @@ static int menu_count=0;
 
       // particle
 
-      if(npartinfo>0){
+      if(global_scase.npartinfo>0){
         strcpy(loadmenulabel,"Particles");
         if(tload_step > 1){
           sprintf(steplabel,"/Skip Frame %i",tload_skip);
@@ -13095,11 +13095,11 @@ static int menu_count=0;
 
       // plot3d
 
-      if(nplot3dinfo>0)GLUTADDSUBMENU(_("Plot3D"),loadplot3dmenu);
+      if(global_scase.nplot3dinfo>0)GLUTADDSUBMENU(_("Plot3D"),loadplot3dmenu);
 
       // zone fire
 
-      if(nzoneinfo>0){
+      if(global_scase.nzoneinfo>0){
         strcpy(loadmenulabel,"Zone fire");
         GLUTADDSUBMENU(loadmenulabel,zonemenu);
       }
@@ -13107,13 +13107,13 @@ static int menu_count=0;
       if(glui_active==1){
         glutAddMenuEntry("-",MENU_DUMMY);
       }
-      if(hvaccoll.nhvacinfo > 0 && hvaccoll.hvacductvalsinfo!=NULL){
+      if(global_scase.hvaccoll.nhvacinfo > 0 && global_scase.hvaccoll.hvacductvalsinfo!=NULL){
         GLUTADDSUBMENU("HVAC", loadhvacmenu);
       }
       GLUTADDSUBMENU(_("Configuration files"),smokeviewinimenu);
       GLUTADDSUBMENU(_("Scripts"),scriptmenu);
 #ifdef pp_COMPRESS
-      if(smokezippath!=NULL&&(npatchinfo>0||smoke3dcoll.nsmoke3dinfo>0||slicecoll.nsliceinfo>0)){
+      if(smokezippath!=NULL&&(global_scase.npatchinfo>0||global_scase.smoke3dcoll.nsmoke3dinfo>0||global_scase.slicecoll.nsliceinfo>0)){
         GLUTADDSUBMENU(_("Compression"),compressmenu);
       }
 #endif
@@ -13124,7 +13124,7 @@ static int menu_count=0;
         strcpy(menulabel,"");
         if(redirect==1)strcat(menulabel,"*");
         strcat(menulabel,"Redirect messages to ");
-        strcat(menulabel,log_filename);
+        strcat(menulabel,global_scase.paths.log_filename);
         glutAddMenuEntry(menulabel,REDIRECT);
       }
 

--- a/Source/smokeview/output.c
+++ b/Source/smokeview/output.c
@@ -48,14 +48,14 @@ void OutputAxisLabels(){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
-  x = (xbar0+xbarORIG)/2.0;
-  y = (ybar0+ybarORIG)/2.0;
-  z = (zbar0+zbarORIG)/2.0;
-  x0 = xbar0 - SCALE2FDS(0.02);
-  y0 = ybar0 - SCALE2FDS(0.02);
-  z0 = zbar0 - SCALE2FDS(0.02);
+  x = (global_scase.xbar0+xbarORIG)/2.0;
+  y = (global_scase.ybar0+ybarORIG)/2.0;
+  z = (global_scase.zbar0+zbarORIG)/2.0;
+  x0 = global_scase.xbar0 - SCALE2FDS(0.02);
+  y0 = global_scase.ybar0 - SCALE2FDS(0.02);
+  z0 = global_scase.zbar0 - SCALE2FDS(0.02);
 
   Output3Text(foregroundcolor,   x,y0, z0, "X");
   Output3Text(foregroundcolor, x0,  y, z0, "Y");
@@ -432,7 +432,7 @@ void WriteLabels(labels_collection *labelscoll_arg){
   char quote[2];
 
   if(event_file_exists==0)return;
-  stream = fopen(event_filename, "w");
+  stream = fopen(global_scase.paths.event_filename, "w");
   if(stream==NULL)return;
 
   first_label = labelscoll_arg->label_first_ptr;
@@ -464,7 +464,7 @@ void DrawLabels(labels_collection *labelscoll_arg){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0),SCALE2SMV(1.0),SCALE2SMV(1.0));
-  glTranslatef(-xbar0,-ybar0,-zbar0);
+  glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
   for(thislabel=first_label->next;thislabel->next!=NULL;thislabel=thislabel->next){
     float *labelcolor,*tstart_stop,*xyz;
     int drawlabel;

--- a/Source/smokeview/renderhtml.c
+++ b/Source/smokeview/renderhtml.c
@@ -34,10 +34,10 @@ void GetPartVerts(int option, int option2, int *offset,
 
   *nverts = 0;
   *nindices  = 0;
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     if(parti->loaded==0||parti->display==0)continue;
     parttime = parti;
     if(first==1){
@@ -59,10 +59,10 @@ void GetPartVerts(int option, int option2, int *offset,
     iend = parttime->itime+1;
   }
   for(itime = ibeg; itime<iend; itime++){
-    for(i = 0; i<npartinfo; i++){
+    for(i = 0; i<global_scase.npartinfo; i++){
       partdata *parti;
 
-      parti = partinfo+i;
+      parti = global_scase.partinfo+i;
       if(parti->loaded==0||parti->display==0||part5show==0)continue;
       if(streak5show == 0 || (streak5show == 1 && showstreakhead == 1)){
         part5data *datacopy;
@@ -76,11 +76,11 @@ void GetPartVerts(int option, int option2, int *offset,
   if(option==0)return;
   for(itime = ibeg; itime<iend; itime++){
     frame_sizes[itime-ibeg] = 0;
-    for(i = 0; i<npartinfo; i++){
+    for(i = 0; i<global_scase.npartinfo; i++){
       partdata *parti;
       int j;
 
-      parti = partinfo+i;
+      parti = global_scase.partinfo+i;
       if(parti->loaded==0||parti->display==0||part5show==0)continue;
       if(streak5show==0||(streak5show==1&&showstreakhead==1)){
         part5data *datacopy;
@@ -95,7 +95,7 @@ void GetPartVerts(int option, int option2, int *offset,
         zpos = datacopy->zpos;
 
         partclassi = parti->partclassptr[i];
-        partclass_index = partclassi - partclassinfo;
+        partclass_index = partclassi - global_scase.partclassinfo;
         itype = current_property->class_types[partclass_index];
 
         for(j=0;j<datacopy->npoints_file;j++){
@@ -142,13 +142,13 @@ void GetBndfNodeVerts(int option, int option2, int *offset,
   *nframes = 0;
   *nverts = 0;
   *ntris = 0;
-  for(i = 0;i<npatchinfo;i++){
+  for(i = 0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==0||patchi->display==0||patchi->structured==NO)continue;
     if(patchi->patch_filetype!=PATCH_STRUCTURED_NODE_CENTER)continue;
-    meshpatch0 = meshinfo+patchi->blocknumber;
+    meshpatch0 = global_scase.meshescoll.meshinfo+patchi->blocknumber;
     if(first==1){
       first = 0;
       minsteps = patchi->ntimes;
@@ -175,17 +175,17 @@ void GetBndfNodeVerts(int option, int option2, int *offset,
   for(itime = ibeg; itime<iend; itime++){
     int j;
 
-    for(j = 0;j<npatchinfo;j++){
+    for(j = 0;j<global_scase.npatchinfo;j++){
       patchdata *patchi;
       meshdata *meshpatch;
       int n;
       unsigned char *cpatch_time;
 
-      patchi = patchinfo + j;
+      patchi = global_scase.patchinfo + j;
       if(patchi->loaded==0||patchi->display==0||patchi->structured==NO)continue;
       if(patchi->patch_filetype!=PATCH_STRUCTURED_NODE_CENTER)continue;
 
-      meshpatch = meshinfo+patchi->blocknumber;
+      meshpatch = global_scase.meshescoll.meshinfo+patchi->blocknumber;
 
       cpatch_time = meshpatch->cpatchval+itime*meshpatch->npatchsize;
       if(itime==ibeg){
@@ -280,10 +280,10 @@ void GetSliceCellVerts(int option, int option2, int *offset, float *verts, unsig
   int ibeg, iend, itime, first=1, minsteps;
   slicedata *slicetime=NULL;
 
-  for(islice = 0; islice<slicecoll.nsliceinfo; islice++){
+  for(islice = 0; islice<global_scase.slicecoll.nsliceinfo; islice++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+islice;
+    slicei = global_scase.slicecoll.sliceinfo+islice;
     if(slicei->loaded==0||slicei->display==0||slicei->slice_filetype!=SLICE_CELL_CENTER||slicei->volslice==1)continue;
     if(slicei->idir!=XDIR&&slicei->idir!=YDIR&&slicei->idir!=ZDIR)continue;
     slicetime = slicei;
@@ -316,12 +316,12 @@ void GetSliceCellVerts(int option, int option2, int *offset, float *verts, unsig
   *frame_size = 0;
   for(itime = ibeg; itime<iend; itime++){
 
-    for(islice = 0; islice<slicecoll.nsliceinfo; islice++){
+    for(islice = 0; islice<global_scase.slicecoll.nsliceinfo; islice++){
       slicedata *slicei;
       int nrows=1, ncols=1;
       unsigned char *iq;
 
-      slicei = slicecoll.sliceinfo+islice;
+      slicei = global_scase.slicecoll.sliceinfo+islice;
 
       if(slicei->loaded==0||slicei->display==0||slicei->slice_filetype!=SLICE_CELL_CENTER||slicei->volslice==1)continue;
       if(slicei->idir!=XDIR&&slicei->idir!=YDIR&&slicei->idir!=ZDIR)continue;
@@ -361,7 +361,7 @@ void GetSliceCellVerts(int option, int option2, int *offset, float *verts, unsig
           float  constval;
           int n, i, j, k;
 
-          meshi = meshinfo+slicei->blocknumber;
+          meshi = global_scase.meshescoll.meshinfo+slicei->blocknumber;
 
           xplt = meshi->xplt;
           yplt = meshi->yplt;
@@ -516,10 +516,10 @@ void GetSliceGeomVerts(int option, int option2, int *offset, float *verts, unsig
   int ibeg, iend, itime, first = 1, minsteps;
   slicedata *slicetime = NULL;
 
-  for(islice = 0; islice<slicecoll.nsliceinfo; islice++){
+  for(islice = 0; islice<global_scase.slicecoll.nsliceinfo; islice++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+islice;
+    slicei = global_scase.slicecoll.sliceinfo+islice;
     if(slicei->loaded==0||slicei->display==0||slicei->slice_filetype!=SLICE_GEOM||slicei->volslice==1)continue;
     if(slicei->idir!=XDIR&&slicei->idir!=YDIR&&slicei->idir!=ZDIR)continue;
     slicetime = slicei;
@@ -552,14 +552,14 @@ void GetSliceGeomVerts(int option, int option2, int *offset, float *verts, unsig
   *frame_size = 0;
   for(itime = ibeg; itime<iend; itime++){
 
-    for(islice = 0; islice<slicecoll.nsliceinfo; islice++){
+    for(islice = 0; islice<global_scase.slicecoll.nsliceinfo; islice++){
       slicedata *slicei;
       geomdata *geomi;
       geomlistdata *geomlisti;
       patchdata *patchi;
       unsigned char *ivals;
 
-      slicei = slicecoll.sliceinfo+islice;
+      slicei = global_scase.slicecoll.sliceinfo+islice;
 
       if(slicei->loaded==0||slicei->display==0||slicei->slice_filetype!=SLICE_GEOM||slicei->volslice==1)continue;
       if(slicei->idir!=XDIR&&slicei->idir!=YDIR&&slicei->idir!=ZDIR)continue;
@@ -631,10 +631,10 @@ void GetSliceNodeVerts(int option, int option2,
   int ibeg, iend, itime, first=1, minsteps;
   slicedata *slicetime=NULL;
 
-  for(islice = 0; islice<slicecoll.nsliceinfo; islice++){
+  for(islice = 0; islice<global_scase.slicecoll.nsliceinfo; islice++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+islice;
+    slicei = global_scase.slicecoll.sliceinfo+islice;
     if(slicei->loaded==0||slicei->display==0||(slicei->slice_filetype!=SLICE_NODE_CENTER&&slicei->slice_filetype!=SLICE_TERRAIN)||slicei->volslice==1)continue;
     if(slicei->idir!=XDIR&&slicei->idir!=YDIR&&slicei->idir!=ZDIR)continue;
     slicetime = slicei;
@@ -667,12 +667,12 @@ void GetSliceNodeVerts(int option, int option2,
   *frame_size = 0;
   for(itime = ibeg; itime<iend; itime++){
 
-    for(islice = 0; islice<slicecoll.nsliceinfo; islice++){
+    for(islice = 0; islice<global_scase.slicecoll.nsliceinfo; islice++){
       slicedata *slicei;
       int nrows=1, ncols=1;
       unsigned char *iq;
 
-      slicei = slicecoll.sliceinfo+islice;
+      slicei = global_scase.slicecoll.sliceinfo+islice;
 
       if(slicei->loaded==0||slicei->display==0||(slicei->slice_filetype!=SLICE_NODE_CENTER&&slicei->slice_filetype!=SLICE_TERRAIN)||slicei->volslice==1)continue;
       if(slicei->idir!=XDIR&&slicei->idir!=YDIR&&slicei->idir!=ZDIR)continue;
@@ -712,7 +712,7 @@ void GetSliceNodeVerts(int option, int option2,
           int nx, ny, nxy;
           float agl;
 
-          meshi = meshinfo+slicei->blocknumber;
+          meshi = global_scase.meshescoll.meshinfo+slicei->blocknumber;
           nx = meshi->ibar+1;
           ny = meshi->jbar+1;
           nxy = nx*ny;
@@ -1125,33 +1125,33 @@ void Lines2Geom(float **vertsptr, float **colorsptr, int *n_verts, int **linespt
   *verts++ = 0.0;
   *verts++ = 0.0;
 
-  *verts++ = xbar;
+  *verts++ = global_scase.xbar;
   *verts++ = 0.0;
   *verts++ = 0.0;
 
-  *verts++ = xbar;
-  *verts++ = ybar;
+  *verts++ = global_scase.xbar;
+  *verts++ = global_scase.ybar;
   *verts++ = 0.0;
 
   *verts++ = 0.0;
-  *verts++ = ybar;
+  *verts++ = global_scase.ybar;
   *verts++ = 0.0;
 
   *verts++ = 0.0;
   *verts++ = 0.0;
-  *verts++ = zbar;
+  *verts++ = global_scase.zbar;
 
-  *verts++ = xbar;
+  *verts++ = global_scase.xbar;
   *verts++ = 0.0;
-  *verts++ = zbar;
+  *verts++ = global_scase.zbar;
 
-  *verts++ = xbar;
-  *verts++ = ybar;
-  *verts++ = zbar;
+  *verts++ = global_scase.xbar;
+  *verts++ = global_scase.ybar;
+  *verts++ = global_scase.zbar;
 
   *verts++ = 0.0;
-  *verts++ = ybar;
-  *verts++ = zbar;
+  *verts++ = global_scase.ybar;
+  *verts++ = global_scase.zbar;
 
   for(i = 0; i<24; i++){
     *colors++ = 0.0;
@@ -1200,7 +1200,7 @@ void BndfNodeTriangles2Geom(webgeomdata *bndf_node_web, int option){
   unsigned char *textures, *textures_save;
   int *indices, *indices_save;
 
-  if(npatchinfo>0){
+  if(global_scase.npatchinfo>0){
     int nbndf_node_verts, nbndf_node_tris;
 
     GetBndfNodeVerts(0, option, NULL, NULL, NULL, &nbndf_node_verts,
@@ -1229,7 +1229,7 @@ void BndfNodeTriangles2Geom(webgeomdata *bndf_node_web, int option){
 
   // load slice file data into data structures
 
-  if(npatchinfo>0){
+  if(global_scase.npatchinfo>0){
     int nbndf_node_verts, nbndf_node_tris;
 
     GetBndfNodeVerts(1, option, &offset, verts, textures, &nbndf_node_verts,
@@ -1254,7 +1254,7 @@ void PartNodeVerts2Geom(webgeomdata *part_node_web, int option){
   float *verts, *verts_save, *colors, *colors_save;
   int *indices, *indices_save, *framesizes;
 
-  if(npartinfo>0){
+  if(global_scase.npartinfo>0){
     int npart_verts, npart_indices;
 
     GetPartVerts(0, option, NULL, NULL, NULL, &npart_verts, NULL, &npart_indices, NULL, &(part_node_web->nframes));
@@ -1285,7 +1285,7 @@ void PartNodeVerts2Geom(webgeomdata *part_node_web, int option){
 
   // load particle file data into data structures
 
-  if(npartinfo>0){
+  if(global_scase.npartinfo>0){
     int npart_verts, npart_indices;
 
 
@@ -1314,7 +1314,7 @@ int SliceCellTriangles2Geom(webgeomdata *slice_cell_web, int option){
   unsigned char *textures, *textures_save;
   int *indices, *indices_save;
 
-  if(slicecoll.nsliceinfo>0){
+  if(global_scase.slicecoll.nsliceinfo>0){
     int nslice_verts, nslice_tris;
 
     GetSliceCellVerts(0, option, NULL, NULL, NULL, &nslice_verts, NULL, &nslice_tris, &(slice_cell_web->framesize), &(slice_cell_web->nframes));
@@ -1341,7 +1341,7 @@ int SliceCellTriangles2Geom(webgeomdata *slice_cell_web, int option){
 
   // load slice file data into data structures
 
-  if(slicecoll.nsliceinfo>0){
+  if(global_scase.slicecoll.nsliceinfo>0){
     int nslice_verts, nslice_tris;
 
     GetSliceCellVerts(1, option, &offset,
@@ -1369,7 +1369,7 @@ int SliceNodeTriangles2Geom(webgeomdata *slice_node_web, int option){
   int *indices, *indices_save;
   int *blank, *blank_save;
 
-  if(slicecoll.nsliceinfo>0){
+  if(global_scase.slicecoll.nsliceinfo>0){
     int nslice_verts, nslice_tris;
 
     GetSliceNodeVerts(0, option, NULL, NULL, NULL, &nslice_verts, NULL, NULL, &nslice_tris, &(slice_node_web->framesize), &(slice_node_web->nframes));
@@ -1401,7 +1401,7 @@ int SliceNodeTriangles2Geom(webgeomdata *slice_node_web, int option){
 
   // load slice file data into data structures
 
-  if(slicecoll.nsliceinfo>0){
+  if(global_scase.slicecoll.nsliceinfo>0){
     int nslice_verts, nslice_tris;
 
     GetSliceNodeVerts(1, option, &offset, verts, textures, &nslice_verts, indices, blank, &nslice_tris, &(slice_node_web->framesize), &(slice_node_web->nframes));
@@ -1428,7 +1428,7 @@ void SliceGeomTriangles2Geom(webgeomdata *slice_geom_web, int option){
   unsigned char *textures, *textures_save;
   int *indices, *indices_save;
 
-  if(slicecoll.nsliceinfo>0){
+  if(global_scase.slicecoll.nsliceinfo>0){
     int nslice_verts, nslice_tris;
 
     GetSliceGeomVerts(0, option, NULL, NULL, NULL, &nslice_verts, NULL, &nslice_tris, &(slice_geom_web->framesize), &(slice_geom_web->nframes));
@@ -1455,7 +1455,7 @@ void SliceGeomTriangles2Geom(webgeomdata *slice_geom_web, int option){
 
   // load slice file data into data structures
 
-  if(slicecoll.nsliceinfo>0){
+  if(global_scase.slicecoll.nsliceinfo>0){
     int nslice_verts, nslice_tris;
 
     GetSliceGeomVerts(1, option, &offset, verts, textures, &nslice_verts, indices, &nslice_tris, &(slice_geom_web->framesize), &(slice_geom_web->nframes));
@@ -1484,10 +1484,10 @@ void ObstLitTriangles2Geom(float **vertsptr, float **normalsptr, float **colorsp
 
   // count triangle vertices and indices for blockes
 
-  for(j = 0; j<nmeshes; j++){
+  for(j = 0; j<global_scase.meshescoll.nmeshes; j++){
     meshdata *meshi;
 
-    meshi     = meshinfo+j;
+    meshi     = global_scase.meshescoll.meshinfo+j;
     nverts   += meshi->nbptrs*24*3;    // 24 vertices per blockages * 3 coordinates per vertex
     n4verts  += meshi->nbptrs*24*4;    // 24 vertices per blockages * 4 coordinates per vertex
     nindices += meshi->nbptrs*6*2*3;   // 6 faces per blockage * 2 triangles per face * 3 indicies per triangle
@@ -1518,11 +1518,11 @@ void ObstLitTriangles2Geom(float **vertsptr, float **normalsptr, float **colorsp
 
   // load blockage info into data structures
 
-  for(j = 0; j<nmeshes; j++){
+  for(j = 0; j<global_scase.meshescoll.nmeshes; j++){
     meshdata *meshi;
     int i;
 
-    meshi = meshinfo+j;
+    meshi = global_scase.meshescoll.meshinfo+j;
     for(i = 0; i<meshi->nbptrs; i++){
       blockagedata *bc;
       float xyz[72];
@@ -2236,10 +2236,10 @@ int Smv2Html(char *html_file, int option, int from_where){
   GeomLitTriangles2Geom(&vertsGeomLit, &normalsGeomLit, &colorsGeomLit, &nvertsGeomLit, &facesGeomLit, &nfacesGeomLit);
   Lines2Geom(&vertsLine, &colorsLine, &nvertsLine, &facesLine, &nfacesLine);
 
-  for(i = 0;i<nmeshes;i++){
+  for(i = 0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     if(meshi->nbptrs>0){
       have_blockages = 1;
       break;
@@ -2309,9 +2309,9 @@ int Smv2Html(char *html_file, int option, int from_where){
     }
     else if(Match(buffer, "//***VERTS")==1){
       // center of scene
-      fprintf(stream_out, "         var xcen=%f;\n", xbar/2.0);
-      fprintf(stream_out, "         var ycen=%f;\n", ybar/2.0);
-      fprintf(stream_out, "         var zcen=%f;\n", zbar/2.0);
+      fprintf(stream_out, "         var xcen=%f;\n", global_scase.xbar/2.0);
+      fprintf(stream_out, "         var ycen=%f;\n", global_scase.ybar/2.0);
+      fprintf(stream_out, "         var zcen=%f;\n", global_scase.zbar/2.0);
       if(option==HTML_ALL_TIMES){
         fprintf(stream_out, "         document.getElementById(\"buttonPauseResume\").style.width = \"75px\";\n");
       }

--- a/Source/smokeview/renderimage.c
+++ b/Source/smokeview/renderimage.c
@@ -141,10 +141,10 @@ void MakeMovie(void){
 
 // make movie
     if(output_ffmpeg_command==1){
-      if(ffmpeg_command_filename!=NULL){
+      if(global_scase.paths.ffmpeg_command_filename!=NULL){
         FILE *stream_ffmpeg=NULL;
 
-        stream_ffmpeg = fopen(ffmpeg_command_filename,"w");
+        stream_ffmpeg = fopen(global_scase.paths.ffmpeg_command_filename,"w");
         if(stream_ffmpeg!=NULL){
 #ifdef WIN32
           fprintf(stream_ffmpeg,"@echo off\n");
@@ -267,7 +267,7 @@ int GetRenderFileName(int view_mode, char *renderfile_dir, char *renderfile_full
       use_scriptfile = 1;
     }
     else{
-      strcpy(renderfile_name, fdsprefix);
+      strcpy(renderfile_name, global_scase.fdsprefix);
     }
     if(script_dir_path != NULL&&strlen(script_dir_path) > 0){
       if(strlen(script_dir_path) == 2 && script_dir_path[0] == '.'&&script_dir_path[1] == dirseparator[0]){
@@ -360,11 +360,11 @@ int GetRenderFileName(int view_mode, char *renderfile_dir, char *renderfile_full
 
       time_local = global_times[itimes];
       dt = ABS(global_times[1] - global_times[0]);
-      maxtime = MAX(ABS(global_times[nglobal_times-1]), ABS(global_tend));
-      maxtime = MAX(maxtime, ABS(global_tbegin));
+      maxtime = MAX(ABS(global_times[nglobal_times-1]), ABS(global_scase.global_tend));
+      maxtime = MAX(maxtime, ABS(global_scase.global_tbegin));
       maxtime = MAX(maxtime, 10.0);
       //allow space for minus sign
-      if(global_tend<0.0 || global_tbegin<0.0 || global_times[nglobal_times-1] < 0.0)maxtime *= 10.0;
+      if(global_scase.global_tend<0.0 || global_scase.global_tbegin<0.0 || global_times[nglobal_times-1] < 0.0)maxtime *= 10.0;
       timelabelptr = Time2RenderLabel(time_local, dt, maxtime, timelabel_local);
       strcpy(suffix, timelabelptr);
       strcat(suffix, "s");
@@ -422,7 +422,7 @@ void OutputSliceData(void){
 
   for(ii = 0; ii < nslice_loaded; ii++){
     i = slice_loaded_list[ii];
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     if(sd->display == 0 || sd->slicefile_labelindex != slicefile_labelindex)continue;
     if(sd->times[0] > global_times[itimes])continue;
 
@@ -1115,13 +1115,13 @@ void SetSmokeSensor(gdImagePtr RENDERimage, int width, int height){
   if(test_smokesensors == 1 && active_smokesensors == 1 && show_smokesensors != SMOKESENSORS_HIDDEN){
     int idev;
 
-    for(idev = 0; idev < ndeviceinfo; idev++){
+    for(idev = 0; idev < global_scase.devicecoll.ndeviceinfo; idev++){
       devicedata *devicei;
       int idev_col, idev_row;
       int col_offset, row_offset;
       unsigned int red = 255 << 16;
 
-      devicei = deviceinfo + idev;
+      devicei = global_scase.devicecoll.deviceinfo + idev;
 
       if(devicei->object->visible == 0 || devicei->show == 0)continue;
       if(strcmp(devicei->object->label, "smokesensor") != 0)continue;

--- a/Source/smokeview/showscene.c
+++ b/Source/smokeview/showscene.c
@@ -23,7 +23,7 @@ void DrawLights(float *position0, float *position1){
 
   glPushMatrix();
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-  glTranslatef(-xbar0, -ybar0, -zbar0);
+  glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
   glLineWidth(10.0);
   glBegin(GL_LINES);
   glColor3f(0.0, 0.0, 0.0);
@@ -76,7 +76,7 @@ void ShowScene2(int mode){
 
     /* ++++++++++++++++++++++++ DrawTrees +++++++++++++++++++++++++ */
 
-    if(ntreeinfo>0){
+    if(global_scase.ntreeinfo>0){
       CLIP_GEOMETRY;
       DrawTrees();
       SNIFF_ERRORS("after DrawTrees");
@@ -97,7 +97,7 @@ void ShowScene2(int mode){
 
     /* ++++++++++++++++++++++++ draw circular vents +++++++++++++++++++++++++ */
 
-    if(ncvents>0 && visCircularVents != VENT_HIDE && showpatch==0){
+    if(global_scase.ncvents>0 && visCircularVents != VENT_HIDE && showpatch==0){
       CLIP_GEOMETRY;
       DrawCircVents(visCircularVents);
     }
@@ -128,7 +128,7 @@ void ShowScene2(int mode){
 
     /* ++++++++++++++++++++++++ draw ticks +++++++++++++++++++++++++ */
 
-    if(visFDSticks == 1 && ntickinfo>0){
+    if(visFDSticks == 1 && global_scase.ntickinfo>0){
       UNCLIP;
       DrawTicks();
       SNIFF_ERRORS("after DrawTicks");
@@ -152,7 +152,7 @@ void ShowScene2(int mode){
 
     /* ++++++++++++++++++++++++ draw fds specified blockage outlines +++++++++++++++++++++++++ */
 
-    if(nobstinfo>0&&blocklocation!=BLOCKlocation_grid){
+    if(global_scase.obstcoll.nobstinfo>0&&blocklocation!=BLOCKlocation_grid){
       if(visBlocks==visBLOCKOutline||visBlocks==visBLOCKAsInputOutline||
          visBlocks==visBLOCKSolidOutline||visBlocks==visBLOCKAddOutline){
         DrawOrigObstOutlines();
@@ -165,7 +165,7 @@ void ShowScene2(int mode){
     /* ++++++++++++++++++++++++ draw simulation frame (corners at (0,0,0) and (xbar,ybar,zbar) +++++++++++++++++++++++++ */
 
 
-    if(geom_bounding_box_mousedown==1||(isZoneFireModel == 0 && visFrame == 1 && highlight_flag == 2)){
+    if(geom_bounding_box_mousedown==1||(global_scase.isZoneFireModel == 0 && visFrame == 1 && highlight_flag == 2)){
       CLIP_GEOMETRY;
       DrawOutlines();
       SNIFF_ERRORS("after DrawOutlines");
@@ -179,11 +179,11 @@ void ShowScene2(int mode){
       int i;
       float box_black[4] = {0.0, 0.0, 0.0, 1.0};
 
-      for(i = 0;i < nmeshes;i++){
+      for(i = 0;i < global_scase.meshescoll.nmeshes;i++){
         meshdata *meshi;
         float *xyz_min, *xyz_max;
 
-        meshi = meshinfo + i;
+        meshi = global_scase.meshescoll.meshinfo + i;
         xyz_min = meshi->boxmin_scaled;
         xyz_max = meshi->boxmax_scaled;
         if(meshi->use == 1){
@@ -208,7 +208,7 @@ void ShowScene2(int mode){
 
       glPushMatrix();
       glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
-      glTranslatef(-xbar0, -ybar0, -zbar0);
+      glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
       DrawBoxOutline(meshclip, box_red);
       glPopMatrix();
     }
@@ -229,14 +229,14 @@ void ShowScene2(int mode){
 
     /* ++++++++++++++++++++++++ draw mesh +++++++++++++++++++++++++ */
 
-    if(setPDIM == 1){
+    if(global_scase.setPDIM == 1){
       if(visGrid != NOGRID_NOPROBE){
         int igrid;
         meshdata *meshi;
 
         UNCLIP;
-        for(igrid = 0;igrid<nmeshes;igrid++){
-          meshi = meshinfo + igrid;
+        for(igrid = 0;igrid<global_scase.meshescoll.nmeshes;igrid++){
+          meshi = global_scase.meshescoll.meshinfo + igrid;
           DrawGrid(meshi);
           SNIFF_ERRORS("DrawGrid");
         }
@@ -280,7 +280,7 @@ void ShowScene2(int mode){
   /* ++++++++++++++++++++++++ DrawSelectTours +++++++++++++++++++++++++ */
 
   if(mode == SELECTOBJECT){
-    if(edittour == 1 && tourcoll.ntourinfo>0){
+    if(edittour == 1 && global_scase.tourcoll.ntourinfo>0){
       CLIP_GEOMETRY;
       DrawSelectTours();
       SNIFF_ERRORS("after DrawSelectTours");
@@ -302,7 +302,7 @@ void ShowScene2(int mode){
   if(show_parallax == 1){
     UNCLIP;
     AntiAliasLine(ON);
-    glLineWidth(linewidth);
+    glLineWidth(global_scase.linewidth);
     glBegin(GL_LINES);
     glColor3fv(foregroundcolor);
     glVertex3f(0.75, 0.0, 0.25);
@@ -329,10 +329,10 @@ void ShowScene2(int mode){
     if(use_cfaces==1){
       int i;
 
-      for(i = 0; i<ncgeominfo; i++){
+      for(i = 0; i<global_scase.ncgeominfo; i++){
         geomdata *geomi;
 
-        geomi = cgeominfo+i;
+        geomi = global_scase.cgeominfo+i;
         DrawCGeom(DRAW_OPAQUE, geomi);
       }
     }
@@ -354,7 +354,7 @@ void ShowScene2(int mode){
   CLIP_GEOMETRY;
   DrawTerrainGeom(DRAW_OPAQUE);
 
-  if(visTerrainType != TERRAIN_HIDDEN&&nterraininfo>0&&ngeominfo==0 && geom_bounding_box_mousedown==0){
+  if(global_scase.visTerrainType != TERRAIN_HIDDEN&&global_scase.nterraininfo>0&&global_scase.ngeominfo==0 && geom_bounding_box_mousedown==0){
     int i;
 
     //shaded  17 0
@@ -371,16 +371,16 @@ void ShowScene2(int mode){
       flag = TERRAIN_TOP_SIDE;
     }
     CLIP_GEOMETRY;
-    for(i = 0;i<nterraininfo;i++){
+    for(i = 0;i<global_scase.nterraininfo;i++){
       terraindata *terri;
 
-      terri = terraininfo + i;
-      switch(visTerrainType){
+      terri = global_scase.terraininfo + i;
+      switch(global_scase.visTerrainType){
       case TERRAIN_SURFACE:
         DrawTerrainOBST(terri, flag);
         break;
       case TERRAIN_IMAGE:
-        if(terrain_textures != NULL&&terrain_textures[iterrain_textures].loaded == 1){
+        if(global_scase.terrain_texture_coll.terrain_textures != NULL&&global_scase.terrain_texture_coll.terrain_textures[iterrain_textures].loaded == 1){
           DrawTerrainOBSTTexture(terri);
         }
         else{
@@ -392,12 +392,12 @@ void ShowScene2(int mode){
         break;
       }
     }
-    if(visTerrainType==TERRAIN_IMAGE||visTerrainType==TERRAIN_SURFACE){
+    if(global_scase.visTerrainType==TERRAIN_IMAGE||global_scase.visTerrainType==TERRAIN_SURFACE){
       if(terrain_showonly_top==0){
-        for(i = 0; i<nmeshes; i++){
+        for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
           meshdata *meshi;
 
-          meshi = meshinfo+i;
+          meshi = global_scase.meshescoll.meshinfo+i;
           DrawTerrainOBSTSides(meshi);
         }
       }
@@ -406,7 +406,7 @@ void ShowScene2(int mode){
 
   /* ++++++++++++++++++++++++ draw HVAC networks +++++++++++++++++++++++++ */
 
-  if (hvaccoll.nhvacinfo > 0) {
+  if (global_scase.hvaccoll.nhvacinfo > 0) {
     DrawHVACS();
   }
 
@@ -434,7 +434,7 @@ void ShowScene2(int mode){
 
   if(visLabels == 1){
     CLIP_GEOMETRY;
-    DrawLabels(&labelscoll);
+    DrawLabels(&global_scase.labelscoll);
   }
 
   /* ++++++++++++++++++++++++ draw animated isosurfaces +++++++++++++++++++++++++ */
@@ -446,7 +446,7 @@ void ShowScene2(int mode){
 
   /* ++++++++++++++++++++++++ draw zone fire modeling info +++++++++++++++++++++++++ */
 
-  if(nrooms>0){
+  if(global_scase.nrooms>0){
     CLIP_GEOMETRY;
     DrawZoneRoomGeom();
     SNIFF_ERRORS("after DrawZoneRoomGeom");
@@ -456,7 +456,7 @@ void ShowScene2(int mode){
       DrawZoneFireData();
       SNIFF_ERRORS("after DrawZoneFireData");
       if(ReadZoneFile == 1){
-        if(nzvents>0){
+        if(global_scase.nzvents>0){
           DrawZoneVentData();
           SNIFF_ERRORS("after DrawZoneVentData");
         }
@@ -484,14 +484,14 @@ void ShowScene2(int mode){
 
   /* ++++++++++++++++++++++++ draw transparent cfaces +++++++++++++++++++++++++ */
 
-  if(ncgeominfo > 0){
+  if(global_scase.ncgeominfo > 0){
     if(use_cfaces == 1){
       int i;
 
-      for(i = 0; i < ncgeominfo; i++){
+      for(i = 0; i < global_scase.ncgeominfo; i++){
         geomdata *geomi;
 
-        geomi = cgeominfo + i;
+        geomi = global_scase.cgeominfo + i;
         DrawCGeom(DRAW_TRANSPARENT, geomi);
       }
     }
@@ -556,7 +556,7 @@ void ShowScene2(int mode){
 
   /* ++++++++++++++++++++++++ draw zone fire modeling info +++++++++++++++++++++++++ */
 
-  if(nrooms>0 && showzone == 1){
+  if(global_scase.nrooms>0 && showzone == 1){
     CLIP_VALS;
     DrawZoneRoomData();
     SNIFF_ERRORS("after DrawZoneRoomData");

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -9,7 +9,7 @@
 #define TERRAIN_FIRE_LINE_UPDATE 39
 #endif
 
-#include "colorbars.h"
+#include "shared_structures.h"
 
 //*** glui_clip.cpp headers
 

--- a/Source/smokeview/smokeview.c
+++ b/Source/smokeview/smokeview.c
@@ -178,9 +178,9 @@ void InitVolrenderScript(char *prefix, char *tour_label, int startframe, int ski
   if(volrender_scriptname==NULL){
     int len;
 
-    len = strlen(fdsprefix)+strlen("_volrender.ssf")+1;
+    len = strlen(global_scase.fdsprefix)+strlen("_volrender.ssf")+1;
     NewMemory((void **)&volrender_scriptname,(unsigned int)(len));
-    STRCPY(volrender_scriptname,fdsprefix);
+    STRCPY(volrender_scriptname,global_scase.fdsprefix);
     STRCAT(volrender_scriptname,"_volrender.ssf");
   }
 
@@ -206,8 +206,8 @@ void InitVolrenderScript(char *prefix, char *tour_label, int startframe, int ski
 
 void DisplayVersionInfo(char *progname){
   PRINTVERSION(progname);
-  if(fds_version!=NULL){
-    PRINTF("FDS Build        : %s\n",fds_githash);
+  if(global_scase.fds_version!=NULL){
+    PRINTF("FDS Build        : %s\n",global_scase.fds_githash);
   }
   char *smv_progname = GetBinPath();
   PRINTF("Smokeview path   : %s\n",smv_progname);
@@ -243,17 +243,17 @@ void DisplayVersionInfo(char *progname){
   char fullini_filename[256];
   strcpy(fullini_filename, "");
   char *smokeview_scratchdir = GetUserConfigDir();
-  if(caseini_filename != NULL){
-    if(FileExistsOrig(caseini_filename) == 1){
+  if(global_scase.paths.caseini_filename != NULL){
+    if(FileExistsOrig(global_scase.paths.caseini_filename) == 1){
       char cwdpath[1000];
       GETCWD(cwdpath, 1000);
       strcpy(fullini_filename, cwdpath);
       strcat(fullini_filename, dirseparator);
-      strcat(fullini_filename, caseini_filename);
+      strcat(fullini_filename, global_scase.paths.caseini_filename);
     }
     else if(smokeview_scratchdir!=NULL){
       strcpy(fullini_filename, smokeview_scratchdir);
-      strcat(fullini_filename, caseini_filename);
+      strcat(fullini_filename, global_scase.paths.caseini_filename);
       if(FileExistsOrig(fullini_filename)==0)strcpy(fullini_filename, "");
     }
   }
@@ -275,7 +275,7 @@ void DisplayVersionInfo(char *progname){
 int IsFDSRunning(FILE_SIZE *last_size){
   FILE_SIZE file_size;
 
-  file_size = GetFileSizeSMV(stepcsv_filename);
+  file_size = GetFileSizeSMV(global_scase.paths.stepcsv_filename);
   if(file_size != *last_size){
     *last_size = file_size;
     return 1;
@@ -289,15 +289,15 @@ int BuildGbndFile(int file_type){
   switch(file_type){
     case BOUND_SLICE:
       if(FileExistsOrig(slice_gbnd_filename)==0)return 1;
-      if(IsFileNewer(stepcsv_filename, slice_gbnd_filename)==1)return 1;
+      if(IsFileNewer(global_scase.paths.stepcsv_filename, slice_gbnd_filename)==1)return 1;
       break;
     case BOUND_PATCH:
       if(FileExistsOrig(patch_gbnd_filename)==0)return 1;
-      if(IsFileNewer(stepcsv_filename, patch_gbnd_filename)==1)return 1;
+      if(IsFileNewer(global_scase.paths.stepcsv_filename, patch_gbnd_filename)==1)return 1;
       break;
     case BOUND_PLOT3D:
       if(FileExistsOrig(plot3d_gbnd_filename)==0)return 1;
-      if(IsFileNewer(stepcsv_filename, plot3d_gbnd_filename)==1)return 1;
+      if(IsFileNewer(global_scase.paths.stepcsv_filename, plot3d_gbnd_filename)==1)return 1;
       break;
     default:
       assert(FFALSE);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -128,15 +128,9 @@ SVEXTERN int SVDECL(hvac_network_ductnode_index, -1);
 #define HVAC_NCIRC 72
 SVEXTERN float SVDECL(*hvac_circ_x, NULL), SVDECL(*hvac_circ_y, NULL);
 #ifdef INMAIN
-SVEXTERN hvacdatacollection hvaccoll = {
-  .hvacductvar_index= -1,
-  .hvacnodevar_index= -1,
-  0
-};
 SVEXTERN int hvac_duct_color[3] = { 63,0,15};
 SVEXTERN int hvac_node_color[3] = { 63,0,15};
 #else
-SVEXTERN hvacdatacollection hvaccoll;
 SVEXTERN int hvac_duct_color[3];
 SVEXTERN int hvac_node_color[3];
 #endif
@@ -151,7 +145,6 @@ SVEXTERN char SVDECL(*slice_buffer, NULL);
 
 SVEXTERN FILE_SIZE SVDECL(last_size_for_slice, 0);
 SVEXTERN FILE_SIZE SVDECL(last_size_for_boundary, 0);
-SVEXTERN char SVDECL(*stepcsv_filename, NULL);
 
 SVEXTERN char SVDECL(*plot3d_gbnd_filename, NULL), SVDECL(**sorted_plot3d_filenames, NULL);
 SVEXTERN char SVDECL(*slice_gbnd_filename,  NULL), SVDECL(**sorted_slice_filenames,  NULL);
@@ -462,7 +455,6 @@ SVEXTERN int SVDECL(iso_opacity_change, 1);
 #ifdef pp_RENDER360_DEBUG
 SVEXTERN int SVDECL(debug_360, 0), SVDECL(debug_360_skip_x,25), SVDECL(debug_360_skip_y,25);
 #endif
-SVEXTERN char SVDECL(*ffmpeg_command_filename, NULL);
 SVEXTERN int SVDECL(output_ffmpeg_command, 0);
 SVEXTERN int SVDECL(margin360_size, 0);
 
@@ -527,7 +519,6 @@ SVEXTERN int SVDECL(nsmoke3d_temp, 0);
 SVEXTERN int SVDECL(nsmoke3d_co2, 0);
 SVEXTERN int SVDECL(update_zaxis_custom, 0);
 SVEXTERN int SVDECL(from_DisplayCB, 0);
-SVEXTERN int SVDECL(ngeom_data, 0);
 SVEXTERN float SVDECL(*fire_rgbs, NULL);
 SVEXTERN int SVDECL(nfire_colors, 1024);
 SVEXTERN float SVDECL(fire_temp_min, 100.0), SVDECL(fire_temp_max, 5500.0);
@@ -538,7 +529,6 @@ SVEXTERN int SVDECL(have_geom_slice_menus, 0), SVDECL(geom_slice_loaded,0);
 SVEXTERN FILE SVDECL(*stderr2,NULL);
 SVEXTERN char SVDECL(*script_error1_filename,NULL);
 SVEXTERN int SVDECL(render_firsttime, NO);
-SVEXTERN int SVDECL(solid_ht3d, 0);
 SVEXTERN int SVDECL(load_incremental, 0);
 SVEXTERN int SVDECL(show_tour_hint, 1);
 SVEXTERN int cb_rgb[3];
@@ -615,7 +605,7 @@ SVEXTERN float box_corners[8][3], box_geom_corners[8][3];
 SVEXTERN int SVDECL(have_box_geom_corners, 0);
 SVEXTERN float boxmin_global[3], boxmax_global[3], max_cell_length;
 SVEXTERN int SVDECL(update_boxbounds, 1);
-SVEXTERN int SVDECL(have_beam, 0), SVDECL(showbeam_as_line, 1), SVDECL(use_beamcolor,0), beam_color[3];
+SVEXTERN int SVDECL(showbeam_as_line, 1), SVDECL(use_beamcolor,0), beam_color[3];
 SVEXTERN float SVDECL(beam_line_width, 4.0);
 
 SVEXTERN float SVDECL(zone_hvac_diam, 0.05);
@@ -634,7 +624,6 @@ SVEXTERN int SVDECL(*colorbar_list_inverse, NULL);
 SVEXTERN int SVDECL(show_Lab_dist_bars, 0);
 SVEXTERN int SVDECL(update_colorbar_orig, 0);
 SVEXTERN float SVDECL(*lab_check_xyz, NULL);
-SVEXTERN char SVDECL(*dEcsv_filename, NULL);
 SVEXTERN float cb_lab2[3], cb_frgb2[3];
 SVEXTERN int cb_rgb2[3];
 SVEXTERN int SVDECL(index_colorbar1, 0), SVDECL(index_colorbar2, 1);
@@ -642,7 +631,7 @@ SVEXTERN int SVDECL(colorbar_toggle, 1);
 SVEXTERN int SVDECL(color_vector_black, 0);
 SVEXTERN float SVDECL(geom_transparency, 0.5);
 SVEXTERN int SVDECL(geom_force_transparent, 0);
-SVEXTERN float SVDECL(load_3dsmoke_cutoff, 1.0), SVDECL(load_hrrpuv_cutoff,200.0);
+SVEXTERN float SVDECL(load_3dsmoke_cutoff, 1.0);
 SVEXTERN int SVDECL(override_3dsmoke_cutoff, 0);
 SVEXTERN int SVDECL(visCompartments, 1);
 SVEXTERN int render_mode, render_times;
@@ -721,8 +710,7 @@ SVEXTERN float northangle_position[3] = {0.0, 0.0, 0.1};
 #else
 SVEXTERN float northangle_position[3];
 #endif
-SVEXTERN float SVDECL(northangle, 0.0);
-SVEXTERN int SVDECL(vis_northangle, 0), SVDECL(have_northangle,0);
+SVEXTERN int SVDECL(vis_northangle, 0);
 
 SVEXTERN int SVDECL(viswindrose, 0), SVDECL(windrose_xy_vis, 1), SVDECL(windrose_xz_vis, 0), SVDECL(windrose_yz_vis, 0);
 SVEXTERN int SVDECL(nr_windrose, 8), SVDECL(ntheta_windrose, 12);
@@ -740,7 +728,7 @@ SVEXTERN int SVDECL(update_makemovie, 0),SVDECL(movie_filetype,AVI);
 SVEXTERN char movie_name[1024], movie_ext[10];
 SVEXTERN int SVDECL(movie_framerate, 10), SVDECL(have_ffmpeg, 0), SVDECL(have_ffplay, 0), SVDECL(overwrite_movie, 1);
 
-SVEXTERN int SVDECL(show_missing_objects, 1),SVDECL(have_missing_objects,0);
+SVEXTERN int SVDECL(show_missing_objects, 1);
 SVEXTERN int SVDECL(toggle_dialogs, 1);
 SVEXTERN int SVDECL(use_data_extremes, 1);
 SVEXTERN int SVDECL(extreme_data_offset, 1), SVDECL(colorbar_offset, 0);
@@ -749,15 +737,11 @@ SVEXTERN int SVDECL(colorbar_autoflip,1);
 SVEXTERN int SVDECL(update_flipped_colorbar,0);
 
 #ifdef INMAIN
-SVEXTERN float gvecphys[3]={0.0,0.0,-9.8};
-SVEXTERN float gvecunit[3]={0.0,0.0,-1.0};
 SVEXTERN float gvecphys_orig[3] = {0.0,0.0,-9.8};
 #else
-SVEXTERN float gvecphys[3];
-SVEXTERN float gvecunit[3];
 SVEXTERN float gvecphys_orig[3];
 #endif
-SVEXTERN int SVDECL(gvec_down,1),SVDECL(have_gvec,0),SVDECL(zaxis_custom,0),SVDECL(showgravity_vector,0);
+SVEXTERN int SVDECL(gvec_down,1),SVDECL(zaxis_custom,0),SVDECL(showgravity_vector,0);
 SVEXTERN float SVDECL(slice_line_contour_width,1.0);
 SVEXTERN int SVDECL(slice_contour_type,0);
 SVEXTERN int SVDECL(viscadopaque,0);
@@ -851,8 +835,6 @@ SVEXTERN int SVDECL(colorbar_coord_type, 0);
 
 SVEXTERN int SVDECL(*meshvisptr,NULL);
 SVEXTERN int SVDECL(from_commandline,0);
-SVEXTERN filelistdata SVDECL(*ini_filelist,NULL), SVDECL(*filelist_casename, NULL), SVDECL(*filelist_casedir, NULL);
-SVEXTERN int          SVDECL(nini_filelist,0),    SVDECL(nfilelist_casename, 0),    SVDECL(nfilelist_casedir, 0);
 SVEXTERN float this_mouse_time, SVDECL(last_mouse_time,0.0);
 SVEXTERN int move_gslice;
 
@@ -990,7 +972,7 @@ SVEXTERN int SVDECL(niso_timesteps,0);
 SVEXTERN isotri SVDECL(**iso_trans,NULL),SVDECL(**iso_opaques,NULL);
 SVEXTERN int SVDECL(niso_trans,0),SVDECL(niso_opaques,0);
 SVEXTERN int SVDECL(sort_iso_triangles,1);
-SVEXTERN int SVDECL(object_outlines,0), SVDECL(object_box, 0), SVDECL(have_object_box, 0);
+SVEXTERN int SVDECL(object_outlines,0), SVDECL(object_box, 0);
 SVEXTERN int SVDECL(usemenu,1);
 SVEXTERN float direction_color[4], SVDECL(*direction_color_ptr,NULL);
 #ifdef INMAIN
@@ -998,8 +980,6 @@ SVEXTERN float hrrpuv_iso_color[4]={1.0,0.5,0.0,1.0};
 #else
 SVEXTERN float hrrpuv_iso_color[4];
 #endif
-SVEXTERN int npropinfo;
-SVEXTERN propdata SVDECL(*propinfo,NULL);
 SVEXTERN float SVDECL(right_green,0.0), SVDECL(right_blue,1.0);
 
 SVEXTERN int SVDECL(saved_colorbar, -1);
@@ -1007,22 +987,16 @@ SVEXTERN int SVDECL(levelset_colorbar,-1), SVDECL(wallthickness_colorbar,-1);
 SVEXTERN colorbardata SVDECL(*fire_colorbar,NULL);
 SVEXTERN float SVDECL(glui_time,0.0);
 SVEXTERN int show_mode;
-SVEXTERN int SVDECL(cellcenter_slice_active,0);
 SVEXTERN int SVDECL(part5colorindex,0), SVDECL(show_tracers_always,0);
 SVEXTERN int SVDECL(select_avatar,0), SVDECL(selected_avatar_tag,-1), SVDECL(view_from_selected_avatar,0);
 SVEXTERN float selected_avatar_pos[3], selected_avatar_angle;
 SVEXTERN unsigned char select_device_color[4], SVDECL(*select_device_color_ptr,NULL);
 SVEXTERN int SVDECL(script_render_flag,0), SVDECL(script_itime,0);
 
-SVEXTERN int SVDECL(show_slice_in_obst,ONLY_IN_GAS), SVDECL(offset_slice,0);
+SVEXTERN int SVDECL(offset_slice,0);
 SVEXTERN int SVDECL(show_slice_in_solid, 0), SVDECL(show_slice_in_gas, 1);
 SVEXTERN int SVDECL(skip_slice_in_embedded_mesh,0);
 SVEXTERN int n_embedded_meshes;
-
-SVEXTERN geomdata SVDECL(*geominfo,NULL);
-SVEXTERN int SVDECL(ngeominfo,0);
-SVEXTERN geomdata SVDECL(*cgeominfo, NULL);
-SVEXTERN int SVDECL(ncgeominfo, 0);
 
 SVEXTERN int npartframes_max;
 SVEXTERN int SVDECL(force_isometric,0);
@@ -1068,21 +1042,16 @@ SVEXTERN int SVDECL(vis_hrr_plot, 0);
 SVEXTERN int SVDECL(vis_slice_plot, 0);
 SVEXTERN int SVDECL(vis_colorbar_dists_plot, 0);
 
-SVEXTERN fueldata SVDECL(*fuelinfo, NULL);
-SVEXTERN int SVDECL(nfuelinfo, 0);
 SVEXTERN char hrrlabel[256];
-SVEXTERN hrrdata SVDECL(*hrrinfo, NULL), SVDECL(*hrrptr, NULL), SVDECL(*timeptr, NULL);
-SVEXTERN int SVDECL(nhrrinfo, 0);
+SVEXTERN hrrdata SVDECL(*hrrptr, NULL), SVDECL(*timeptr, NULL);
 SVEXTERN int SVDECL(time_col, -1), SVDECL(hrr_col, -1), SVDECL(mlr_col, -1);
 SVEXTERN int SVDECL(glui_hrr, 1);
-SVEXTERN float SVDECL(fuel_hoc, -1.0), SVDECL(fuel_hoc_default, -1.0);
+SVEXTERN float SVDECL(fuel_hoc_default, -1.0);
 SVEXTERN char fuel_name[256];
-SVEXTERN int SVDECL(qradi_col, -1), SVDECL(chirad_col, -1), SVDECL(nhrrhcinfo, 0);
+SVEXTERN int SVDECL(qradi_col, -1), SVDECL(chirad_col, -1);
 SVEXTERN int SVDECL(have_mlr, 0);
 SVEXTERN int SVDECL(hoc_hrr, 0);
 SVEXTERN int SVDECL(update_avg, 0);
-SVEXTERN int SVDECL(ncsvfileinfo,0);
-SVEXTERN csvfiledata SVDECL(*csvfileinfo,NULL);
 SVEXTERN int smoke_render_option;
 SVEXTERN float fnear, ffar;
 #ifdef INMAIN
@@ -1218,7 +1187,6 @@ SVEXTERN float SVDECL(maxslabflow, 0.0);
 SVEXTERN int SVDECL(have_ventslab_flow,0);
 SVEXTERN float SVDECL(*zoneslab_T, NULL), SVDECL(*zoneslab_F, NULL), SVDECL(*zoneslab_YB, NULL), SVDECL(*zoneslab_YT, NULL);
 SVEXTERN int SVDECL(*zoneslab_n, NULL);
-SVEXTERN int SVDECL(zonecsv, 0), SVDECL(nzvents, 0), SVDECL(nzhvents, 0), SVDECL(nzvvents, 0), SVDECL(nzmvents, 0);
 SVEXTERN float zone_maxventflow;
 SVEXTERN unsigned char SVDECL(*hazardcolor,NULL);
 SVEXTERN float SVDECL(zone_ventfactor,1.0);
@@ -1283,7 +1251,6 @@ SVEXTERN float SVDECL(iso_transparency, 0.1196078), SVDECL(*iso_colors,NULL), SV
 SVEXTERN int glui_iso_colors[4], SVDECL(glui_iso_level,1), glui_iso_transparency;
 
 SVEXTERN float SVDECL(*rgb_ini,NULL);
-SVEXTERN float rgb[MAXRGB][4];
 SVEXTERN float SVDECL(mouse_deltax,0.0), SVDECL(mouse_deltay,0.0);
 SVEXTERN float SVDECL(**rgbptr,NULL), SVDECL(**rgb_plot3d_contour,NULL);
 #ifdef INMAIN
@@ -1299,7 +1266,6 @@ SVEXTERN float movedir[3];
 #endif
 SVEXTERN float rgb_base[MAXRGB][4];
 SVEXTERN float bw_base[MAXRGB][4];
-SVEXTERN int SVDECL(nrgb2,8);
 SVEXTERN float rgb2[MAXRGB][3];
 SVEXTERN float inverse_modelview_setup[16];
 SVEXTERN float modelview_setup[16];
@@ -1384,7 +1350,6 @@ SVEXTERN int SVDECL(glui_active,0);
 SVEXTERN int SVDECL(old_draw_colorlabel,0);
 SVEXTERN int SVDECL(vis3DSmoke3D,1);
 SVEXTERN int SVDECL(smokeskip,1),SVDECL(smokeskipm1,0);
-SVEXTERN int SVDECL(nrooms,0),SVDECL(nzoneinfo,0), SVDECL(nfires,0);
 SVEXTERN float SVDECL(scene_aspect_ratio,1.0);
 
 SVEXTERN int SVDECL(fix_window_aspect, 0);
@@ -1418,8 +1383,6 @@ SVEXTERN float SVDECL(xcenCUSTOMsmv,0.5), SVDECL(ycenCUSTOMsmv,0.5), SVDECL(zcen
 SVEXTERN int glui_rotation_index,SVDECL(update_rotation_center,0);
 SVEXTERN int glui_rotation_index_ini,SVDECL(update_rotation_center_ini,0);
 
-SVEXTERN float SVDECL(xbar,1.0), SVDECL(ybar,1.0), SVDECL(zbar,1.0);
-SVEXTERN float SVDECL(xbar0,0.0), SVDECL(ybar0,0.0), SVDECL(zbar0,0.0);
 SVEXTERN float SVDECL(xbarORIG,1.0), SVDECL(ybarORIG,1.0), SVDECL(zbarORIG,1.0);
 SVEXTERN float SVDECL(xbar0ORIG,0.0), SVDECL(ybar0ORIG,0.0), SVDECL(zbar0ORIG,0.0);
 SVEXTERN float xbarFDS, ybarFDS, zbarFDS;
@@ -1534,11 +1497,8 @@ SVEXTERN int SVDECL(visAIso,1);
 SVEXTERN int SVDECL(surfincrement,0),SVDECL(visiso,0);
 SVEXTERN int SVDECL(isotest,0);
 SVEXTERN int SVDECL(isolevelindex,0), SVDECL(isolevelindex2,0);
-SVEXTERN float SVDECL(pref,101325.0),SVDECL(pamb,0.0),SVDECL(tamb,293.15);
-SVEXTERN int SVDECL(ntc_total,0.0), SVDECL(nspr_total,0.0), SVDECL(nheat_total,0.0);
 SVEXTERN int SVDECL(n_devices,0);
 
-SVEXTERN int SVDECL(npartinfo,0), SVDECL(nplot3dinfo,0), SVDECL(npatchinfo,0);
 SVEXTERN float SVDECL(*globalmin_part, NULL), SVDECL(*globalmax_part, NULL);
 
 SVEXTERN int SVDECL(sliceload_boundtype, 0);
@@ -1549,9 +1509,7 @@ SVEXTERN int SVDECL(sliceload_isvector, 0);
 SVEXTERN sliceparmdata sliceparminfo;
 
 SVEXTERN int SVDECL(nslicebounds, 0), SVDECL(npatchbounds,0), SVDECL(npatch2,0);
-SVEXTERN int SVDECL(nisoinfo,0), SVDECL(niso_bounds,0);
-SVEXTERN int SVDECL(ntrnx,0), SVDECL(ntrny,0), SVDECL(ntrnz,0),SVDECL(npdim,0),SVDECL(nmeshes,0),SVDECL(clip_mesh,0);
-SVEXTERN int SVDECL(nOBST,0),SVDECL(nVENT,0),SVDECL(nCVENT,0),SVDECL(ncvents,0),SVDECL(noffset,0);
+SVEXTERN int SVDECL(niso_bounds,0);
 SVEXTERN int SVDECL(visLabels,0);
 SVEXTERN float SVDECL(framerate,-1.0);
 SVEXTERN int SVDECL(seqnum,0),SVDECL(RenderTime,0),SVDECL(RenderTimeOld,0), SVDECL(itime_cycle,0);
@@ -1574,7 +1532,7 @@ SVEXTERN int SVDECL(updatezoommenu,0),SVDECL(updatezoomini,0);
 SVEXTERN int SVDECL(updatemenu_count,0);
 SVEXTERN int SVDECL(use_graphics,1);
 
-SVEXTERN int SVDECL(updatefaces,0),SVDECL(updatefacelists,0);
+SVEXTERN int SVDECL(updatefacelists,0);
 SVEXTERN int SVDECL(updateOpenSMVFile,0);
 
 SVEXTERN int SVDECL(periodic_reloads, 0), SVDECL(periodic_reload_value, 2);
@@ -1585,7 +1543,6 @@ SVEXTERN float min_gridcell_size;
 
 SVEXTERN volfacelistdata SVDECL(*volfacelistinfo,NULL),SVDECL(**volfacelistinfoptrs,NULL);
 SVEXTERN int SVDECL(nvolfacelistinfo,0);
-SVEXTERN int SVDECL(setPDIM,0);
 SVEXTERN int SVDECL(menustatus,GLUT_MENU_NOT_IN_USE);
 SVEXTERN int SVDECL(visTimeZone,1), SVDECL(visTimeParticles,1), SVDECL(visTimeSlice,1), SVDECL(visTimeBoundary,1);
 SVEXTERN int SVDECL(visTimeIso,1);
@@ -1604,12 +1561,10 @@ SVEXTERN int SVDECL(block_volsmoke,1),SVDECL(smoke3dVoldebug,0);
 SVEXTERN slicedata SVDECL(*sd_shown,NULL);
 SVEXTERN vslicedata SVDECL(*vd_shown,NULL);
 SVEXTERN int SVDECL(showall_slices,1);
-SVEXTERN int SVDECL(auto_terrain,0),SVDECL(manual_terrain,0);
 SVEXTERN float zterrain_max, zterrain_min;
-SVEXTERN char SVDECL(*fds_version, NULL), SVDECL(*fds_githash, NULL);
 SVEXTERN char smv_githash[256], smv_gitdate[256];
 SVEXTERN int SVDECL(visMeshlabel, 1);
-SVEXTERN int SVDECL(visOpenVents,1),SVDECL(visDummyVents,1),SVDECL(visOtherVents,1),SVDECL(visOtherVentsSAVE,1),SVDECL(visCircularVents,VENT_CIRCLE);
+SVEXTERN int SVDECL(visOpenVents,1),SVDECL(visDummyVents,1),SVDECL(visCircularVents,VENT_CIRCLE);
 SVEXTERN int SVDECL(visOpenVentsAsOutline,0);
 SVEXTERN int SVDECL(visParticles,1), SVDECL(visZone,0);
 SVEXTERN int visBlocks;
@@ -1634,7 +1589,6 @@ SVEXTERN int SVDECL(visVents, 1), SVDECL(visVentFlow, 1),SVDECL(visVentHFlow, 1)
 SVEXTERN int SVDECL(viewoption,0);
 SVEXTERN int SVDECL(clip_mode,CLIP_OFF),clip_mode_last;
 SVEXTERN int clip_i,clip_j,clip_k;
-SVEXTERN int clip_I,clip_J,clip_K;
 SVEXTERN clipdata clipinfo,colorbar_clipinfo;
 SVEXTERN int stepclip_xmin,stepclip_ymin,stepclip_zmin;
 SVEXTERN int stepclip_xmax,stepclip_ymax,stepclip_zmax;
@@ -1658,13 +1612,12 @@ SVEXTERN float SVDECL(vector_basediameter,0.1);
 SVEXTERN float SVDECL(vector_headlength,0.2);
 SVEXTERN float SVDECL(vector_headdiameter,0.2);
 
-SVEXTERN float SVDECL(linewidth, 2.0), SVDECL(ventlinewidth, 2.0), SVDECL(highlight_linewidth, 4.0);
+SVEXTERN float SVDECL(highlight_linewidth, 4.0);
 SVEXTERN float solidlinewidth;
 SVEXTERN float SVDECL(sliceoffset_factor,0.1), SVDECL(ventoffset_factor,0.2), SVDECL(boundaryoffset, 0.0);
 SVEXTERN int SVDECL(visBLOCKold,-1);
 
 SVEXTERN int SVDECL(planar_terrain_slice,0);
-SVEXTERN int  SVDECL(nrgb, NRGB);
 SVEXTERN int SVDECL(nrgb_ini,-1);
 SVEXTERN int SVDECL(nrgb2_ini,0);
 SVEXTERN int SVDECL(rgb_white,NRGB), SVDECL(rgb_yellow,NRGB+1), SVDECL(rgb_blue,NRGB+2), SVDECL(rgb_red,NRGB+3);
@@ -1686,7 +1639,6 @@ SVEXTERN float SVDECL(geom_zmin, 0.0), SVDECL(geom_zmax, 1.0);
 SVEXTERN int SVDECL(use_geom_factors, 1), SVDECL(have_geom_factors, 0);
 SVEXTERN int SVDECL(transparent_state,ALL_SOLID);
 
-SVEXTERN float SVDECL(tload_begin, 0.0), SVDECL(tload_end, 0.0);
 SVEXTERN int SVDECL(use_tload_begin, 0), SVDECL(use_tload_end, 0);
 SVEXTERN float SVDECL(tload_begin2, 0.0), SVDECL(tload_end2, 0.0);
 SVEXTERN int SVDECL(use_tload_begin2, 0), SVDECL(use_tload_end2, 0);
@@ -1793,14 +1745,9 @@ SVEXTERN char plot3d_title[1024];
 SVEXTERN char SVDECL(*partshortlabel,NULL),SVDECL(*partunitlabel,NULL);
 SVEXTERN char emptylabel[2];
 
-SVEXTERN int nopenvents,nopenvents_nonoutline,ndummyvents,ntransparentblocks,ntransparentvents;
+SVEXTERN int nopenvents,nopenvents_nonoutline,ntransparentblocks,ntransparentvents;
 SVEXTERN int nventcolors;
 SVEXTERN float SVDECL(**ventcolors,NULL);
-#ifdef INMAIN
-SVEXTERN float texture_origin[3]={0.0,0.0,0.0};
-#else
-SVEXTERN float texture_origin[3];
-#endif
 
 SVEXTERN int vslicecolorbarflag;
 SVEXTERN int SVDECL(blockage_draw_option, 1);
@@ -1815,24 +1762,67 @@ SVEXTERN int SVDECL(n_blockages_debug, 0);
 SVEXTERN int SVDECL(colorbar_select_index,-1),SVDECL(update_colorbar_select_index,0);
 SVEXTERN float fds_eyepos[3],smv_eyepos[3],fds_viewdir[3],smv_viewpos[3];
 SVEXTERN int SVDECL(tour_usecurrent,0);
-SVEXTERN int SVDECL(isZoneFireModel,0);
 SVEXTERN int SVDECL(output_slicedata,0),SVDECL(output_patchdata,0);
 SVEXTERN f_units SVDECL(*unitclasses,NULL),SVDECL(*unitclasses_default,NULL),SVDECL(*unitclasses_ini,NULL);
 SVEXTERN int SVDECL(nunitclasses,0),SVDECL(nunitclasses_default,0),SVDECL(nunitclasses_ini,0);
-SVEXTERN meshdata SVDECL(*meshinfo,NULL),SVDECL(*current_mesh,NULL), SVDECL(*mesh_save,NULL);
-SVEXTERN supermeshdata SVDECL(*supermeshinfo,NULL);
-SVEXTERN int SVDECL(nsupermeshinfo,0);
+#ifdef INMAIN
+SVEXTERN smv_case global_scase = {.tourcoll = {.ntourinfo = 0,
+                                        .tourinfo = NULL,
+                                        .tour_ntimes = 1000,
+                                        .tour_t = NULL,
+                                        .tour_t2 = NULL,
+                                        .tour_dist = NULL,
+                                        .tour_dist2 = NULL,
+                                        .tour_dist3 = NULL,
+                                        .tour_tstart = 0.0,
+                                        .tour_tstop = 100.0},
+                           .fuel_hoc = -1.0,
+                           .have_cface_normals = CFACE_NORMALS_NO,
+                           .gvecphys = {0.0, 0.0, -9.8},
+                           .gvecunit = {0.0, 0.0, -1.0},
+                           .global_tbegin = 1.0,
+                           .global_tend = 0.0,
+                           .tload_begin = 0.0,
+                           .tload_end = 0.0,
+                           .load_hrrpuv_cutoff = 200.0,
+                           .global_hrrpuv_cutoff = 200.0,
+                           .global_hrrpuv_cutoff_default = 200.0,
+                           .smoke_albedo = 0.3,
+                           .smoke_albedo_base = 0.3,
+                           .xbar = 1.0,
+                           .ybar = 1.0,
+                           .zbar = 1.0,
+                           .show_slice_in_obst = ONLY_IN_GAS,
+                           .use_iblank = 1,
+                           .visOtherVents = 1,
+                           .visOtherVentsSAVE = 1,
+                           .hvac_duct_color = {63, 0, 15},
+                           .hvac_node_color = {63, 0, 15},
+                           .block_shininess = 100.0,
+                           .nrgb2 = 8,
+                           .pref = 101325.0,
+                           .pamb = 0.0,
+                           .tamb = 293.15,
+                           .nrgb = NRGB,
+                           .linewidth = 2.0,
+                           .ventlinewidth = 2.0,
+                           .hvaccoll = {
+                              .hvacductvar_index= -1,
+                              .hvacnodevar_index= -1,
+                              0
+                            }
+                          };
+#else
+SVEXTERN smv_case global_scase;
+#endif
+SVEXTERN meshdata SVDECL(*current_mesh,NULL), SVDECL(*mesh_save,NULL);
 SVEXTERN meshdata SVDECL(*mesh_last,NULL), SVDECL(*loaded_isomesh,NULL);
 SVEXTERN float SVDECL(devicenorm_length,0.1);
-SVEXTERN int SVDECL(ndeviceinfo,0),nvdeviceinfo,ndeviceinfo_exp;
 SVEXTERN float max_dev_vel;
 SVEXTERN int SVDECL(last_prop_display,-1);
 SVEXTERN int SVDECL(devicetypes_index,0);
 
 SVEXTERN float SVDECL(plot2d_hrr_min,0.0), SVDECL(plot2d_hrr_max,1.0);
-SVEXTERN devicedata SVDECL(*deviceinfo,NULL);
-SVEXTERN vdevicedata SVDECL(*vdeviceinfo, NULL);
-SVEXTERN vdevicesortdata SVDECL(*vdevices_sorted, NULL);
 
 SVEXTERN int SVDECL(have_ext, 0);
 SVEXTERN int SVDECL(ntreedeviceinfo, 0), SVDECL(mintreesize, 3);
@@ -1843,12 +1833,6 @@ SVEXTERN treedevicedata SVDECL(**zwindtreeinfo, NULL);
 SVEXTERN int SVDECL(show_smokesensors,SMOKESENSORS_0255),SVDECL(active_smokesensors,0),SVDECL(test_smokesensors,0);
 SVEXTERN float SVDECL(smoke3d_cvis,1.0);
 SVEXTERN std_objects SVDECL(std_object_defs,{0});
-SVEXTERN object_collection SVDECL(*objectscoll,NULL);
-SVEXTERN char SVDECL(**device_texture_list,NULL);
-SVEXTERN int ndevice_texture_list, SVDECL(*device_texture_list_index,NULL);
-SVEXTERN treedata SVDECL(*treeinfo,NULL);
-SVEXTERN terraindata SVDECL(*terraininfo,NULL);
-SVEXTERN int SVDECL(ntreeinfo,0), SVDECL(nterraininfo,0), SVDECL(visTerrainType,0);
 SVEXTERN float treecolor[4];
 #ifdef INMAIN
 SVEXTERN float treecharcolor[4]={0.3,0.3,0.3,1.0};
@@ -1913,26 +1897,18 @@ SVEXTERN int SVDECL(titlesafe_offsetBASE,45);
 SVEXTERN int   SVDECL(reset_frame,0);
 SVEXTERN float SVDECL(reset_time,0.0),SVDECL(start_frametime,0.0),SVDECL(stop_frametime,0.0);
 SVEXTERN float SVDECL(max_velocity,0.0);
-SVEXTERN int niso_compressed;
 SVEXTERN int nslice_loaded, ngeomslice_loaded, nvolsmoke_loaded;
 SVEXTERN int SVDECL(*slice_loaded_list,NULL), SVDECL(*slice_sorted_loaded_list,NULL);
-SVEXTERN char SVDECL(*fdsprefix,NULL), SVDECL(*fdsprefix2,NULL);
+SVEXTERN char SVDECL(*fdsprefix2,NULL);
 SVEXTERN char SVDECL(*endian_filename,NULL);
 SVEXTERN char SVDECL(*target_filename,NULL);
 
 SVEXTERN int SVDECL(update_bounds,0);
-SVEXTERN int SVDECL(*sorted_surfidlist,NULL),SVDECL(*inv_sorted_surfidlist,NULL),SVDECL(nsorted_surfidlist,0);
-SVEXTERN char SVDECL(*trainer_filename,NULL), SVDECL(*test_filename,NULL);
 SVEXTERN FILE SVDECL(*STREAM_SB,NULL);
 SVEXTERN float SVDECL(temp_threshold,400.0);
-SVEXTERN char SVDECL(*smv_filename,NULL),SVDECL(*smv_orig_filename,NULL),SVDECL(*stop_filename,NULL);
-SVEXTERN char SVDECL(*smvzip_filename, NULL);
+SVEXTERN char SVDECL(*smv_filename,NULL);
 SVEXTERN int  SVDECL(have_multislice, 0), SVDECL(have_multivslice, 0);
-SVEXTERN char SVDECL(*hrr_filename, NULL);
 SVEXTERN char SVDECL(*part_globalbound_filename, NULL);
-SVEXTERN char SVDECL(*sliceinfo_filename,NULL);
-SVEXTERN char SVDECL(*deviceinfo_filename, NULL);
-SVEXTERN char SVDECL(*database_filename,NULL),SVDECL(*iso_filename,NULL);
 SVEXTERN char SVDECL(*smokeview_casedir, NULL);
 SVEXTERN int SVDECL(update_vectorskip, 0);
 SVEXTERN int SVDECL(smoke_offaxis, 0), SVDECL(smoke_adjust, 1);
@@ -1943,10 +1919,6 @@ SVEXTERN int SVDECL(nscriptinfo,0);
 SVEXTERN scriptfiledata SVDECL(*script_recording,NULL);
 SVEXTERN int SVDECL(runscript,0), SVDECL(noexit,0);
 SVEXTERN int SVDECL(runhtmlscript, 0);
-#ifdef pp_LUA
-SVEXTERN int SVDECL(runluascript,0);
-SVEXTERN int SVDECL(exit_on_script_crash,0);
-#endif
 #ifdef INMAIN
 SVEXTERN float slice_xyz[3]={0.0,0.0,0.0}, slice_dxyz[3] = {0.0, 0.0, 0.0};
 #else
@@ -1955,27 +1927,16 @@ SVEXTERN float slice_xyz[3], slice_dxyz[3];
 SVEXTERN int   SVDECL(update_slice2device, 0);
 SVEXTERN int SVDECL(script_multislice,0), SVDECL(script_multivslice,0), SVDECL(script_iso,0);
 SVEXTERN FILE SVDECL(*scriptoutstream,NULL);
-SVEXTERN char SVDECL(*log_filename,NULL);
 SVEXTERN FILE SVDECL(*LOG_FILENAME,NULL);
 SVEXTERN char SVDECL(*flushfile,NULL), SVDECL(*chidfilebase,NULL);
 SVEXTERN int SVDECL(csv_loaded, 0), SVDECL(devices_setup,0),SVDECL(update_csv_load,0);
-SVEXTERN char SVDECL(*hrr_csv_filename,NULL),SVDECL(*devc_csv_filename,NULL),SVDECL(*exp_csv_filename,NULL);
-SVEXTERN char SVDECL(*smokezippath,NULL), SVDECL(*smokeviewpath,NULL);
-SVEXTERN char SVDECL(*INI_fds_filein,NULL), SVDECL(*fds_filein,NULL);
-SVEXTERN char SVDECL(*caseini_filename,NULL);
+SVEXTERN char SVDECL(*smokezippath,NULL), SVDECL(*smokeviewpath,NULL), SVDECL(*fdsprog, NULL);
+SVEXTERN char SVDECL(*INI_fds_filein,NULL);
 #ifdef pp_FRAME
 SVEXTERN char SVDECL(*frametest_filename, NULL);
 #endif
-SVEXTERN char SVDECL(*fedsmv_filename, NULL);
-SVEXTERN char SVDECL(*expcsv_filename, NULL);
-SVEXTERN char SVDECL(*event_filename, NULL);
 SVEXTERN int SVDECL(event_file_exists,0);
 SVEXTERN char SVDECL(*zonelonglabels,NULL), SVDECL(*zoneshortlabels,NULL), SVDECL(*zoneunits,NULL);
-SVEXTERN char SVDECL(*html_filename, NULL);
-SVEXTERN char SVDECL(*htmlvr_filename, NULL);
-SVEXTERN char SVDECL(*htmlslicenode_filename, NULL);
-SVEXTERN char SVDECL(*htmlslicecell_filename, NULL);
-SVEXTERN char SVDECL(*htmlobst_filename, NULL);
 SVEXTERN int SVDECL(overwrite_all,0),SVDECL(erase_all,0);
 SVEXTERN int SVDECL(compress_autoloaded,0);
 SVEXTERN tridata SVDECL(**opaque_triangles,NULL),SVDECL(**transparent_triangles,NULL),SVDECL(**alltriangles,NULL);
@@ -1988,9 +1949,7 @@ SVEXTERN float xyzmaxdiff;
 SVEXTERN char ext_png[5];
 SVEXTERN char ext_jpg[5];
 
-SVEXTERN int SVDECL(hide_overlaps, 0);
-SVEXTERN int SVDECL(nsurfids,0);
-SVEXTERN surfid SVDECL(*surfids,NULL);
+SVEXTERN int SVDECL(updatehiddenfaces,1),SVDECL(hide_overlaps,0);
 SVEXTERN int key_state;
 SVEXTERN float starteyex, starteyey;
 SVEXTERN float eye_xyz0[3];
@@ -2024,7 +1983,7 @@ SVEXTERN float SVDECL(**p3levels256,NULL);
 SVEXTERN char SVDECL(***colorlabelp3,NULL),SVDECL(***colorlabeliso,NULL);
 SVEXTERN int SVDECL(slicefile_labelindex,-1),SVDECL(slicefile_labelindex_save,-1),SVDECL(iboundarytype,-1);
 SVEXTERN int SVDECL(iisotype,-1),iisottype;
-SVEXTERN char SVDECL(**colorlabelpart,NULL), SVDECL(**colorlabelpatch,NULL),  SVDECL(**colorlabelzone,NULL);
+SVEXTERN char SVDECL(**colorlabelpart,NULL), SVDECL(**colorlabelpatch,NULL);
 SVEXTERN float colorvaluespatch[12], colorvalueszone[12], colorvaluesp3[MAXPLOT3DVARS][12];
 SVEXTERN int SVDECL(hilight_skinny,0);
 
@@ -2034,7 +1993,6 @@ SVEXTERN int SVDECL(*plotiso,NULL);
 
 SVEXTERN int nglobal_times, SVDECL(itimes,0), SVDECL(itime_save,-1), SVDECL(itimeold,-999);
 SVEXTERN float SVDECL(*global_times,NULL), SVDECL(*times_buffer, NULL), cputimes[20];
-SVEXTERN float SVDECL(global_tbegin, 1.0), SVDECL(global_tend, 0.0);
 SVEXTERN int SVDECL(ntimes_buffer, 0);
 
 SVEXTERN int SVDECL(cpuframe,0);
@@ -2050,7 +2008,6 @@ SVEXTERN int SVDECL(have_extreme_mindata,0), SVDECL(have_extreme_maxdata,0);
 SVEXTERN int SVDECL(show_extreme_mindata,0), SVDECL(show_extreme_maxdata,0);
 SVEXTERN int SVDECL(show_extreme_mindata_save,0), SVDECL(show_extreme_maxdata_save,0);
 
-SVEXTERN int SVDECL(use_iblank,1),SVDECL(iblank_set_on_commandline,0);
 SVEXTERN int SVDECL(update_make_iblank, 0);
 
 SVEXTERN int script_index, ini_index;
@@ -2059,9 +2016,6 @@ SVEXTERN char script_renderdir[1024], script_renderfilesuffix[1024], script_rend
 SVEXTERN char SVDECL(*script_renderdir_cmd, NULL);
 SVEXTERN inifiledata first_inifile, last_inifile;
 SVEXTERN char script_filename[1024];
-#ifdef pp_LUA
-SVEXTERN char luascript_filename[MAX_LUASCRIPT_FILENAME_BUFFER];
-#endif
 SVEXTERN int SVDECL(highlight_block,-1), SVDECL(highlight_mesh,0), SVDECL(highlight_flag,2);
 SVEXTERN int SVDECL(updategetobstlabels,1);
 
@@ -2084,7 +2038,6 @@ SVEXTERN int SVDECL(toggle_on, 0);
 SVEXTERN int SVDECL(update_load_files, 0);
 SVEXTERN int SVDECL(do_threshold,0);
 SVEXTERN int ntotal_blockages;
-SVEXTERN int SVDECL(updateindexcolors,0);
 SVEXTERN int SVDECL(show_path_knots,0);
 SVEXTERN int SVDECL(show_avatar,1);
 SVEXTERN int SVDECL(tourlocus_type,0);
@@ -2099,38 +2052,17 @@ SVEXTERN float SVDECL(fire_opacity_factor,3.0),SVDECL(mass_extinct,8700.0);
 SVEXTERN float SVDECL(global_temp_min,20.0),SVDECL(global_temp_max,2000.0);
 SVEXTERN float SVDECL(global_temp_cutoff, 600.0), SVDECL(global_temp_cutoff_default, 600.0);
 SVEXTERN float SVDECL(global_hrrpuv_min,0.0),SVDECL(global_hrrpuv_max,1200.0);
-SVEXTERN float SVDECL(global_hrrpuv_cutoff, 200.0), SVDECL(global_hrrpuv_cutoff_default, 200.0);
 SVEXTERN int SVDECL(volbw,0);
 SVEXTERN float SVDECL(tourrad_avatar,0.1);
 SVEXTERN int SVDECL(dirtycircletour,0);
-
-#ifdef INMAIN
-SVEXTERN tour_collection tourcoll = {.ntourinfo = 0,
-                                     .tourinfo = NULL,
-                                     .tour_ntimes = 1000,
-                                     .tour_t = NULL,
-                                     .tour_t2 = NULL,
-                                     .tour_dist = NULL,
-                                     .tour_dist2 = NULL,
-                                     .tour_dist3 = NULL,
-                                     .tour_tstart = 0.0,
-                                     .tour_tstop = 100.0
-                                     };
-#else
-SVEXTERN tour_collection tourcoll;
-#endif
 
 SVEXTERN int SVDECL(selectedtour_index, TOURINDEX_MANUAL), SVDECL(selectedtour_index_old, TOURINDEX_MANUAL), SVDECL(selectedtour_index_ini, TOURINDEX_MANUAL);
 SVEXTERN int SVDECL(update_selectedtour_index,0);
 SVEXTERN int SVDECL(viewtourfrompath,0),SVDECL(viewalltours,0),SVDECL(viewanytours,0),SVDECL(edittour,0);
 
 SVEXTERN int SVDECL(have_animate_blockages, 0), SVDECL(animate_blockages, 0);
-SVEXTERN xbdata SVDECL(*obstinfo, NULL);
-SVEXTERN int SVDECL(nobstinfo, 0);
 SVEXTERN selectdata SVDECL(*selectfaceinfo,NULL);
 SVEXTERN blockagedata SVDECL(**selectblockinfo,NULL);
-SVEXTERN tickdata SVDECL(*tickinfo,NULL);
-SVEXTERN int SVDECL(ntickinfo,0),SVDECL(ntickinfo_smv,0);
 SVEXTERN int SVDECL(visFDSticks,0);
 SVEXTERN float user_tick_origin[3], user_tick_max[3], user_tick_min[3], user_tick_step[3], user_tick_length, user_tick_width;
 SVEXTERN float user_tick_direction;
@@ -2141,8 +2073,6 @@ SVEXTERN int SVDECL(visCadTextures,1), SVDECL(visTerrainTexture,1);
 SVEXTERN int SVDECL(viscolorbarpath,0);
 SVEXTERN int SVDECL(*sortedblocklist,NULL),SVDECL(*changed_idlist,NULL),SVDECL(nchanged_idlist,0);
 SVEXTERN int SVDECL(nselectblocks,0);
-SVEXTERN surfdata SVDECL(*surfinfo,NULL),sdefault,v_surfacedefault,e_surfacedefault;
-SVEXTERN int nsurfinfo;
 #ifdef INMAIN
 SVEXTERN int surface_indices[7]={0,0,0,0,0,0};
 #else
@@ -2150,8 +2080,7 @@ SVEXTERN int surface_indices[7];
 #endif
 SVEXTERN int surface_indices_bak[7];
 SVEXTERN int SVDECL(wall_case,0);
-SVEXTERN surfdata SVDECL(*surfacedefault,NULL), SVDECL(*vent_surfacedefault,NULL), SVDECL(*exterior_surfacedefault,NULL);
-SVEXTERN char surfacedefaultlabel[256];
+SVEXTERN surfdata SVDECL(*surfacedefault,NULL), SVDECL(*vent_surfacedefault,NULL);
 SVEXTERN int ntotalfaces;
 SVEXTERN colordata SVDECL(*firstcolor,NULL);
 SVEXTERN texturedata SVDECL(*textureinfo,NULL), SVDECL(*terrain_textures,NULL);
@@ -2175,15 +2104,10 @@ SVEXTERN float xclip_max, yclip_max, zclip_max;
 SVEXTERN float SVDECL(nearclip, 0.001), SVDECL(farclip, 3.0);
 SVEXTERN int SVDECL(updateclipvals, 0);
 SVEXTERN int SVDECL(updateUpdateFrameRateMenu,0);
-SVEXTERN int SVDECL(ntextureinfo,0),ntextures_loaded_used, SVDECL(nterrain_textures, 0), SVDECL(iterrain_textures,0);
+SVEXTERN int ntextures_loaded_used, SVDECL(iterrain_textures,0);
 SVEXTERN int SVDECL(nskyboxinfo,0);
 SVEXTERN skyboxdata SVDECL(*skyboxinfo,NULL);
-SVEXTERN firedata SVDECL(*fireinfo,NULL);
-SVEXTERN roomdata SVDECL(*roominfo,NULL);
-SVEXTERN zventdata SVDECL(*zventinfo,NULL);
-SVEXTERN zonedata SVDECL(*zoneinfo,NULL);
 SVEXTERN zonedata SVDECL(*activezone,NULL);
-SVEXTERN partdata SVDECL(*partinfo,NULL);
 SVEXTERN int SVDECL(update_screensize,0);
 SVEXTERN int SVDECL(part5show,1);
 SVEXTERN int SVDECL(streak5show,0),streak5value, SVDECL(streak5step,0), SVDECL(showstreakhead,1);
@@ -2194,9 +2118,7 @@ SVEXTERN float streak_rvalue[8]={0.25,0.5,1.0,2.0,4.0,8.0,16.0,32.0};
 SVEXTERN float streak_rvalue[8];
 #endif
 SVEXTERN int SVDECL(streak_index,-1), SVDECL(update_streaks,0);
-SVEXTERN float SVDECL(float_streak5value,0.0);
-SVEXTERN partclassdata SVDECL(*partclassinfo,NULL);
-SVEXTERN int SVDECL(npartclassinfo,0);
+SVEXTERN float SVDECL(float_streak5value,0.0);;
 SVEXTERN partpropdata SVDECL(*part5propinfo,NULL), SVDECL(*current_property,NULL);
 SVEXTERN int SVDECL(npart5prop,0),ipart5prop,ipart5prop_old;
 SVEXTERN int SVDECL(global_prop_index,-1);
@@ -2212,7 +2134,8 @@ SVEXTERN int SVDECL(nsliceboundsinfo, 0), SVDECL(npatchboundsinfo, 0);
 SVEXTERN camdata SVDECL(*caminfo,NULL);
 SVEXTERN outlinedata SVDECL(*outlineinfo,NULL);
 SVEXTERN int SVDECL(noutlineinfo,0);
-SVEXTERN int SVDECL(*sliceorderindex,NULL),SVDECL(*vsliceorderindex,NULL),SVDECL(*partorderindex,NULL);
+SVEXTERN int SVDECL(*sliceorderindex,NULL),SVDECL(*vsliceorderindex,NULL);
+SVEXTERN int SVDECL(*partorderindex,NULL);
 SVEXTERN int SVDECL(*patchorderindex,NULL),SVDECL(*isoorderindex,NULL),SVDECL(*plot3dorderindex,NULL);
 SVEXTERN int SVDECL(showfiles,0);
 SVEXTERN cpp_boundsdata SVDECL(*slicebounds_cpp, NULL), SVDECL(*partbounds_cpp, NULL), SVDECL(*patchbounds_cpp, NULL), SVDECL(*plot3dbounds_cpp, NULL);
@@ -2226,15 +2149,11 @@ SVEXTERN boundsdata SVDECL(*hvacductbounds, NULL), SVDECL(*hvacnodebounds, NULL)
 SVEXTERN int SVDECL(nhvacductbounds, 0), SVDECL(nhvacnodebounds, 0);
 SVEXTERN int SVDECL(hvac_maxcells, 0), SVDECL(hvac_n_ducts, 0);
 
-SVEXTERN slice_collection SVDECL(slicecoll, {0});
-
 SVEXTERN int force_redisplay;
 SVEXTERN int glui_setp3min, glui_setp3max;
 SVEXTERN int setp3chopmin_temp, setp3chopmax_temp;
 SVEXTERN float p3chopmin_temp, p3chopmax_temp;
 SVEXTERN float glui_p3min, glui_p3max;
-
-SVEXTERN smoke3d_collection SVDECL(smoke3dcoll,{0});
 
 SVEXTERN int SVDECL(bound_slice_init, 1);
 SVEXTERN int SVDECL(bound_part_init, 1);
@@ -2257,7 +2176,7 @@ SVEXTERN int SVDECL(use_opacity_multiplier, 0), SVDECL(use_opacity_multiplier_in
 SVEXTERN int SVDECL(use_opacity_ini, 0);
 
 SVEXTERN int SVDECL(update_smokefire_colors, 0);
-SVEXTERN float SVDECL(fire_halfdepth,0.3), SVDECL(fire_halfdepth2, 0.3), SVDECL(smoke_albedo, 0.3), SVDECL(smoke_albedo_base, 0.3);
+SVEXTERN float SVDECL(fire_halfdepth,0.3), SVDECL(fire_halfdepth2, 0.3);
 SVEXTERN float SVDECL(co2_halfdepth, 10.0);
 
 SVEXTERN int SVDECL(co2_colormap_type, CO2_COLORBAR);
@@ -2275,26 +2194,19 @@ SVEXTERN int SVDECL(visMAINmenus,0);
 SVEXTERN int SVDECL(ijkbarmax,5);
 SVEXTERN int SVDECL(blockage_as_input,0), SVDECL(blockage_snapped,1);
 SVEXTERN int SVDECL(show_cad_and_grid,0);
-SVEXTERN labels_collection SVDECL(labelscoll, {0});
-SVEXTERN int SVDECL(*isotypes,NULL), SVDECL(*boundarytypes,NULL);
-SVEXTERN plot3ddata SVDECL(*plot3dinfo,NULL);
 SVEXTERN int SVDECL(iplot3dtimelist, -1), SVDECL(nplot3dtimelist, 0);
 SVEXTERN float SVDECL(*plot3dtimelist,NULL);
-SVEXTERN patchdata SVDECL(*patchinfo,NULL);
-SVEXTERN isodata SVDECL(*isoinfo,NULL);
 
 SVEXTERN blockagedata SVDECL(*bchighlight,NULL),SVDECL(*bchighlight_old,NULL);
-SVEXTERN cadgeom_collection SVDECL(*cadgeomcoll,NULL);
 
 SVEXTERN int SVDECL(smokediff,0);
 SVEXTERN int SVDECL(buffertype,DOUBLE_BUFFER);
 SVEXTERN int SVDECL(opengldefined,0);
 SVEXTERN int SVDECL(restart_time,0);
-SVEXTERN int nisotypes;
 SVEXTERN int SVDECL(*isosubmenus,NULL), nisosubmenus;
 SVEXTERN int SVDECL(*loadpatchsubmenus,NULL), nloadpatchsubmenus;
-SVEXTERN int nboundarytypes;
 SVEXTERN char SVDECL(**patchlabellist,NULL);
+SVEXTERN char SVDECL(*socket_path,NULL);
 SVEXTERN int SVDECL(*patchlabellist_index,NULL);
 SVEXTERN int SVDECL(*isoindex,NULL);
 

--- a/Source/smokeview/smv_geometry.c
+++ b/Source/smokeview/smv_geometry.c
@@ -290,11 +290,11 @@ void UpdatePlotxyzAll(void){
   float *xp, *yp, *zp;
   float dxyz_min=100000.0;
 
-  for(i = 0;i < nmeshes;i++){
+  for(i = 0;i < global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     float *xplt, *yplt, *zplt, *dxyz;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     xplt = meshi->xplt_orig;
     yplt = meshi->yplt_orig;
     zplt = meshi->zplt_orig;
@@ -310,10 +310,10 @@ void UpdatePlotxyzAll(void){
   nplotx_all=0;
   nploty_all=0;
   nplotz_all=0;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     nplotx_all+=(meshi->ibar+1);
     nploty_all+=(meshi->jbar+1);
     nplotz_all+=(meshi->kbar+1);
@@ -342,11 +342,11 @@ void UpdatePlotxyzAll(void){
   xp = plotx_all;
   yp = ploty_all;
   zp = plotz_all;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     for(j=0;j<meshi->ibar+1;j++){
       *xp++ = meshi->xplt[j];
     }
@@ -379,11 +379,11 @@ void UpdatePlotxyzAll(void){
   RemoveDupFloats(&plotx_all,&nplotx_all,&iplotx_all,dxyz_min);
   RemoveDupFloats(&ploty_all,&nploty_all,&iploty_all,dxyz_min);
   RemoveDupFloats(&plotz_all,&nplotz_all,&iplotz_all,dxyz_min);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int j;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     NewMemory((void **)&meshi->iplotx_all,nplotx_all*sizeof(int));
     NewMemory((void **)&meshi->iploty_all,nploty_all*sizeof(int));
     NewMemory((void **)&meshi->iplotz_all,nplotz_all*sizeof(int));
@@ -419,30 +419,30 @@ void UpdatePlotxyzAll(void){
       meshi->iplotz_all[j]=ival;
     }
   }
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     int ival;
 
-    meshi = meshinfo+i;
-    ival = ClosestNodeIndex(xbar/2.0, meshi->xplt, meshi->ibar+1);
+    meshi = global_scase.meshescoll.meshinfo+i;
+    ival = ClosestNodeIndex(global_scase.xbar/2.0, meshi->xplt, meshi->ibar+1);
     if(ival<0)continue;
     iplotx_all = ival;
   }
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     int ival;
 
-    meshi = meshinfo+i;
-    ival = ClosestNodeIndex(ybar/2.0, meshi->yplt, meshi->jbar+1);
+    meshi = global_scase.meshescoll.meshinfo+i;
+    ival = ClosestNodeIndex(global_scase.ybar/2.0, meshi->yplt, meshi->jbar+1);
     if(ival<0)continue;
     iploty_all = ival;
   }
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     int ival;
 
-    meshi = meshinfo+i;
-    ival = ClosestNodeIndex(zbar/2.0, meshi->zplt, meshi->kbar+1);
+    meshi = global_scase.meshescoll.meshinfo+i;
+    ival = ClosestNodeIndex(global_scase.zbar/2.0, meshi->zplt, meshi->kbar+1);
     if(ival<0)continue;
     iplotz_all = ival;
   }
@@ -478,10 +478,10 @@ int InExterior(float *xyz){
   if(x < xbar0FDS || x > xbarFDS)return 1;
   if(y < ybar0FDS || y > ybarFDS)return 1;
   if(z < zbar0FDS || z > zbarFDS)return 1;
-  for(i = 0;i < nmeshes;i++){
+  for(i = 0;i < global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     if(x >= meshi->xplt_orig[0] && x <= meshi->xplt_orig[meshi->ibar] &&
        y >= meshi->yplt_orig[0] && y <= meshi->yplt_orig[meshi->jbar] &&
        z >= meshi->zplt_orig[0] && z <= meshi->zplt_orig[meshi->kbar]){
@@ -496,12 +496,12 @@ int InExterior(float *xyz){
 meshdata *GetMesh(float *xyz){
   int i;
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int ibar, jbar, kbar;
     float *xplt, *yplt, *zplt;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
 
     ibar = meshi->ibar;
     jbar = meshi->jbar;
@@ -526,12 +526,12 @@ meshdata *GetMesh(float *xyz){
 int OnMeshBoundary(float *xyz){
   int i;
 
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     int ibar, jbar, kbar;
     float *xplt, *yplt, *zplt;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
 
     ibar = meshi->ibar;
     jbar = meshi->jbar;
@@ -589,12 +589,12 @@ int OnMeshBoundary(float *xyz){
 meshdata *GetMeshNoFail(float *xyz){
   int i;
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int ibar, jbar, kbar;
     float *xplt, *yplt, *zplt;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
 
     ibar = meshi->ibar;
     jbar = meshi->jbar;
@@ -611,12 +611,12 @@ meshdata *GetMeshNoFail(float *xyz){
       return meshi;
     }
   }
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int ibar, jbar, kbar;
     float *xplt, *yplt, *zplt;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
 
     ibar = meshi->ibar;
     jbar = meshi->jbar;
@@ -633,7 +633,7 @@ meshdata *GetMeshNoFail(float *xyz){
       return meshi;
     }
   }
-  return meshinfo;
+  return global_scase.meshescoll.meshinfo;
 }
 
 /* ------------------ ExtractFrustum ------------------------ */
@@ -1042,8 +1042,8 @@ float GetBlockageDistance(float x, float y, float z){
   float view_height;
   char *iblank_cell;
 
-  for(i=0;i<nmeshes;i++){
-    meshi = meshinfo+i;
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
+    meshi = global_scase.meshescoll.meshinfo+i;
 
     iblank_cell = meshi->c_iblank_cell;
 
@@ -1095,20 +1095,20 @@ int MakeIBlankCarve(void){
   char *ib_embed;
 
   n_embedded_meshes=0;
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     meshi->c_iblank_embed=NULL;
   }
-  if(nmeshes==1)return 0;
+  if(global_scase.meshescoll.nmeshes==1)return 0;
 
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int n_embedded;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     ibar = meshi->ibar;
     jbar = meshi->jbar;
     kbar = meshi->kbar;
@@ -1123,11 +1123,11 @@ int MakeIBlankCarve(void){
     // check to see if there are any embedded meshes
 
     n_embedded=0;
-    for(j=0;j<nmeshes;j++){
+    for(j=0;j<global_scase.meshescoll.nmeshes;j++){
       meshdata *meshj;
 
       if(i==j)continue;
-      meshj = meshinfo + j;
+      meshj = global_scase.meshescoll.meshinfo + j;
       if(
         meshi->boxmin[0]<=meshj->boxmin[0]&&meshj->boxmax[0]<=meshi->boxmax[0]&&
         meshi->boxmin[1]<=meshj->boxmin[1]&&meshj->boxmax[1]<=meshi->boxmax[1]&&
@@ -1140,7 +1140,7 @@ int MakeIBlankCarve(void){
     if(n_embedded==0)continue;
 
     ib_embed=NULL;
-    if(use_iblank==1){
+    if(global_scase.use_iblank==1){
       if(NewMemory((void **)&ib_embed,ijksize*sizeof(char))==0)return 1;
     }
     meshi->c_iblank_embed=ib_embed;
@@ -1148,14 +1148,14 @@ int MakeIBlankCarve(void){
     for(j=0;j<ijksize;j++){
       ib_embed[j]=EMBED_NO;
     }
-    for(j=0;j<nmeshes;j++){
+    for(j=0;j<global_scase.meshescoll.nmeshes;j++){
       meshdata *meshj;
       int i1, i2, jj1, j2, k1, k2;
       int ii, jj, kk;
       float *xplt, *yplt, *zplt;
 
       if(i==j)continue;
-      meshj = meshinfo + j;
+      meshj = global_scase.meshescoll.meshinfo + j;
       // meshj is embedded inside meshi
       if(
         meshi->boxmin[0]>meshj->boxmin[0]||meshj->boxmax[0]>meshi->boxmax[0]||
@@ -1350,8 +1350,8 @@ void SetHiddenBlockages(meshdata *meshi){
 int MakeIBlank(void){
   int ig;
 
-  if(use_iblank==0)return 0;
-  for(ig=0;ig<nmeshes;ig++){
+  if(global_scase.use_iblank==0)return 0;
+  for(ig=0;ig<global_scase.meshescoll.nmeshes;ig++){
     meshdata *meshi;
     int nx, ny, nxy, ibarjbar;
     int ibar,jbar,kbar;
@@ -1360,7 +1360,7 @@ int MakeIBlank(void){
     int ii,ijksize;
     int i,j,k;
 
-    meshi = meshinfo+ig;
+    meshi = global_scase.meshescoll.meshinfo+ig;
 
     ibar = meshi->ibar;
     jbar = meshi->jbar;
@@ -1544,10 +1544,10 @@ int MakeIBlank(void){
       }
     }
   }
-  for(ig = 0; ig < nmeshes; ig++){
+  for(ig = 0; ig < global_scase.meshescoll.nmeshes; ig++){
     meshdata *meshi;
 
-    meshi = meshinfo + ig;
+    meshi = global_scase.meshescoll.meshinfo + ig;
     meshi->c_iblank_node_temp = meshi->c_iblank_node0_temp;
     meshi->c_iblank_cell_temp = meshi->c_iblank_cell0_temp;
     meshi->f_iblank_cell_temp = meshi->f_iblank_cell0_temp;
@@ -1598,9 +1598,9 @@ void InitClip(void){
   clip_i=0;
   clip_j=0;
   clip_k=0;
-  clip_I=0;
-  clip_J=0;
-  clip_K=0;
+  global_scase.clip_I=0;
+  global_scase.clip_J=0;
+  global_scase.clip_K=0;
 
   stepclip_xmin=0,stepclip_ymin=0,stepclip_zmin=0;
   stepclip_xmax=0,stepclip_ymax=0,stepclip_zmax=0;

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -39,7 +39,7 @@ void InitDefaultCameras(void){
   }
 
   strcpy(name_external, "external");
-  if(is_terrain_case==1){
+  if(global_scase.is_terrain_case==1){
     CopyCamera(camera_external, camera_defaults[5]);
     strcpy(camera_external->name, name_external);
   }
@@ -71,14 +71,14 @@ void InitMisc(void){
   NewMemory((void **)&plotiso, MAXPLOT3DVARS*sizeof(int));
 
   if(colorbar_vals==NULL){
-    NewMemory((void **)&colorbar_vals, nrgb*sizeof(float));
+    NewMemory((void **)&colorbar_vals, global_scase.nrgb*sizeof(float));
   }
   if(colorbar_exponents==NULL){
-    NewMemory((void **)&colorbar_exponents, nrgb*sizeof(int));
+    NewMemory((void **)&colorbar_exponents, global_scase.nrgb*sizeof(int));
   }
   if(colorbar_labels==NULL){
-    NewMemory((void **)&colorbar_labels, nrgb*sizeof(char *));
-    for(i = 0; i<nrgb; i++){
+    NewMemory((void **)&colorbar_labels, global_scase.nrgb*sizeof(char *));
+    for(i = 0; i<global_scase.nrgb; i++){
       NewMemory((void **)&colorbar_labels[i], 256);
     }
   }
@@ -92,7 +92,7 @@ void InitMisc(void){
     }
   }
   for(i=0;i<MAXPLOT3DVARS;i++){
-    plotiso[i]=nrgb/2;
+    plotiso[i]=global_scase.nrgb/2;
   }
 
   for(i=0;i<16;i++){
@@ -102,26 +102,26 @@ void InitMisc(void){
     modelview_setup[i+4*i]=1.0;
   }
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi=meshinfo+i;
-    InitContour(meshi->plot3dcontour1,rgb_plot3d_contour,nrgb);
-    InitContour(meshi->plot3dcontour2,rgb_plot3d_contour,nrgb);
-    InitContour(meshi->plot3dcontour3,rgb_plot3d_contour,nrgb);
+    meshi=global_scase.meshescoll.meshinfo+i;
+    InitContour(meshi->plot3dcontour1,rgb_plot3d_contour,global_scase.nrgb);
+    InitContour(meshi->plot3dcontour2,rgb_plot3d_contour,global_scase.nrgb);
+    InitContour(meshi->plot3dcontour3,rgb_plot3d_contour,global_scase.nrgb);
   }
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     meshi->currentsurf->defined=0;
     meshi->currentsurf2->defined=0;
   }
 
   /* initialize box sizes, lighting parameters */
 
-  xyzbox = MAX(MAX(xbar,ybar),zbar);
+  xyzbox = MAX(MAX(global_scase.xbar,global_scase.ybar),global_scase.zbar);
 
   InitDefaultCameras();
 
@@ -200,10 +200,10 @@ void ReadBoundINI(void){
       TrimBack(buffer2);
       buffer2ptr = TrimFront(buffer2);
       lenbuffer2 = strlen(buffer2ptr);
-      for(i = 0; i < npatchinfo; i++){
+      for(i = 0; i < global_scase.npatchinfo; i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(lenbuffer2 != 0 &&
           strcmp(patchi->label.shortlabel, buffer2ptr) == 0 &&
           patchi->patch_filetype == filetype){
@@ -230,8 +230,8 @@ int SetupCase(char *filename){
 
   return_code=-1;
   FREEMEMORY(part_globalbound_filename);
-  NewMemory((void **)&part_globalbound_filename, strlen(fdsprefix)+strlen(".prt.gbnd")+1);
-  STRCPY(part_globalbound_filename, fdsprefix);
+  NewMemory((void **)&part_globalbound_filename, strlen(global_scase.fdsprefix)+strlen(".prt.gbnd")+1);
+  STRCPY(part_globalbound_filename, global_scase.fdsprefix);
   STRCAT(part_globalbound_filename, ".prt.gbnd");
   char *smokeview_scratchdir = GetUserConfigDir();
   part_globalbound_filename = GetFileName(smokeview_scratchdir, part_globalbound_filename, NOT_FORCE_IN_DIR);
@@ -244,22 +244,22 @@ int SetupCase(char *filename){
     trainer_mode=1;
     trainer_active=1;
     if(strcmp(input_filename_ext,".svd")==0){
-      input_file=trainer_filename;
+      input_file=global_scase.paths.trainer_filename;
     }
     else if(strcmp(input_filename_ext,".smt")==0){
-      input_file=test_filename;
+      input_file=global_scase.paths.test_filename;
     }
   }
   {
     bufferstreamdata *smv_streaminfo = NULL;
 
     PRINTF("reading  %s\n", input_file);
-    if(FileExistsOrig(smvzip_filename) == 1){
+    if(FileExistsOrig(global_scase.paths.smvzip_filename) == 1){
       lookfor_compressed_files = 1;
     }
     smv_streaminfo = GetSMVBuffer(input_file);
-    smv_streaminfo = AppendFileBuffer(smv_streaminfo, iso_filename);
-    smv_streaminfo = AppendFileBuffer(smv_streaminfo, fedsmv_filename);
+    smv_streaminfo = AppendFileBuffer(smv_streaminfo, global_scase.paths.iso_filename);
+    smv_streaminfo = AppendFileBuffer(smv_streaminfo, global_scase.paths.fedsmv_filename);
 
     return_code = ReadSMV(smv_streaminfo);
     if(smv_streaminfo!=NULL){
@@ -318,7 +318,7 @@ int SetupCase(char *filename){
   FREEMEMORY(smv_bindir);
   PRINT_TIMER(timer_start, "InitTranslate");
 
-  if(tourcoll.ntourinfo==0)SetupTour();
+  if(global_scase.tourcoll.ntourinfo==0)SetupTour();
   InitRolloutList();
   GLUIColorbarSetup(mainwindow_id);
   GLUIMotionSetup(mainwindow_id);
@@ -341,7 +341,7 @@ int SetupCase(char *filename){
 
   SetMainWindow();
   glutShowWindow();
-  glutSetWindowTitle(fdsprefix);
+  glutSetWindowTitle(global_scase.fdsprefix);
   InitMisc();
   GLUITrainerSetup(mainwindow_id);
   glutDetachMenu(GLUT_RIGHT_BUTTON);
@@ -356,7 +356,7 @@ int SetupCase(char *filename){
     GLUIShowAlert();
   }
   // initialize info header
-  initialiseInfoHeader(&titleinfo, release_title, smv_githash, fds_githash, chidfilebase, fds_title);
+  initialiseInfoHeader(&titleinfo, release_title, smv_githash, global_scase.fds_githash, chidfilebase, fds_title);
   PRINT_TIMER(timer_start, "glut routines");
   return 0;
 }
@@ -370,7 +370,7 @@ int GetScreenHeight(void){
   int screen_height=-1;
 
   strcpy(command,"system_profiler SPDisplaysDataType | grep Resolution | awk '{print $4}' | tail -1 >& ");
-  strcpy(height_file, fdsprefix);
+  strcpy(height_file, global_scase.fdsprefix);
   strcat(height_file, ".hgt");
   char *smokeview_scratchdir = GetUserConfigDir();
   full_height_file = GetFileName(smokeview_scratchdir, height_file, NOT_FORCE_IN_DIR);
@@ -399,6 +399,7 @@ void InitStartupDirs(void){
   if(FileExistsOrig(smokeview_scratchdir)==NO){
     MKDIR(smokeview_scratchdir);
   }
+  FREEMEMORY(smokeview_scratchdir);
 
   // Create the colorbar directory if it doesn't already exist.
   char *colorbars_user_dir = GetUserColorbarDirPath();
@@ -516,21 +517,21 @@ void SetupGlut(int argc, char **argv){
 
   NewMemory((void **)&rgbptr,MAXRGB*sizeof(float *));
   for(i=0;i<MAXRGB;i++){
-    rgbptr[i]=&rgb[i][0];
+    rgbptr[i]=&global_scase.rgb[i][0];
   }
   NewMemory((void **)&rgb_plot3d_contour,MAXRGB*sizeof(float *));
-  for(i=0;i<nrgb-2;i++){
+  for(i=0;i<global_scase.nrgb-2;i++){
     int ii;
     float factor;
 
-    factor=256.0/(float)(nrgb-2);
+    factor=256.0/(float)(global_scase.nrgb-2);
 
     ii = factor*((float)i+0.5);
     if(ii>255)ii=255;
     rgb_plot3d_contour[i]=&rgb_full[ii][0];
   }
-  rgb_plot3d_contour[nrgb-2]=&rgb_full[0][0];
-  rgb_plot3d_contour[nrgb-1]=&rgb_full[255][0];
+  rgb_plot3d_contour[global_scase.nrgb-2]=&rgb_full[0][0];
+  rgb_plot3d_contour[global_scase.nrgb-1]=&rgb_full[255][0];
 }
 
 /* ------------------ GetOpenGLVersion ------------------------ */
@@ -687,10 +688,10 @@ void InitOpenGL(int option){
  void Set3DSmokeStartup(void){
    int i;
 
-    for(i=0;i<slicecoll.nvsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo + i;
+      vslicei = global_scase.slicecoll.vsliceinfo + i;
 
       if(vslicei->loaded==1){
         vslicei->autoload=1;
@@ -699,10 +700,10 @@ void InitOpenGL(int option){
         vslicei->autoload=0;
       }
     }
-    for(i=0;i<npartinfo;i++){
+    for(i=0;i<global_scase.npartinfo;i++){
       partdata *parti;
 
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
 
       if(parti->loaded==1){
         parti->autoload=1;
@@ -711,10 +712,10 @@ void InitOpenGL(int option){
         parti->autoload=0;
       }
     }
-    for(i=0;i<nplot3dinfo;i++){
+    for(i=0;i<global_scase.nplot3dinfo;i++){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
 
       if(plot3di->loaded==1){
         plot3di->autoload=1;
@@ -723,10 +724,10 @@ void InitOpenGL(int option){
         plot3di->autoload=0;
       }
     }
-    for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
+    for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
       smoke3ddata *smoke3di;
 
-      smoke3di = smoke3dcoll.smoke3dinfo + i;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
 
       if(smoke3di->loaded==1){
         smoke3di->autoload=1;
@@ -735,10 +736,10 @@ void InitOpenGL(int option){
         smoke3di->autoload=0;
       }
     }
-    for(i=0;i<npatchinfo;i++){
+    for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
 
-      patchi = patchinfo + i;
+      patchi = global_scase.patchinfo + i;
 
       if(patchi->loaded==1){
         patchi->autoload=1;
@@ -747,10 +748,10 @@ void InitOpenGL(int option){
         patchi->autoload=0;
       }
     }
-    for(i=0;i<nisoinfo;i++){
+    for(i=0;i<global_scase.nisoinfo;i++){
       isodata *isoi;
 
-      isoi = isoinfo + i;
+      isoi = global_scase.isoinfo + i;
 
       if(isoi->loaded==1){
         isoi->autoload=1;
@@ -759,10 +760,10 @@ void InitOpenGL(int option){
         isoi->autoload=0;
       }
     }
-    for(i=0;i<slicecoll.nsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
 
       if(slicei->loaded==1){
         slicei->autoload=1;
@@ -785,20 +786,20 @@ void InitOpenGL(int option){
    // startup particle
 
    nstartup=0;
-   for(i=0;i<npartinfo;i++){
+   for(i=0;i<global_scase.npartinfo;i++){
       partdata *parti;
 
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
 
       if(parti->loaded==1)nstartup++;
    }
    if(nstartup!=0){
      fprintf(fileout,"PARTAUTO\n");
      fprintf(fileout," %i \n",nstartup);
-     for(i=0;i<npartinfo;i++){
+     for(i=0;i<global_scase.npartinfo;i++){
         partdata *parti;
 
-        parti = partinfo + i;
+        parti = global_scase.partinfo + i;
 
         if(parti->loaded==1)fprintf(fileout," %i\n",parti->seq_id);
      }
@@ -807,20 +808,20 @@ void InitOpenGL(int option){
    // startup plot3d
 
    nstartup=0;
-   for(i=0;i<nplot3dinfo;i++){
+   for(i=0;i<global_scase.nplot3dinfo;i++){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
 
       if(plot3di->loaded==1)nstartup++;
    }
    if(nstartup!=0){
      fprintf(fileout,"PLOT3DAUTO\n");
      fprintf(fileout," %i \n",nstartup);
-     for(i=0;i<nplot3dinfo;i++){
+     for(i=0;i<global_scase.nplot3dinfo;i++){
         plot3ddata *plot3di;
 
-        plot3di = plot3dinfo + i;
+        plot3di = global_scase.plot3dinfo + i;
 
         if(plot3di->loaded==1)fprintf(fileout," %i\n",plot3di->seq_id);
      }
@@ -829,20 +830,20 @@ void InitOpenGL(int option){
    // startup iso
 
    nstartup=0;
-   for(i=0;i<nisoinfo;i++){
+   for(i=0;i<global_scase.nisoinfo;i++){
       isodata *isoi;
 
-      isoi = isoinfo + i;
+      isoi = global_scase.isoinfo + i;
 
       if(isoi->loaded==1)nstartup++;
    }
    if(nstartup!=0){
      fprintf(fileout,"ISOAUTO\n");
      fprintf(fileout," %i \n",nstartup);
-     for(i=0;i<nisoinfo;i++){
+     for(i=0;i<global_scase.nisoinfo;i++){
         isodata *isoi;
 
-        isoi = isoinfo + i;
+        isoi = global_scase.isoinfo + i;
 
         if(isoi->loaded==1)fprintf(fileout," %i\n",isoi->seq_id);
      }
@@ -851,20 +852,20 @@ void InitOpenGL(int option){
    // startup vslice
 
    nstartup=0;
-   for(i=0;i<slicecoll.nvsliceinfo;i++){
+   for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo + i;
+      vslicei = global_scase.slicecoll.vsliceinfo + i;
 
       if(vslicei->loaded==1)nstartup++;
    }
    if(nstartup!=0){
      fprintf(fileout,"VSLICEAUTO\n");
      fprintf(fileout," %i \n",nstartup);
-     for(i=0;i<slicecoll.nvsliceinfo;i++){
+     for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
         vslicedata *vslicei;
 
-        vslicei = slicecoll.vsliceinfo + i;
+        vslicei = global_scase.slicecoll.vsliceinfo + i;
 
         if(vslicei->loaded==1)fprintf(fileout," %i\n",vslicei->seq_id);
      }
@@ -873,20 +874,20 @@ void InitOpenGL(int option){
    // startup slice
 
    nstartup=0;
-   for(i=0;i<slicecoll.nsliceinfo;i++){
+   for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
 
       if(slicei->loaded==1)nstartup++;
    }
    if(nstartup!=0){
      fprintf(fileout,"SLICEAUTO\n");
      fprintf(fileout," %i \n",nstartup);
-     for(i=0;i<slicecoll.nsliceinfo;i++){
+     for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         if(slicei->loaded==1)fprintf(fileout," %i\n",slicei->seq_id);
      }
    }
@@ -894,10 +895,10 @@ void InitOpenGL(int option){
    // startup mslice
 
    nstartup=0;
-   for(i=0;i<slicecoll.nmultisliceinfo;i++){
+   for(i=0;i<global_scase.slicecoll.nmultisliceinfo;i++){
       multislicedata *mslicei;
 
-      mslicei = slicecoll.multisliceinfo + i;
+      mslicei = global_scase.slicecoll.multisliceinfo + i;
       mslicei->loadable = 1;
 
       if(mslicei->loaded==1)nstartup++;
@@ -905,10 +906,10 @@ void InitOpenGL(int option){
    if(nstartup!=0){
      fprintf(fileout,"MSLICEAUTO\n");
      fprintf(fileout," %i \n",nstartup);
-     for(i=0;i<slicecoll.nmultisliceinfo;i++){
+     for(i=0;i<global_scase.slicecoll.nmultisliceinfo;i++){
         multislicedata *mslicei;
 
-        mslicei = slicecoll.multisliceinfo + i;
+        mslicei = global_scase.slicecoll.multisliceinfo + i;
         mslicei->loadable = 1;
         if(mslicei->loaded==1)fprintf(fileout," %i\n",i);
      }
@@ -917,20 +918,20 @@ void InitOpenGL(int option){
    // startup smoke
 
    nstartup=0;
-   for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
+   for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
       smoke3ddata *smoke3di;
 
-      smoke3di = smoke3dcoll.smoke3dinfo + i;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
 
       if(smoke3di->loaded==1)nstartup++;
    }
    if(nstartup!=0){
      fprintf(fileout,"S3DAUTO\n");
      fprintf(fileout," %i \n",nstartup);
-     for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
+     for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
         smoke3ddata *smoke3di;
 
-        smoke3di = smoke3dcoll.smoke3dinfo + i;
+        smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
 
         if(smoke3di->loaded==1)fprintf(fileout," %i\n",smoke3di->seq_id);
      }
@@ -939,20 +940,20 @@ void InitOpenGL(int option){
    // startup patch
 
    nstartup=0;
-   for(i=0;i<npatchinfo;i++){
+   for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
 
-      patchi = patchinfo + i;
+      patchi = global_scase.patchinfo + i;
 
       if(patchi->loaded==1)nstartup++;
    }
    if(nstartup!=0){
      fprintf(fileout,"PATCHAUTO\n");
      fprintf(fileout," %i \n",nstartup);
-     for(i=0;i<npatchinfo;i++){
+     for(i=0;i<global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
 
         if(patchi->loaded==1)fprintf(fileout," %i\n",patchi->seq_id);
      }
@@ -965,10 +966,10 @@ void InitOpenGL(int option){
 
   void GetStartupPart(int seq_id){
     int i;
-    for(i=0;i<npartinfo;i++){
+    for(i=0;i<global_scase.npartinfo;i++){
       partdata *parti;
 
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
       if(parti->seq_id==seq_id){
         parti->autoload=1;
         return;
@@ -980,10 +981,10 @@ void InitOpenGL(int option){
 
   void GetStartupPlot3D(int seq_id){
     int i;
-    for(i=0;i<nplot3dinfo;i++){
+    for(i=0;i<global_scase.nplot3dinfo;i++){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
       if(plot3di->seq_id==seq_id){
         plot3di->autoload=1;
         return;
@@ -995,10 +996,10 @@ void InitOpenGL(int option){
 
   void GetStartupBoundary(int seq_id){
     int i;
-    for(i=0;i<npatchinfo;i++){
+    for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
 
-      patchi = patchinfo + i;
+      patchi = global_scase.patchinfo + i;
       if(patchi->seq_id==seq_id){
         patchi->autoload=1;
         return;
@@ -1010,10 +1011,10 @@ void InitOpenGL(int option){
 
   void GetStartupSmoke(int seq_id){
     int i;
-    for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
+    for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
       smoke3ddata *smoke3di;
 
-      smoke3di = smoke3dcoll.smoke3dinfo + i;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
 
       if(smoke3di->seq_id==seq_id){
         smoke3di->autoload=1;
@@ -1027,10 +1028,10 @@ void InitOpenGL(int option){
 
   void GetStartupISO(int seq_id){
     int i;
-    for(i=0;i<nisoinfo;i++){
+    for(i=0;i<global_scase.nisoinfo;i++){
       isodata *isoi;
 
-      isoi = isoinfo + i;
+      isoi = global_scase.isoinfo + i;
 
       if(isoi->seq_id==seq_id){
         isoi->autoload=1;
@@ -1043,10 +1044,10 @@ void InitOpenGL(int option){
 
   void GetStartupSlice(int seq_id){
     int i;
-    for(i=0;i<slicecoll.nsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
       slicedata *slicei;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
 
       if(slicei->seq_id==seq_id){
         slicei->autoload=1;
@@ -1059,10 +1060,10 @@ void InitOpenGL(int option){
 
   void GetStartupVSlice(int seq_id){
     int i;
-    for(i=0;i<slicecoll.nvsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo + i;
+      vslicei = global_scase.slicecoll.vsliceinfo + i;
 
       if(vslicei->seq_id==seq_id){
         vslicei->autoload=1;
@@ -1078,25 +1079,25 @@ void InitOpenGL(int option){
     int errorcode;
 
 //    GLUIShowAlert();
-    for(i = 0; i<nplot3dinfo; i++){
+    for(i = 0; i<global_scase.nplot3dinfo; i++){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo+i;
+      plot3di = global_scase.plot3dinfo+i;
       plot3di->finalize = 0;
     }
-    for(i = nplot3dinfo-1;i>=0; i--){
+    for(i = global_scase.nplot3dinfo-1;i>=0; i--){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo+i;
+      plot3di = global_scase.plot3dinfo+i;
       if(plot3di->autoload==1){
         plot3di->finalize = 1;
         break;
       }
     }
-    for(i=0;i<nplot3dinfo;i++){
+    for(i=0;i<global_scase.nplot3dinfo;i++){
       plot3ddata *plot3di;
 
-      plot3di = plot3dinfo + i;
+      plot3di = global_scase.plot3dinfo + i;
       if(plot3di->autoload==0&&plot3di->loaded==1){
         ReadPlot3D(plot3di->file,i,UNLOAD,&errorcode);
       }
@@ -1105,26 +1106,26 @@ void InitOpenGL(int option){
       }
     }
     npartframes_max=GetMinPartFrames(PARTFILE_RELOADALL);
-    for(i=0;i<npartinfo;i++){
+    for(i=0;i<global_scase.npartinfo;i++){
       partdata *parti;
 
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
       if(parti->autoload==0&&parti->loaded==1)ReadPart(parti->file, i, UNLOAD, &errorcode);
       if(parti->autoload==1)ReadPart(parti->file, i, UNLOAD, &errorcode);
     }
-    for(i=0;i<npartinfo;i++){
+    for(i=0;i<global_scase.npartinfo;i++){
       partdata *parti;
 
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
       if(parti->autoload==0&&parti->loaded==1)ReadPart(parti->file, i, UNLOAD, &errorcode);
       if(parti->autoload==1)ReadPart(parti->file, i, LOAD, &errorcode);
     }
     update_readiso_geom_wrapup = UPDATE_ISO_START_ALL;
     CancelUpdateTriangles();
-    for(i = 0; i<nisoinfo; i++){
+    for(i = 0; i<global_scase.nisoinfo; i++){
       isodata *isoi;
 
-      isoi = isoinfo + i;
+      isoi = global_scase.isoinfo + i;
       if(isoi->autoload==0&&isoi->loaded==1)ReadIso(isoi->file,i,UNLOAD,NULL,&errorcode);
       if(isoi->autoload == 1){
         ReadIso(isoi->file, i, LOAD,NULL, &errorcode);
@@ -1134,19 +1135,19 @@ void InitOpenGL(int option){
     update_readiso_geom_wrapup = UPDATE_ISO_OFF;
 
     int lastslice=0;
-    for(i = slicecoll.nvsliceinfo-1; i>=0; i--){
+    for(i = global_scase.slicecoll.nvsliceinfo-1; i>=0; i--){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo+i;
+      vslicei = global_scase.slicecoll.vsliceinfo+i;
       if(vslicei->autoload==1){
         lastslice = i;
         break;
       }
     }
-    for(i = 0; i<slicecoll.nvsliceinfo; i++){
+    for(i = 0; i<global_scase.slicecoll.nvsliceinfo; i++){
       vslicedata *vslicei;
 
-      vslicei = slicecoll.vsliceinfo + i;
+      vslicei = global_scase.slicecoll.vsliceinfo + i;
       if(vslicei->autoload==0&&vslicei->loaded==1){
         ReadVSlice(i, ALL_FRAMES, NULL, UNLOAD, DEFER_SLICECOLOR, &errorcode);
       }
@@ -1163,21 +1164,21 @@ void InitOpenGL(int option){
     {
       int last_slice;
 
-      last_slice = slicecoll.nsliceinfo - 1;
-      for(i = slicecoll.nsliceinfo-1; i >=0; i--){
+      last_slice = global_scase.slicecoll.nsliceinfo - 1;
+      for(i = global_scase.slicecoll.nsliceinfo-1; i >=0; i--){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         if((slicei->autoload == 0 && slicei->loaded == 1)||(slicei->autoload == 1 && slicei->loaded == 0)){
           last_slice = i;
           break;
         }
       }
-      for(i = 0; i < slicecoll.nsliceinfo; i++){
+      for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
         slicedata *slicei;
         int set_slicecolor;
 
-        slicei = slicecoll.sliceinfo + i;
+        slicei = global_scase.slicecoll.sliceinfo + i;
         set_slicecolor = DEFER_SLICECOLOR;
         if(i == last_slice)set_slicecolor = SET_SLICECOLOR;
         if(slicei->autoload == 0 && slicei->loaded == 1)ReadSlice(slicei->file, i, ALL_FRAMES, NULL, UNLOAD, set_slicecolor,&errorcode);
@@ -1185,17 +1186,17 @@ void InitOpenGL(int option){
         }
       }
     }
-    for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
+    for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
       smoke3ddata *smoke3di;
 
-      smoke3di = smoke3dcoll.smoke3dinfo + i;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
       if(smoke3di->autoload==0&&smoke3di->loaded==1)ReadSmoke3D(ALL_SMOKE_FRAMES, i, UNLOAD, FIRST_TIME, &errorcode);
       if(smoke3di->autoload==1)ReadSmoke3D(ALL_SMOKE_FRAMES, i, LOAD, FIRST_TIME, &errorcode);
     }
-    for(i=0;i<npatchinfo;i++){
+    for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
 
-      patchi = patchinfo + i;
+      patchi = global_scase.patchinfo + i;
       if(patchi->autoload==0&&patchi->loaded==1)ReadBoundary(i,UNLOAD,&errorcode);
       if(patchi->autoload==1)ReadBoundary(i,LOAD,&errorcode);
     }
@@ -1352,7 +1353,7 @@ void InitVars(void){
   strcpy((char *)degC,"C");
   strcpy((char *)degF,"F");
 
-  InitLabelsCollection(&labelscoll);
+  InitLabelsCollection(&global_scase.labelscoll);
 
   {
     labeldata *gl;
@@ -1507,7 +1508,7 @@ void InitVars(void){
   blocklocation=BLOCKlocation_grid;
   render_window_size=RenderWindow;
   RenderMenu(render_window_size);
-  solidlinewidth=linewidth;
+  solidlinewidth=global_scase.linewidth;
   setbwSAVE=setbw;
 
   glui_backgroundbasecolor[0] = 255 * backgroundbasecolor[0];
@@ -1546,10 +1547,10 @@ void InitVars(void){
   strcpy(ext_jpg,".jpg");
   render_filetype=PNG;
 
-  strcpy(surfacedefaultlabel,"");
+  strcpy(global_scase.surfacedefaultlabel,"");
   if(streak_index>=0)float_streak5value=streak_rvalue[streak_index];
 
-  objectscoll = CreateObjectCollection();
+  InitObjectCollection(&global_scase.objectscoll);
 
   GetTitle("Smokeview ", release_title);
   GetTitle("Smokeview ", plot3d_title);
@@ -1669,5 +1670,5 @@ void InitVars(void){
 }
 
 void FreeVars(void){
-  FreeObjectCollection(objectscoll);
+  ClearObjectCollection(&global_scase.objectscoll);
 }

--- a/Source/smokeview/unit.c
+++ b/Source/smokeview/unit.c
@@ -52,10 +52,10 @@ void SetUnitVis(void){
     uci = unitclasses + i;
     uci->visible=0;
 
-    for(j=0;j<slicecoll.nsliceinfo;j++){
+    for(j=0;j<global_scase.slicecoll.nsliceinfo;j++){
       slicedata *slicej;
 
-      slicej = slicecoll.sliceinfo + j;
+      slicej = global_scase.slicecoll.sliceinfo + j;
       if(IsUnitPresent(slicej->label.unit,uci->units->unit)==1){
         uci->visible=1;
         break;
@@ -63,10 +63,10 @@ void SetUnitVis(void){
     }
     if(uci->visible==1)continue;
 
-    for(j=0;j<npatchinfo;j++){
+    for(j=0;j<global_scase.npatchinfo;j++){
       patchdata *patchj;
 
-      patchj = patchinfo + j;
+      patchj = global_scase.patchinfo + j;
       if(IsUnitPresent(patchj->label.unit,uci->units->unit)==1){
         uci->visible=1;
         break;
@@ -74,11 +74,11 @@ void SetUnitVis(void){
     }
     if(uci->visible==1)continue;
 
-    for(j=0;j<nplot3dinfo;j++){
+    for(j=0;j<global_scase.nplot3dinfo;j++){
       plot3ddata *plot3dj;
       int n;
 
-      plot3dj = plot3dinfo + j;
+      plot3dj = global_scase.plot3dinfo + j;
       for(n=0;n<5;n++){
         if(IsUnitPresent(plot3dj->label[n].unit,uci->units->unit)==1){
           uci->visible=1;
@@ -115,10 +115,10 @@ void UpdateUnitDefs(void){
     int firstslice, firstpatch, firstplot3d, diff_index;
 
     firstpatch=1;
-    for(j=0;j<npatchinfo;j++){
+    for(j=0;j<global_scase.npatchinfo;j++){
       patchdata *patchj;
 
-      patchj = patchinfo + j;
+      patchj = global_scase.patchinfo + j;
       if(patchj->loaded==0||patchj->display==0)continue;
       if(UnitTypeMatch(patchj->label.unit,unitclasses+i)!=0)continue;
       if(firstpatch==1){
@@ -133,10 +133,10 @@ void UpdateUnitDefs(void){
     }
 
     firstslice=1;
-    for(j=0;j<slicecoll.nsliceinfo;j++){
+    for(j=0;j<global_scase.slicecoll.nsliceinfo;j++){
       slicedata *slicej;
 
-      slicej = slicecoll.sliceinfo + j;
+      slicej = global_scase.slicecoll.sliceinfo + j;
       if(slicej->loaded==0||slicej->display==0)continue;
       if(UnitTypeMatch(slicej->label.unit,unitclasses+i)!=0)continue;
       if(firstslice==1){
@@ -151,11 +151,11 @@ void UpdateUnitDefs(void){
     }
 
     firstplot3d=1;
-    for(j=0;j<nplot3dinfo;j++){
+    for(j=0;j<global_scase.nplot3dinfo;j++){
       plot3ddata *plot3dj;
       int n;
 
-      plot3dj = plot3dinfo + j;
+      plot3dj = global_scase.plot3dinfo + j;
       if(plot3dj->loaded==0||plot3dj->display==0)continue;
       for(n=0;n<5;n++){
         if(UnitTypeMatch(plot3dj->label[n].unit,unitclasses+i)!=0)continue;

--- a/Source/smokeview/update.c
+++ b/Source/smokeview/update.c
@@ -38,10 +38,10 @@ void UpdateFrameNumber(int changetime){
     force_redisplay=0;
     itimeold=itimes;
     if(showsmoke==1){
-      for(i=0;i<npartinfo;i++){
+      for(i=0;i<global_scase.npartinfo;i++){
         partdata *parti;
 
-        parti = partinfo+i;
+        parti = global_scase.partinfo+i;
         if(parti->loaded==0||parti->timeslist==NULL)continue;
         parti->itime=parti->timeslist[itimes];
       }
@@ -49,13 +49,13 @@ void UpdateFrameNumber(int changetime){
     if(showvolrender==1){
       int imesh;
 
-      for(imesh=0;imesh<nmeshes;imesh++){
+      for(imesh=0;imesh<global_scase.meshescoll.nmeshes;imesh++){
         meshdata *meshi;
         volrenderdata *vr;
         slicedata *fireslice, *smokeslice;
         int j;
 
-        meshi = meshinfo + imesh;
+        meshi = global_scase.meshescoll.meshinfo + imesh;
         vr = meshi->volrenderinfo;
         fireslice=vr->fireslice;
         smokeslice=vr->smokeslice;
@@ -123,7 +123,7 @@ void UpdateFrameNumber(int changetime){
         slicedata *sd;
 
         i = slice_loaded_list[ii];
-        sd = slicecoll.sliceinfo+i;
+        sd = global_scase.slicecoll.sliceinfo+i;
         if(sd->slice_filetype == SLICE_GEOM){
           patchdata *patchi;
 
@@ -154,10 +154,10 @@ void UpdateFrameNumber(int changetime){
           slice_time = sd->itime;
         }
       }
-      for(i = 0; i < npatchinfo; i++){
+      for(i = 0; i < global_scase.npatchinfo; i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->structured == YES || patchi->boundary == 1 || patchi->geom_times == NULL || patchi->geom_timeslist == NULL)continue;
         patchi->geom_itime = patchi->geom_timeslist[itimes];
         patchi->geom_ival_static  = patchi->geom_ivals + patchi->geom_ivals_static_offset[patchi->geom_itime];
@@ -168,7 +168,7 @@ void UpdateFrameNumber(int changetime){
         patchi->geom_nval_dynamic = patchi->geom_ndynamics[patchi->geom_itime];
       }
     }
-    if(show3dsmoke==1 && smoke3dcoll.nsmoke3dinfo > 0){
+    if(show3dsmoke==1 && global_scase.smoke3dcoll.nsmoke3dinfo > 0){
       INIT_PRINT_TIMER(merge_smoke_time);
       THREADcontrol(mergesmoke_threads, THREAD_LOCK);
       THREADruni(mergesmoke_threads, (unsigned char *)smokethreadinfo, sizeof(smokethreaddata));
@@ -178,10 +178,10 @@ void UpdateFrameNumber(int changetime){
       PRINT_TIMER(merge_smoke_time, "UpdateSmoke3D + MergeSmoke3D");
     }
     if(showpatch==1){
-      for(i=0;i<npatchinfo;i++){
+      for(i=0;i<global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->structured == YES||patchi->boundary==0||patchi->geom_times==NULL||patchi->geom_timeslist==NULL)continue;
         patchi->geom_itime=patchi->geom_timeslist[itimes];
         if(patchi->geom_ivals != NULL){
@@ -192,13 +192,13 @@ void UpdateFrameNumber(int changetime){
         patchi->geom_nval_dynamic = patchi->geom_ndynamics[patchi->geom_itime];
         if(patchi->is_compressed==1)UncompressBoundaryDataGEOM(patchi, patchi->geom_itime);
       }
-      for(i=0;i<nmeshes;i++){
+      for(i=0;i<global_scase.meshescoll.nmeshes;i++){
         patchdata *patchi;
         meshdata *meshi;
 
-        meshi = meshinfo+i;
-        if(meshi->patchfilenum < 0||meshi->patchfilenum>npatchinfo-1)continue;
-        patchi=patchinfo + meshi->patchfilenum;
+        meshi = global_scase.meshescoll.meshinfo+i;
+        if(meshi->patchfilenum < 0||meshi->patchfilenum>global_scase.npatchinfo-1)continue;
+        patchi=global_scase.patchinfo + meshi->patchfilenum;
         if(patchi->structured == NO||meshi->patch_times==NULL||meshi->patch_timeslist==NULL)continue;
         meshi->patch_itime=meshi->patch_timeslist[itimes];
         if(patchi->compression_type==UNCOMPRESSED){
@@ -218,9 +218,9 @@ void UpdateFrameNumber(int changetime){
       meshdata *meshi;
 
       CheckMemory;
-      for(i=0;i<nisoinfo;i++){
-        isoi = isoinfo + i;
-        meshi = meshinfo + isoi->blocknumber;
+      for(i=0;i<global_scase.nisoinfo;i++){
+        isoi = global_scase.isoinfo + i;
+        meshi = global_scase.meshescoll.meshinfo + isoi->blocknumber;
         if(isoi->loaded==0||meshi->iso_times==NULL||meshi->iso_timeslist==NULL)continue;
         meshi->iso_itime=meshi->iso_timeslist[itimes];
       }
@@ -237,67 +237,67 @@ void UpdateFileLoad(void){
   int i;
 
   npartloaded = 0;
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     if(parti->loaded==1)npartloaded++;
   }
 
   nsliceloaded = 0;
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     if(slicei->loaded==1)nsliceloaded++;
   }
 
   nvsliceloaded = 0;
-  for(i = 0; i<slicecoll.nvsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nvsliceinfo; i++){
     vslicedata *vslicei;
 
-    vslicei = slicecoll.vsliceinfo+i;
+    vslicei = global_scase.slicecoll.vsliceinfo+i;
     if(vslicei->loaded==1)nvsliceloaded++;
   }
 
   nisoloaded = 0;
-  for(i = 0; i<nisoinfo; i++){
+  for(i = 0; i<global_scase.nisoinfo; i++){
     isodata *isoi;
 
-    isoi = isoinfo+i;
+    isoi = global_scase.isoinfo+i;
     if(isoi->loaded==1)nisoloaded++;
   }
 
   npatchloaded = 0;
-  for(i = 0; i<npatchinfo; i++){
+  for(i = 0; i<global_scase.npatchinfo; i++){
     patchdata *patchi;
 
-    patchi = patchinfo+i;
+    patchi = global_scase.patchinfo+i;
     if(patchi->loaded==1)npatchloaded++;
   }
 
   nsmoke3dloaded = 0;
-  for(i = 0; i<smoke3dcoll.nsmoke3dinfo; i++){
+  for(i = 0; i<global_scase.smoke3dcoll.nsmoke3dinfo; i++){
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo+i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo+i;
     if(smoke3di->loaded==1)nsmoke3dloaded++;
   }
 
   nplot3dloaded = 0;
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *plot3di;
 
-    plot3di = plot3dinfo+i;
+    plot3di = global_scase.plot3dinfo+i;
     if(plot3di->loaded==1)nplot3dloaded++;
   }
 
   nvolsmoke3dloaded = 0;
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
     volrenderdata *vr;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     vr = meshi->volrenderinfo;
     if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
     if(vr->loaded==1)nvolsmoke3dloaded++;
@@ -305,10 +305,10 @@ void UpdateFileLoad(void){
 
   npart5loaded = 0;
   npartloaded = 0;
-  for(i = 0; i<npartinfo; i++){
+  for(i = 0; i<global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo+i;
+    parti = global_scase.partinfo+i;
     if(parti->loaded==1)npartloaded++;
     if(parti->loaded==1)npart5loaded++;
   }
@@ -352,15 +352,15 @@ void UpdateShow(void){
 
   if(vis_hrr_plot==1&&hrrptr!=NULL)showhrrflag = 1;
 
-  if(hvaccoll.hvacductvar_index >= 0 || hvaccoll.hvacnodevar_index >= 0){
+  if(global_scase.hvaccoll.hvacductvar_index >= 0 || global_scase.hvaccoll.hvacnodevar_index >= 0){
     showhvacflag = 1;
   }
 
   if(showdevice_val==1||vis_device_plot!=DEVICE_PLOT_HIDDEN){
-    for(i = 0; i<ndeviceinfo; i++){
+    for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
       devicedata *devicei;
 
-      devicei = deviceinfo+i;
+      devicei = global_scase.devicecoll.deviceinfo+i;
       if(devicei->type2==devicetypes_index&&devicei->object->visible==1&&devicei->show==1){
         showdeviceflag = 1;
         break;
@@ -371,9 +371,9 @@ void UpdateShow(void){
   {
     tourdata *touri;
 
-    if(tourcoll.ntourinfo>0){
-      for(i=0;i<tourcoll.ntourinfo;i++){
-        touri = tourcoll.tourinfo + i;
+    if(global_scase.tourcoll.ntourinfo>0){
+      for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
+        touri = global_scase.tourcoll.tourinfo + i;
         if(touri->display==1){
           showtours=1;
           break;
@@ -384,10 +384,10 @@ void UpdateShow(void){
   {
     int ii;
 
-    for(ii=0;ii<smoke3dcoll.nsmoke3dinfo;ii++){
+    for(ii=0;ii<global_scase.smoke3dcoll.nsmoke3dinfo;ii++){
       smoke3ddata *smoke3di;
 
-      smoke3di = smoke3dcoll.smoke3dinfo + ii;
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + ii;
       if(smoke3di->loaded==1&&smoke3di->display==1){
         smoke3dflag = 1;
         break;
@@ -395,11 +395,11 @@ void UpdateShow(void){
     }
   }
   if(nvolrenderinfo>0&&usevolrender==1){
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       volrenderdata *vr;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       vr = meshi->volrenderinfo;
       if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
       if(vr->loaded==0||vr->display==0)continue;
@@ -418,7 +418,7 @@ void UpdateShow(void){
       slicedata *sd;
 
       i=slice_loaded_list[ii];
-      sd = slicecoll.sliceinfo+i;
+      sd = global_scase.slicecoll.sliceinfo+i;
       if(sd->display==0||sd->slicefile_labelindex!=slicefile_labelindex)continue;
       if(sd->volslice==1&&sd->slice_filetype==SLICE_NODE_CENTER&&vis_gslice_data==1)SHOW_gslice_data=1;
       if(sd->ntimes>0){
@@ -434,7 +434,7 @@ void UpdateShow(void){
       slicedata *sd;
 
       i=slice_loaded_list[ii];
-      sd = slicecoll.sliceinfo+i;
+      sd = global_scase.slicecoll.sliceinfo+i;
       if(sd->display==0||sd->slicefile_labelindex!=slicefile_labelindex)continue;
       if(sd->constant_color!=NULL)continue;
       if(sd->ntimes>0){
@@ -447,7 +447,7 @@ void UpdateShow(void){
         slicedata *sd;
 
         i=slice_loaded_list[ii];
-        sd = slicecoll.sliceinfo+i;
+        sd = global_scase.slicecoll.sliceinfo+i;
         if(sd->display==0||sd->slicefile_labelindex!=slicefile_labelindex)continue;
         if(sd->extreme_max==1){
           have_extreme_maxdata=1;
@@ -460,7 +460,7 @@ void UpdateShow(void){
         slicedata *sd;
 
         i=slice_loaded_list[ii];
-        sd = slicecoll.sliceinfo+i;
+        sd = global_scase.slicecoll.sliceinfo+i;
         if(sd->display==0||sd->slicefile_labelindex!=slicefile_labelindex)continue;
         if(sd->extreme_min==1){
           have_extreme_mindata=1;
@@ -468,10 +468,10 @@ void UpdateShow(void){
         }
       }
     }
-    for(i=0;i<npatchinfo;i++){
+    for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
 
-      patchi=patchinfo+i;
+      patchi=global_scase.patchinfo+i;
       if(patchi->loaded == 0)continue;
       if(patchi->boundary == 0 && patchi->display == 1 && patchi->shortlabel_index == slicefile_labelindex){
         sliceflag = 1;
@@ -487,10 +487,10 @@ void UpdateShow(void){
   isoflag=0;
   tisoflag=0;
   if(visTimeIso==1){
-    for(i=0;i<nisoinfo;i++){
+    for(i=0;i<global_scase.nisoinfo;i++){
       isodata *isoi;
 
-      isoi = isoinfo+i;
+      isoi = global_scase.isoinfo+i;
       if(isoi->loaded==0)continue;
       if(isoi->display==1&&isoi->type==iisotype){
         isoflag=1;
@@ -505,27 +505,27 @@ void UpdateShow(void){
   vsliceflag=0;
   vslicecolorbarflag=0;
   if(visTimeSlice==1){
-    for(i=0;i<slicecoll.nvsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
       vslicedata *vd;
       slicedata *sd;
 
-      vd = slicecoll.vsliceinfo+i;
+      vd = global_scase.slicecoll.vsliceinfo+i;
       if(vd->loaded==0||vd->display==0)continue;
-      sd = slicecoll.sliceinfo + vd->ival;
+      sd = global_scase.slicecoll.sliceinfo + vd->ival;
 
       if(sd->slicefile_labelindex!=slicefile_labelindex)continue;
       if(sd->volslice==1&&sd->slice_filetype==SLICE_NODE_CENTER&&vis_gslice_data==1)SHOW_gslice_data=1;
       vsliceflag=1;
       break;
     }
-    for(i=0;i<slicecoll.nvsliceinfo;i++){
+    for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
       slicedata *sd;
       vslicedata *vd;
 
-      vd = slicecoll.vsliceinfo+i;
-      sd = slicecoll.sliceinfo + vd->ival;
+      vd = global_scase.slicecoll.vsliceinfo+i;
+      sd = global_scase.slicecoll.sliceinfo + vd->ival;
       if(vd->loaded==0||vd->display==0)continue;
-      if(slicecoll.sliceinfo[vd->ival].slicefile_labelindex!=slicefile_labelindex)continue;
+      if(global_scase.slicecoll.sliceinfo[vd->ival].slicefile_labelindex!=slicefile_labelindex)continue;
       if(sd->constant_color!=NULL)continue;
       vslicecolorbarflag=1;
       break;
@@ -534,17 +534,17 @@ void UpdateShow(void){
 
   patchflag=0;
   if(visTimeBoundary==1){
-    for(i = 0; i < ngeominfo; i++){
+    for(i = 0; i < global_scase.ngeominfo; i++){
       geomdata *geomi;
 
-      geomi = geominfo + i;
+      geomi = global_scase.geominfo + i;
       geomi->patchactive = 0;
     }
     wall_cell_color_flag=0;
-    for(i=0;i<npatchinfo;i++){
+    for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
 
-      patchi=patchinfo+i;
+      patchi=global_scase.patchinfo+i;
       if(patchi->loaded == 0)continue;
       if(patchi->boundary == 1 && patchi->display == 1 && patchi->shortlabel_index == iboundarytype){
         if(strcmp(patchi->label.shortlabel, "wc") == 0)wall_cell_color_flag = 1;
@@ -558,10 +558,10 @@ void UpdateShow(void){
 
   partflag=0;
   if(visParticles==1&&visTimeParticles==1){
-    for(i=0;i<npartinfo;i++){
+    for(i=0;i<global_scase.npartinfo;i++){
       partdata *parti;
 
-      parti = partinfo + i;
+      parti = global_scase.partinfo + i;
       if(parti->loaded==1&&parti->display==1){
         partflag=1;
         break;
@@ -595,20 +595,20 @@ void UpdateShow(void){
     if(patchflag==1)showpatch=1;
     drawing_boundary_files = showpatch;
 
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
 
-      meshi=meshinfo+i;
+      meshi=global_scase.meshescoll.meshinfo+i;
       meshi->visInteriorBoundaries=0;
     }
     if(showpatch==1&&vis_boundary_type[0]==1){
-      for(i=0;i<nmeshes;i++){
+      for(i=0;i<global_scase.meshescoll.nmeshes;i++){
         patchdata *patchi;
         meshdata *meshi;
 
-        meshi=meshinfo+i;
+        meshi=global_scase.meshescoll.meshinfo+i;
         if(meshi->patch_times==NULL)continue;
-        patchi = patchinfo+meshi->patchfilenum;
+        patchi = global_scase.patchinfo+meshi->patchfilenum;
         if(patchi->loaded==1&&patchi->display==1&&patchi->shortlabel_index ==iboundarytype){
           meshi->visInteriorBoundaries=1;
         }
@@ -628,27 +628,27 @@ void UpdateShow(void){
   if(showshooter==1)RenderTime=1;
   if(plotstate==STATIC_PLOTS&&nplot3dloaded>0&&plotn>0&&plotn<=numplot3dvars)showplot3d=1;
   if(showplot3d==1){
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       int ii;
 
-      meshi=meshinfo+i;
+      meshi=global_scase.meshescoll.meshinfo+i;
       ii=meshi->plot3dfilenum;
       if(ii==-1)continue;
-      if(plot3dinfo[ii].loaded==0)continue;
-      if(plot3dinfo[ii].display==0)continue;
-      if(plot3dinfo[ii].extreme_min[plotn-1]==1)have_extreme_mindata=1;
+      if(global_scase.plot3dinfo[ii].loaded==0)continue;
+      if(global_scase.plot3dinfo[ii].display==0)continue;
+      if(global_scase.plot3dinfo[ii].extreme_min[plotn-1]==1)have_extreme_mindata=1;
     }
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       int ii;
 
-      meshi=meshinfo+i;
+      meshi=global_scase.meshescoll.meshinfo+i;
       ii=meshi->plot3dfilenum;
       if(ii==-1)continue;
-      if(plot3dinfo[ii].loaded==0)continue;
-      if(plot3dinfo[ii].display==0)continue;
-      if(plot3dinfo[ii].extreme_max[plotn-1]==1)have_extreme_maxdata=1;
+      if(global_scase.plot3dinfo[ii].loaded==0)continue;
+      if(global_scase.plot3dinfo[ii].display==0)continue;
+      if(global_scase.plot3dinfo[ii].extreme_max[plotn-1]==1)have_extreme_maxdata=1;
     }
   }
 
@@ -658,8 +658,8 @@ void UpdateShow(void){
     if(slicecolorbarflag==1||vslicecolorbarflag==1)num_colorbars++;
     if(patchflag==1&&wall_cell_color_flag==0)num_colorbars++;
     if(ReadZoneFile==1)num_colorbars++;
-    if(hvaccoll.hvacductvar_index >= 0)num_colorbars++;
-    if(hvaccoll.hvacnodevar_index >= 0)num_colorbars++;
+    if(global_scase.hvaccoll.hvacductvar_index >= 0)num_colorbars++;
+    if(global_scase.hvaccoll.hvacnodevar_index >= 0)num_colorbars++;
 
     if(tisoflag==1){
       showiso_colorbar = 1;
@@ -751,10 +751,10 @@ void SynchTimes(void){
 
   /* synchronize tour times */
 
-    for(j=0;j<tourcoll.ntourinfo;j++){
+    for(j=0;j<global_scase.tourcoll.ntourinfo;j++){
       tourdata *tourj;
 
-      tourj = tourcoll.tourinfo + j;
+      tourj = global_scase.tourcoll.tourinfo + j;
       if(tourj->display==0)continue;
       tourj->timeslist[n] = GetDataTimeFrame(global_times[n], NULL, tourj->path_times,tourj->ntimes);
     }
@@ -768,17 +768,17 @@ void SynchTimes(void){
       geomi = geominfoptrs[j];
       if(geomi->loaded==0||geomi->display==0)continue;
       if(geomi->geomtype == GEOM_ISO&& geomi->block_number >= 0){
-        times_map = meshinfo[geomi->block_number].iso_times_map;
+        times_map = global_scase.meshescoll.meshinfo[geomi->block_number].iso_times_map;
       }
       geomi->timeslist[n] = GetDataTimeFrame(global_times[n], times_map, geomi->times, geomi->ntimes);
     }
 
   /* synchronize particle times */
 
-    for(j=0;j<npartinfo;j++){
+    for(j=0;j<global_scase.npartinfo;j++){
       partdata *parti;
 
-      parti=partinfo+j;
+      parti=global_scase.partinfo+j;
       if(parti->loaded==0)continue;
       parti->timeslist[n] = GetDataTimeFrame(global_times[n], parti->times_map, parti->times,parti->ntimes);
     }
@@ -806,7 +806,7 @@ void SynchTimes(void){
     for(jj=0;jj<nslice_loaded;jj++){
       slicedata *sd;
 
-      sd = slicecoll.sliceinfo + slice_loaded_list[jj];
+      sd = global_scase.slicecoll.sliceinfo + slice_loaded_list[jj];
       if(sd->slice_filetype == SLICE_GEOM){
         sd->patchgeom->geom_timeslist[n] = GetDataTimeFrame(global_times[n], sd->patchgeom->geom_times_map , sd->patchgeom->geom_times, sd->ntimes);
       }
@@ -820,8 +820,8 @@ void SynchTimes(void){
     {
       smoke3ddata *smoke3di;
 
-      for(jj=0;jj<smoke3dcoll.nsmoke3dinfo;jj++){
-        smoke3di = smoke3dcoll.smoke3dinfo + jj;
+      for(jj=0;jj<global_scase.smoke3dcoll.nsmoke3dinfo;jj++){
+        smoke3di = global_scase.smoke3dcoll.smoke3dinfo + jj;
         if(smoke3di->loaded==0)continue;
         smoke3di->timeslist[n] = GetDataTimeFrame(global_times[n], smoke3di->times_map, smoke3di->times,smoke3di->ntimes);
       }
@@ -829,31 +829,31 @@ void SynchTimes(void){
 
   /* synchronize patch times */
 
-    for(j=0;j<npatchinfo;j++){
+    for(j=0;j<global_scase.npatchinfo;j++){
       patchdata *patchi;
 
-      patchi = patchinfo + j;
+      patchi = global_scase.patchinfo + j;
       if(patchi->loaded==0)continue;
       if(patchi->structured == YES)continue;
       patchi->geom_timeslist[n] = GetDataTimeFrame(global_times[n], patchi->geom_times_map, patchi->geom_times,patchi->ngeom_times);
     }
-    for(j=0;j<nmeshes;j++){
+    for(j=0;j<global_scase.meshescoll.nmeshes;j++){
       patchdata *patchi;
       meshdata *meshi;
 
-      meshi=meshinfo+j;
+      meshi=global_scase.meshescoll.meshinfo+j;
       if(meshi->patchfilenum<0||meshi->patch_times==NULL)continue;
-      patchi=patchinfo+meshi->patchfilenum;
+      patchi=global_scase.patchinfo+meshi->patchfilenum;
       if(patchi->structured == NO||patchi->loaded==0)continue;
       meshi->patch_timeslist[n] = GetDataTimeFrame(global_times[n], meshi->patch_times_map, meshi->patch_times,patchi->ntimes);
     }
 
   /* synchronize isosurface times */
 
-    for(igrid=0;igrid<nmeshes;igrid++){
+    for(igrid=0;igrid<global_scase.meshescoll.nmeshes;igrid++){
       meshdata *meshi;
 
-      meshi=meshinfo+igrid;
+      meshi=global_scase.meshescoll.meshinfo+igrid;
       if(meshi->iso_times==NULL)continue;
       meshi->iso_timeslist[n] = GetDataTimeFrame(global_times[n], meshi->iso_times_map, meshi->iso_times,meshi->niso_times);
     }
@@ -861,11 +861,11 @@ void SynchTimes(void){
   /* synchronize volume render times */
 
     if(nvolrenderinfo>0){
-      for(igrid=0;igrid<nmeshes;igrid++){
+      for(igrid=0;igrid<global_scase.meshescoll.nmeshes;igrid++){
         volrenderdata *vr;
         meshdata *meshi;
 
-        meshi=meshinfo+igrid;
+        meshi=global_scase.meshescoll.meshinfo+igrid;
         vr = meshi->volrenderinfo;
         if(vr->smokeslice==NULL)continue;
         if(vr->loaded==0||vr->display==0)continue;
@@ -891,10 +891,10 @@ int GetLoadvfileinfo(FILE *stream, char *filename){
 
   TrimBack(filename);
   fileptr = TrimFront(filename);
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     if(strcmp(fileptr, slicei->file)==0){
       fprintf(stream, "// LOADVFILE\n");
       fprintf(stream, "//  %s\n", slicei->file);
@@ -921,10 +921,10 @@ int GetLoadfileinfo(FILE *stream, char *filename){
 
   TrimBack(filename);
   fileptr = TrimFront(filename);
-  for(i = 0; i<slicecoll.nsliceinfo; i++){
+  for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo+i;
+    slicei = global_scase.slicecoll.sliceinfo+i;
     if(strcmp(fileptr, slicei->file)==0){
       fprintf(stream, "// LOADFILE\n");
       fprintf(stream, "//  %s\n", slicei->file);
@@ -940,10 +940,10 @@ int GetLoadfileinfo(FILE *stream, char *filename){
       return 1;
     }
   }
-  for(i = 0; i < nisoinfo; i++){
+  for(i = 0; i < global_scase.nisoinfo; i++){
     isodata *isoi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     if(strcmp(fileptr, isoi->file) == 0){
       fprintf(stream, "// LOADFILE\n");
       fprintf(stream, "//  %s\n", isoi->file);
@@ -954,10 +954,10 @@ int GetLoadfileinfo(FILE *stream, char *filename){
     }
 
   }
-  for(i = 0; i < npatchinfo; i++){
+  for(i = 0; i < global_scase.npatchinfo; i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(strcmp(fileptr, patchi->file) == 0){
       fprintf(stream, "// LOADFILE\n");
       fprintf(stream, "//  %s\n", patchi->file);
@@ -1056,7 +1056,7 @@ void TruncateGlobalTimes(void){
   iend = nglobal_times - 1;
   if(use_tload_begin==1){
     for(i=0;i<nglobal_times;i++){
-      if(tload_begin<global_times[i]){
+      if(global_scase.tload_begin<global_times[i]){
         ibeg = i;
         break;
       }
@@ -1064,7 +1064,7 @@ void TruncateGlobalTimes(void){
   }
   if(use_tload_end==1){
     for(i=nglobal_times-1;i>=0;i--){
-      if(global_times[i]<tload_end){
+      if(global_times[i]<global_scase.tload_end){
         iend = i;
         break;
       }
@@ -1075,10 +1075,10 @@ void TruncateGlobalTimes(void){
   }
   nglobal_times = iend + 1 - ibeg;
   if(use_tload_begin==1){
-    MergeGlobalTimes(&tload_begin, 1);
+    MergeGlobalTimes(&global_scase.tload_begin, 1);
   }
   if(use_tload_end==1){
-    MergeGlobalTimes(&tload_end, 1);
+    MergeGlobalTimes(&global_scase.tload_end, 1);
   }
 }
 
@@ -1201,17 +1201,17 @@ void MergeGlobalTimes(float *time_in, int ntimes_in){
 #ifdef pp_SLICEFRAME
 void UpdateSliceNtimes(void){
   int minslice_index = 1000000000, i;
-  for(i = 0;i < slicecoll.nsliceinfo;i++){
+  for(i = 0;i < global_scase.slicecoll.nsliceinfo;i++){
     slicedata *sd;
 
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     if(sd->loaded == 0 || sd->display == 0)continue;
     minslice_index = MIN(minslice_index, sd->ntimes);
   }
-  for(i = 0;i < slicecoll.nsliceinfo;i++){
+  for(i = 0;i < global_scase.slicecoll.nsliceinfo;i++){
     slicedata *sd;
 
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     if(sd->loaded == 0 || sd->display == 0)continue;
     sd->ntimes = minslice_index;
   }
@@ -1257,17 +1257,17 @@ void UpdateTimes(void){
       MergeGlobalTimes(stimes, 2);
     }
   }
-  if(hvaccoll.hvacductvar_index >= 0){
-    MergeGlobalTimes(hvaccoll.hvacductvalsinfo->times, hvaccoll.hvacductvalsinfo->ntimes);
+  if(global_scase.hvaccoll.hvacductvar_index >= 0){
+    MergeGlobalTimes(global_scase.hvaccoll.hvacductvalsinfo->times, global_scase.hvaccoll.hvacductvalsinfo->ntimes);
   }
-  if(hvaccoll.hvacnodevar_index >= 0){
-    MergeGlobalTimes(hvaccoll.hvacnodevalsinfo->times, hvaccoll.hvacnodevalsinfo->ntimes);
+  if(global_scase.hvaccoll.hvacnodevar_index >= 0){
+    MergeGlobalTimes(global_scase.hvaccoll.hvacnodevalsinfo->times, global_scase.hvaccoll.hvacnodevalsinfo->ntimes);
   }
   if(use_tload_begin==1){
-    MergeGlobalTimes(&tload_begin, 1);
+    MergeGlobalTimes(&global_scase.tload_begin, 1);
   }
   if(use_tload_end==1){
-    MergeGlobalTimes(&tload_end, 1);
+    MergeGlobalTimes(&global_scase.tload_end, 1);
   }
 
   if(vis_hrr_plot==1&&hrrptr!=NULL){
@@ -1282,10 +1282,10 @@ void UpdateTimes(void){
     }
   }
   if(showdevice_val==1||vis_device_plot!=DEVICE_PLOT_HIDDEN){
-    for(i = 0; i<ndeviceinfo; i++){
+    for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
       devicedata *devicei;
 
-      devicei = deviceinfo+i;
+      devicei = global_scase.devicecoll.deviceinfo+i;
       if(devicei->object->visible==0||devicei->nvals==0)continue;
       if(devicei->show == 0)continue;
       if(devicei->type2==devicetypes_index){
@@ -1304,10 +1304,10 @@ void UpdateTimes(void){
   if(visShooter!=0&&shooter_active==1){
     nglobal_times = MAX(nglobal_times,nshooter_frames);
   }
-  for(i = 0; i<nplot3dinfo; i++){
+  for(i = 0; i<global_scase.nplot3dinfo; i++){
     plot3ddata *pd;
 
-    pd = plot3dinfo+i;
+    pd = global_scase.plot3dinfo+i;
     if(pd->loaded==1){
       float ptime[1];
 
@@ -1316,33 +1316,33 @@ void UpdateTimes(void){
     }
   }
   INIT_PRINT_TIMER(slice_timer);
-  for(i=0;i<slicecoll.nsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
     slicedata *sd;
 
-    sd=slicecoll.sliceinfo+i;
+    sd=global_scase.slicecoll.sliceinfo+i;
     if(sd->loaded==1||sd->vloaded==1){
       MergeGlobalTimes(sd->times, sd->ntimes);
     }
   }
   PRINT_TIMER(slice_timer, "UpdateTimes: slice");
-  for(i=0;i<npatchinfo;i++){
+  for(i=0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->loaded==1&&patchi->structured == NO){
       MergeGlobalTimes(patchi->geom_times, patchi->ngeom_times);
     }
   }
   INIT_PRINT_TIMER(boundary_timer);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     patchdata *patchi;
     meshdata *meshi;
     int filenum;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     filenum =meshi->patchfilenum;
     if(filenum!=-1){
-      patchi=patchinfo+filenum;
+      patchi=global_scase.patchinfo+filenum;
       if(patchi->loaded==1&&patchi->structured == YES){
         MergeGlobalTimes(meshi->patch_times, patchi->ntimes);
       }
@@ -1354,23 +1354,23 @@ void UpdateTimes(void){
   }
   if(ReadIsoFile==1&&visAIso!=0){
     INIT_PRINT_TIMER(iso_timer);
-    for(i=0;i<nisoinfo;i++){
+    for(i=0;i<global_scase.nisoinfo;i++){
       meshdata *meshi;
       isodata *ib;
 
-      ib = isoinfo+i;
+      ib = global_scase.isoinfo+i;
       if(ib->geomflag==1||ib->loaded==0)continue;
-      meshi=meshinfo + ib->blocknumber;
+      meshi=global_scase.meshescoll.meshinfo + ib->blocknumber;
       MergeGlobalTimes(meshi->iso_times, meshi->niso_times);
     }
     PRINT_TIMER(iso_timer, "UpdateTimes: iso");
   }
   if(nvolrenderinfo>0){
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       volrenderdata *vr;
       meshdata *meshi;
 
-      meshi=meshinfo+i;
+      meshi=global_scase.meshescoll.meshinfo+i;
       vr = meshi->volrenderinfo;
       if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
       if(vr->loaded==0||vr->display==0)continue;
@@ -1382,26 +1382,26 @@ void UpdateTimes(void){
 
     if(nsmoke3dloaded>0&&vis3DSmoke3D==1){
       INIT_PRINT_TIMER(smoke3d_timer);
-      for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
-        smoke3di = smoke3dcoll.smoke3dinfo + i;
+      for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
+        smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
         if(smoke3di->loaded==0)continue;
         MergeGlobalTimes(smoke3di->times, smoke3di->ntimes);
       }
       PRINT_TIMER(smoke3d_timer, "UpdateTimes: smoke3d");
     }
   }
-  for(i = 0; i < npartinfo; i++){
+  for(i = 0; i < global_scase.npartinfo; i++){
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     if(parti->loaded == 0)continue;
     MergeGlobalTimes(parti->times, parti->ntimes);
   }
 
-  for(i=0;i<tourcoll.ntourinfo;i++){
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
     tourdata *touri;
 
-    touri = tourcoll.tourinfo + i;
+    touri = global_scase.tourcoll.tourinfo + i;
     if(touri->display==0)continue;
     MergeGlobalTimes(touri->path_times, touri->ntimes);
   }
@@ -1423,17 +1423,17 @@ void UpdateTimes(void){
     FREEMEMORY(geomi->timeslist);
     if(nglobal_times>0)NewMemory((void **)&geomi->timeslist,nglobal_times*sizeof(int));
   }
-  for(i=0;i<npartinfo;i++){
+  for(i=0;i<global_scase.npartinfo;i++){
     partdata *parti;
 
-    parti=partinfo+i;
+    parti=global_scase.partinfo+i;
     FREEMEMORY(parti->timeslist);
     if(nglobal_times>0)NewMemory((void **)&parti->timeslist,nglobal_times*sizeof(int));
   }
-  for(i=0;i<tourcoll.ntourinfo;i++){
+  for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
     tourdata *touri;
 
-    touri=tourcoll.tourinfo + i;
+    touri=global_scase.tourcoll.tourinfo + i;
     if(touri->display==0)continue;
     FREEMEMORY(touri->timeslist);
     if(nglobal_times>0)NewMemory((void **)&touri->timeslist,nglobal_times*sizeof(int));
@@ -1443,10 +1443,10 @@ void UpdateTimes(void){
     NewMemory((void **)&shooter_timeslist,nshooter_frames*sizeof(int));
   }
 
-  for(i=0;i<slicecoll.nsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
     slicedata *sd;
 
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     if(sd->loaded==0)continue;
     if(sd->slice_filetype == SLICE_GEOM){
       FREEMEMORY(sd->patchgeom->geom_timeslist);
@@ -1458,11 +1458,11 @@ void UpdateTimes(void){
     }
   }
   if(nvolrenderinfo>0){
-    for(i=0;i<nmeshes;i++){
+    for(i=0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       volrenderdata *vr;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       vr = meshi->volrenderinfo;
       if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
       if(vr->loaded==0||vr->display==0)continue;
@@ -1473,36 +1473,36 @@ void UpdateTimes(void){
   {
     smoke3ddata *smoke3di;
 
-    for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
-      smoke3di = smoke3dcoll.smoke3dinfo + i;
+    for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
+      smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
       FREEMEMORY(smoke3di->timeslist);
       if(nglobal_times>0)NewMemory((void **)&smoke3di->timeslist,nglobal_times*sizeof(int));
     }
   }
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     if(meshi->iso_times==NULL)continue;
     FREEMEMORY(meshi->iso_timeslist);
     if(nglobal_times>0)NewMemory((void **)&meshi->iso_timeslist,  nglobal_times*sizeof(int));
   }
 
-  for(i=0;i<npatchinfo;i++){
+  for(i=0;i<global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     FREEMEMORY(patchi->geom_timeslist);
     if(patchi->structured == YES)continue;
     if(patchi->geom_times==NULL)continue;
     if(nglobal_times>0)NewMemory((void **)&patchi->geom_timeslist,nglobal_times*sizeof(int));
   }
-  for(i=0;i<nmeshes;i++){
-    FREEMEMORY(meshinfo[i].patch_timeslist);
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
+    FREEMEMORY(global_scase.meshescoll.meshinfo[i].patch_timeslist);
   }
-  for(i=0;i<nmeshes;i++){
-    if(meshinfo[i].patch_times==NULL)continue;
-    if(nglobal_times>0)NewMemory((void **)&meshinfo[i].patch_timeslist,nglobal_times*sizeof(int));
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
+    if(global_scase.meshescoll.meshinfo[i].patch_times==NULL)continue;
+    if(nglobal_times>0)NewMemory((void **)&global_scase.meshescoll.meshinfo[i].patch_timeslist,nglobal_times*sizeof(int));
   }
 
   FREEMEMORY(zone_timeslist);
@@ -1533,29 +1533,29 @@ void UpdateTimes(void){
     if(geomi->loaded==0||geomi->display==0)continue;
     geomi->itime=0;
   }
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     meshi->patch_itime=0;
   }
-  for(i=0;i<slicecoll.nsliceinfo;i++){
+  for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
     slicedata *sd;
 
-    sd = slicecoll.sliceinfo + i;
+    sd = global_scase.slicecoll.sliceinfo + i;
     sd->itime=0;
   }
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     if(meshi->iso_times==NULL)continue;
     meshi->iso_itime=0;
   }
-  for(i=0;i<npartinfo;i++){
+  for(i=0;i<global_scase.npartinfo;i++){
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     parti->itime=0;
   }
   PRINT_TIMER(timer_setpointers, "UpdateTimes: set pointer");
@@ -1563,11 +1563,11 @@ void UpdateTimes(void){
   /* determine visibility of each blockage at each time step */
 
   INIT_PRINT_TIMER(timer_visblocks);
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
     meshdata *meshi;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     for(j=0;j<meshi->nbptrs;j++){
       blockagedata *bc;
 
@@ -1593,10 +1593,10 @@ void UpdateTimes(void){
   /* determine state of each device at each time step */
 
   INIT_PRINT_TIMER(timer_device);
-  for(i=0;i<ndeviceinfo;i++){
+  for(i=0;i<global_scase.devicecoll.ndeviceinfo;i++){
     devicedata *devicei;
 
-    devicei = deviceinfo + i;
+    devicei = global_scase.devicecoll.deviceinfo + i;
     if(devicei->object->visible == 0 || devicei->show == 0)continue;
     if(devicei->nstate_changes==0)continue;
     FREEMEMORY(devicei->showstatelist);
@@ -1618,11 +1618,11 @@ void UpdateTimes(void){
 
   INIT_PRINT_TIMER(timer_vent);
 
-  for(i=0;i<nmeshes;i++){
+  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
     int j;
     meshdata *meshi;
 
-    meshi=meshinfo+i;
+    meshi=global_scase.meshescoll.meshinfo+i;
     if(meshi->ventinfo==NULL)continue;
     for(j=0;j<meshi->nvents;j++){
       ventdata *vi;
@@ -1647,11 +1647,11 @@ void UpdateTimes(void){
 
   /* determine visibility of each circular vent at each time step */
 
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     int j;
     meshdata *meshi;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
     if(meshi->cventinfo == NULL)continue;
     for(j = 0; j<meshi->ncvents; j++){
       cventdata *cvi;
@@ -1701,13 +1701,13 @@ int GetPlotStateSub(int choice){
     case STATIC_PLOTS:
     case STATIC_PLOTS_NORECURSE:
       stept = 0;
-      for(i=0;i<nmeshes;i++){
+      for(i=0;i<global_scase.meshescoll.nmeshes;i++){
         plot3ddata *ploti;
         meshdata *meshi;
 
-        meshi=meshinfo + i;
+        meshi=global_scase.meshescoll.meshinfo + i;
         if(meshi->plot3dfilenum==-1)continue;
-        ploti = plot3dinfo + meshi->plot3dfilenum;
+        ploti = global_scase.plot3dinfo + meshi->plot3dfilenum;
         if(ploti->loaded==0||ploti->display==0)continue;
         if(visx_all==0&&visy_all==0&&visz_all==0&&visiso==0)continue;
         return STATIC_PLOTS;
@@ -1718,7 +1718,7 @@ int GetPlotStateSub(int choice){
       break;
     case DYNAMIC_PLOTS:
     case DYNAMIC_PLOTS_NORECURSE:
-      if(hvaccoll.hvacductvar_index>=0||hvaccoll.hvacnodevar_index>=0){
+      if(global_scase.hvaccoll.hvacductvar_index>=0||global_scase.hvaccoll.hvacnodevar_index>=0){
         stept = 1;
         return DYNAMIC_PLOTS;
       }
@@ -1731,10 +1731,10 @@ int GetPlotStateSub(int choice){
         return DYNAMIC_PLOTS;
       }
       if(showdevice_val==1||vis_device_plot!=DEVICE_PLOT_HIDDEN){
-        for(i = 0; i<ndeviceinfo; i++){
+        for(i = 0; i<global_scase.devicecoll.ndeviceinfo; i++){
           devicedata *devicei;
 
-          devicei = deviceinfo+i;
+          devicei = global_scase.devicecoll.deviceinfo+i;
           if(devicei->object->visible == 0 || devicei->show == 0)continue;
           if(devicei->type2==devicetypes_index){
             stept = 1;
@@ -1745,71 +1745,71 @@ int GetPlotStateSub(int choice){
       for(i=0;i<nslice_loaded;i++){
         slicedata *slicei;
 
-        slicei = slicecoll.sliceinfo + slice_loaded_list[i];
+        slicei = global_scase.slicecoll.sliceinfo + slice_loaded_list[i];
         if(slicei->display==0||slicei->slicefile_labelindex!=slicefile_labelindex)continue;
         stept = 1;
         return DYNAMIC_PLOTS;
       }
       if(visGrid==0)stept = 1;
-      for(i=0;i<slicecoll.nvsliceinfo;i++){
+      for(i=0;i<global_scase.slicecoll.nvsliceinfo;i++){
         vslicedata *vslicei;
 
-        vslicei = slicecoll.vsliceinfo + i;
+        vslicei = global_scase.slicecoll.vsliceinfo + i;
         if(vslicei->display==0||vslicei->vslicefile_labelindex!=slicefile_labelindex)continue;
         return DYNAMIC_PLOTS;
       }
-      for(i=0;i<npatchinfo;i++){
+      for(i=0;i<global_scase.npatchinfo;i++){
         patchdata *patchi;
 
-        patchi = patchinfo + i;
+        patchi = global_scase.patchinfo + i;
         if(patchi->loaded == 0)continue;
         if(patchi->display == 1){
           if(patchi->boundary == 1 && patchi->shortlabel_index == iboundarytype)return DYNAMIC_PLOTS;
           if(patchi->boundary == 0 && patchi->shortlabel_index == slicefile_labelindex)return DYNAMIC_PLOTS;
         }
       }
-      for(i=0;i<npartinfo;i++){
+      for(i=0;i<global_scase.npartinfo;i++){
         partdata *parti;
 
-        parti = partinfo + i;
+        parti = global_scase.partinfo + i;
         if(parti->loaded==0||parti->display==0)continue;
         return DYNAMIC_PLOTS;
       }
-      for(i=0;i<nisoinfo;i++){
+      for(i=0;i<global_scase.nisoinfo;i++){
         isodata *isoi;
 
-        isoi = isoinfo + i;
+        isoi = global_scase.isoinfo + i;
         if(isoi->loaded==0)continue;
         if(isoi->display==0)continue;
         return DYNAMIC_PLOTS;
       }
-      for(i=0;i<nzoneinfo;i++){
+      for(i=0;i<global_scase.nzoneinfo;i++){
         zonedata *zonei;
 
-        zonei = zoneinfo + i;
+        zonei = global_scase.zoneinfo + i;
         if(zonei->loaded==0||zonei->display==0)continue;
         return DYNAMIC_PLOTS;
       }
-      for(i=0;i<tourcoll.ntourinfo;i++){
+      for(i=0;i<global_scase.tourcoll.ntourinfo;i++){
         tourdata *touri;
 
-        touri = tourcoll.tourinfo + i;
+        touri = global_scase.tourcoll.tourinfo + i;
         if(touri->display==0)continue;
         return DYNAMIC_PLOTS;
       }
-      for(i=0;i<smoke3dcoll.nsmoke3dinfo;i++){
+      for(i=0;i<global_scase.smoke3dcoll.nsmoke3dinfo;i++){
         smoke3ddata *smoke3di;
 
-        smoke3di = smoke3dcoll.smoke3dinfo + i;
+        smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
         if(smoke3di->loaded==0||smoke3di->display==0)continue;
         return DYNAMIC_PLOTS;
       }
       if(nvolrenderinfo>0){
-        for(i=0;i<nmeshes;i++){
+        for(i=0;i<global_scase.meshescoll.nmeshes;i++){
           meshdata *meshi;
           volrenderdata *vr;
 
-          meshi = meshinfo + i;
+          meshi = global_scase.meshescoll.meshinfo + i;
           vr = meshi->volrenderinfo;
           if(vr->fireslice==NULL||vr->smokeslice==NULL)continue;
           if(vr->loaded==0||vr->display==0)continue;
@@ -1960,10 +1960,10 @@ void UpdateColorTable(colortabledata *ctableinfo, int nctableinfo){
 int HaveFireLoaded(void){
   int i;
 
-  for(i = 0; i<smoke3dcoll.nsmoke3dinfo; i++){
+  for(i = 0; i<global_scase.smoke3dcoll.nsmoke3dinfo; i++){
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo+i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo+i;
     if(smoke3di->loaded==1){
       if(smoke3di->type==HRRPUV_index)return HRRPUV_index;
       if(smoke3di->type==TEMP_index)return TEMP_index;
@@ -1977,10 +1977,10 @@ int HaveFireLoaded(void){
 int HaveSootLoaded(void){
   int i;
 
-  for(i = 0; i<smoke3dcoll.nsmoke3dinfo; i++){
+  for(i = 0; i<global_scase.smoke3dcoll.nsmoke3dinfo; i++){
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo+i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo+i;
     if(smoke3di->loaded==1&&smoke3di->extinct>0.0)return GetSmoke3DType(smoke3di->label.shortlabel);
   }
   return NO_SMOKE;
@@ -2052,11 +2052,11 @@ void OutputFrameSteps(void){
   frames_read       = 0;
   total_time        = 0.0;
   total_wrapup_time = 0.0;
-  for(i = 0;i < slicecoll.nsliceinfo;i++){
+  for(i = 0;i < global_scase.slicecoll.nsliceinfo;i++){
     slicedata *slicei;
     framedata *frameinfo=NULL;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     if(slicei->loaded == 0)continue;
     if(slicei->slice_filetype == SLICE_GEOM)continue;
     frameinfo = slicei->frameinfo;
@@ -2087,11 +2087,11 @@ void OutputFrameSteps(void){
   frames_read = 0;
   total_time = 0.0;
   total_wrapup_time = 0.0;
-  for(i = 0; i < slicecoll.nsliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     framedata *frameinfo = NULL;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     if(slicei->loaded == 0 || slicei->slice_filetype != SLICE_GEOM)continue;
     frameinfo = slicei->frameinfo;
     if(slicei->patchgeom != NULL)frameinfo = slicei->patchgeom->frameinfo;
@@ -2122,10 +2122,10 @@ void OutputFrameSteps(void){
   frames_read       = 0;
   total_time        = 0.0;
   total_wrapup_time = 0.0;
-  for(i = 0;i < smoke3dcoll.nsmoke3dinfo;i++){
+  for(i = 0;i < global_scase.smoke3dcoll.nsmoke3dinfo;i++){
     smoke3ddata *smoke3di;
 
-    smoke3di = smoke3dcoll.smoke3dinfo + i;
+    smoke3di = global_scase.smoke3dcoll.smoke3dinfo + i;
     if(smoke3di->loaded == 0 || smoke3di->frameinfo == NULL || smoke3di->frameinfo->update == 0)continue;
     smoke3di->frameinfo->update = 0;
     count++;
@@ -2153,10 +2153,10 @@ void OutputFrameSteps(void){
   frames_read = 0;
   total_time = 0.0;
   total_wrapup_time = 0.0;
-  for(i = 0;i < npatchinfo;i++){
+  for(i = 0;i < global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->loaded == 0)continue;
     if(patchi->patch_filetype !=PATCH_STRUCTURED_NODE_CENTER &&  patchi->patch_filetype != PATCH_STRUCTURED_CELL_CENTER)continue;
     if(patchi->frameinfo == NULL || patchi->frameinfo->update == 0)continue;
@@ -2187,10 +2187,10 @@ void OutputFrameSteps(void){
   frames_read = 0;
   total_time = 0.0;
   total_wrapup_time = 0.0;
-  for(i = 0;i < npatchinfo;i++){
+  for(i = 0;i < global_scase.npatchinfo;i++){
     patchdata *patchi;
 
-    patchi = patchinfo + i;
+    patchi = global_scase.patchinfo + i;
     if(patchi->loaded == 0 || patchi->patch_filetype != PATCH_GEOMETRY_BOUNDARY)continue;
     if(patchi->frameinfo == NULL || patchi->frameinfo->update == 0)continue;
     patchi->frameinfo->update = 0;
@@ -2219,10 +2219,10 @@ void OutputFrameSteps(void){
   frames_read = 0;
   total_time = 0.0;
   total_wrapup_time = 0.0;
-  for(i = 0;i < nisoinfo;i++){
+  for(i = 0;i < global_scase.nisoinfo;i++){
     isodata *isoi;
 
-    isoi = isoinfo + i;
+    isoi = global_scase.isoinfo + i;
     if(isoi->loaded == 0 || isoi->frameinfo == NULL || isoi->frameinfo->update == 0)continue;
     isoi->frameinfo->update = 0;
     count++;
@@ -2250,10 +2250,10 @@ void OutputFrameSteps(void){
   frames_read = 0;
   total_time = 0.0;
   total_wrapup_time = 0.0;
-  for(i = 0;i < npartinfo;i++){
+  for(i = 0;i < global_scase.npartinfo;i++){
     partdata *parti;
 
-    parti = partinfo + i;
+    parti = global_scase.partinfo + i;
     if(parti->loaded == 0 || parti->frameinfo == NULL || parti->frameinfo->update == 0)continue;
     parti->frameinfo->update = 0;
     count++;
@@ -2342,9 +2342,9 @@ void BoundBoundCB(int var);
     update_csv_load = 0;
     END_SHOW_UPDATE(update_csv_load);
   }
-  if(update_terrain_type == 1){
+  if(global_scase.update_terrain_type == 1){
     SHOW_UPDATE(update_terrain_type);
-    update_terrain_type = 0;
+    global_scase.update_terrain_type = 0;
     GLUIUpdateTerrain();
     END_SHOW_UPDATE(update_terrain_type);
   }
@@ -2384,9 +2384,9 @@ void BoundBoundCB(int var);
     GLUIDeviceCB(DEVICE_TIMEAVERAGE);
     END_SHOW_UPDATE(update_device_timeaverage);
   }
-  if(update_smoke_alphas==1){
+  if(global_scase.update_smoke_alphas==1){
     SHOW_UPDATE(update_smoke_alphas);
-    update_smoke_alphas = 0;
+    global_scase.update_smoke_alphas = 0;
     UpdateSmokeAlphas();
     END_SHOW_UPDATE(update_smoke_alphas);
   }
@@ -2426,11 +2426,11 @@ void BoundBoundCB(int var);
     }
     END_SHOW_UPDATE(open_movie_dialog);
   }
-  if(terrain_update_normals==1&&ngeominfo>0){
+  if(terrain_update_normals==1&&global_scase.ngeominfo>0){
     SHOW_UPDATE(terrain_update_normals);
     terrain_update_normals = 0;
     UpdateAllGeomTriangles();
-    if(auto_terrain==1){
+    if(global_scase.auto_terrain==1){
       GenerateTerrainGeom(&terrain_vertices, &terrain_indices, &terrain_nindices);
     }
     END_SHOW_UPDATE(terrain_update_normals);
@@ -2586,7 +2586,7 @@ void BoundBoundCB(int var);
     FontMenu(LARGE_FONT);
     END_SHOW_UPDATE(trainer_mode);
   }
-  if(updateindexcolors == 1){
+  if(global_scase.updateindexcolors == 1){
     SHOW_UPDATE(updateindexcolors);
     UpdateIndexColors();
     END_SHOW_UPDATE(updateindexcolors);
@@ -2619,8 +2619,8 @@ void BoundBoundCB(int var);
     FrameRateMenu(frameratevalue);
     END_SHOW_UPDATE(updateUpdateFrameRateMenu);
   }
-  if(updatefaces == 1){
-    updatefaces = 0;
+  if(global_scase.updatefaces == 1){
+    global_scase.updatefaces = 0;
     SHOW_UPDATE(updatefaces);
     INIT_PRINT_TIMER(timer_update_faces);
     UpdateFaces();
@@ -2650,7 +2650,7 @@ void UpdateFlippedColorbar(void){
   for(i = 0;i < nslice_loaded;i++){
     slicedata *slicei;
 
-    slicei = slicecoll.sliceinfo + slice_loaded_list[i];
+    slicei = global_scase.slicecoll.sliceinfo + slice_loaded_list[i];
     if(slicei->slicefile_labelindex!=slicefile_labelindex)continue;
     if(slicei->display == 0)continue;
     if(slicei->colorbar_autoflip == 1&&colorbar_autoflip == 1){
@@ -2752,19 +2752,19 @@ void OutputBounds(void){
     char *label, *unit;
     int i;
 
-    label = slicecoll.sliceinfo[update_slice_bounds].label.longlabel;
-    unit = slicecoll.sliceinfo[update_slice_bounds].label.unit;
-    for(i=0;i<slicecoll.nsliceinfo;i++){
+    label = global_scase.slicecoll.sliceinfo[update_slice_bounds].label.longlabel;
+    unit = global_scase.slicecoll.sliceinfo[update_slice_bounds].label.unit;
+    for(i=0;i<global_scase.slicecoll.nsliceinfo;i++){
       slicedata *slicei;
       char *labeli;
       meshdata *meshi;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
       if(slicei->loaded==0)continue;
-      meshi = meshinfo+slicei->blocknumber;
+      meshi = global_scase.meshescoll.meshinfo+slicei->blocknumber;
       labeli = slicei->label.longlabel;
       if(strcmp(label,labeli)!=0)continue;
-      if(nmeshes>1&&bounds_each_mesh==1){
+      if(global_scase.meshescoll.nmeshes>1&&bounds_each_mesh==1){
         OutputMinMax(meshi->label, label, unit, slicei->valmin_slice, slicei->valmax_slice, slicei->valmin_slice, slicei->valmax_slice);
       }
       if(valmin_fds>valmax_fds){
@@ -2793,19 +2793,19 @@ void OutputBounds(void){
     char *label, *unit;
     int i;
 
-    label = patchinfo[update_patch_bounds].label.longlabel;
-    unit = patchinfo[update_patch_bounds].label.unit;
-    for(i=0;i<npatchinfo;i++){
+    label = global_scase.patchinfo[update_patch_bounds].label.longlabel;
+    unit = global_scase.patchinfo[update_patch_bounds].label.unit;
+    for(i=0;i<global_scase.npatchinfo;i++){
       patchdata *patchi;
       char *labeli;
       meshdata *meshi;
 
-      patchi = patchinfo + i;
+      patchi = global_scase.patchinfo + i;
       if(patchi->loaded==0)continue;
-      meshi = meshinfo+patchi->blocknumber;
+      meshi = global_scase.meshescoll.meshinfo+patchi->blocknumber;
       labeli = patchi->label.longlabel;
       if(strcmp(label,labeli)!=0)continue;
-      if(nmeshes>1&&bounds_each_mesh==1){
+      if(global_scase.meshescoll.nmeshes>1&&bounds_each_mesh==1){
         OutputMinMax(meshi->label, label, unit, patchi->valmin_patch, patchi->valmax_patch, patchi->valmin_patch, patchi->valmax_patch);
       }
       if(valmin_patch>valmax_patch){
@@ -2826,14 +2826,14 @@ void OutputBounds(void){
     char *label, *unit;
     int i, j;
 
-    if(nmeshes>1&&nmeshes>1&&bounds_each_mesh==1){
-      for(i = 0; i<npartinfo; i++){
+    if(global_scase.meshescoll.nmeshes>1&&global_scase.meshescoll.nmeshes>1&&bounds_each_mesh==1){
+      for(i = 0; i<global_scase.npartinfo; i++){
         partdata *parti;
         meshdata *meshi;
 
-        parti = partinfo+i;
+        parti = global_scase.partinfo+i;
         if(parti->loaded==0)continue;
-        meshi = meshinfo + parti->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo + parti->blocknumber;
         for(j = 0; j<npart5prop; j++){
           partpropdata *propj;
 
@@ -2858,10 +2858,10 @@ void OutputBounds(void){
       unit = propj->label->unit;
       valmin_part = 1.0;
       valmax_part = 0.0;
-      for(i = 0; i<npartinfo; i++){
+      for(i = 0; i<global_scase.npartinfo; i++){
         partdata *parti;
 
-        parti = partinfo+i;
+        parti = global_scase.partinfo+i;
         if(parti->loaded==0)continue;
         if(valmin_part>valmax_part){
           valmin_part = parti->valmin_part[j];
@@ -2883,17 +2883,17 @@ void OutputBounds(void){
     int i, j;
     plot3ddata *p;
 
-    p = plot3dinfo+update_plot3d_bounds;
+    p = global_scase.plot3dinfo+update_plot3d_bounds;
 
-    if(nmeshes>1&&bounds_each_mesh==1){
+    if(global_scase.meshescoll.nmeshes>1&&bounds_each_mesh==1){
       printf("\n");
-      for(i = 0; i<nplot3dinfo; i++){
+      for(i = 0; i<global_scase.nplot3dinfo; i++){
         plot3ddata *plot3di;
         meshdata *meshi;
 
-        plot3di = plot3dinfo+i;
+        plot3di = global_scase.plot3dinfo+i;
         if(plot3di->loaded==0)continue;
-        meshi = meshinfo+plot3di->blocknumber;
+        meshi = global_scase.meshescoll.meshinfo+plot3di->blocknumber;
         for(j = 0; j<MAXPLOT3DVARS; j++){
 
           label = p->label[j].longlabel;
@@ -2905,19 +2905,19 @@ void OutputBounds(void){
       }
     }
 
-    p = plot3dinfo+update_plot3d_bounds;
+    p = global_scase.plot3dinfo+update_plot3d_bounds;
     for(j=0;j<MAXPLOT3DVARS;j++){
 
-      label = plot3dinfo[update_plot3d_bounds].label[j].longlabel;
-      unit = plot3dinfo[update_plot3d_bounds].label[j].unit;
+      label = global_scase.plot3dinfo[update_plot3d_bounds].label[j].longlabel;
+      unit = global_scase.plot3dinfo[update_plot3d_bounds].label[j].unit;
       valmin_fds = 1.0;
       valmax_fds = 0.0;
       valmin_smv = 1.0;
       valmax_smv = 0.0;
-      for(i = 0; i<nplot3dinfo; i++){
+      for(i = 0; i<global_scase.nplot3dinfo; i++){
         plot3ddata *plot3di;
 
-        plot3di = plot3dinfo+i;
+        plot3di = global_scase.plot3dinfo+i;
         if(plot3di->loaded==0)continue;
         if(valmin_fds>valmax_fds){
           valmin_fds = plot3di->valmin_plot3d[j];
@@ -3006,10 +3006,10 @@ void UpdateDisplay(void){
   if(update_make_iblank == 1){
     int ig;
 
-    for(ig = 0; ig < nmeshes; ig++){
+    for(ig = 0; ig < global_scase.meshescoll.nmeshes; ig++){
       meshdata *meshi;
 
-      meshi = meshinfo + ig;
+      meshi = global_scase.meshescoll.meshinfo + ig;
       meshi->c_iblank_node = meshi->c_iblank_node_temp;
       meshi->c_iblank_cell = meshi->c_iblank_cell_temp;
       meshi->f_iblank_cell = meshi->f_iblank_cell_temp;
@@ -3027,11 +3027,11 @@ void UpdateDisplay(void){
     }
     INIT_PRINT_TIMER(timer_hidden_blockages);
     int nhidden_faces = 0, ntotal_obsts = 0;
-    for(ig = 0; ig < nmeshes; ig++){
+    for(ig = 0; ig < global_scase.meshescoll.nmeshes; ig++){
       meshdata *meshi;
       int j;
 
-      meshi = meshinfo + ig;
+      meshi = global_scase.meshescoll.meshinfo + ig;
       void SetHiddenBlockages(meshdata *meshi);
       if(have_hidden6 == 0){
         if(ig == 0)printf("setting hidden blockages\n");

--- a/Source/smokeview/viewports.c
+++ b/Source/smokeview/viewports.c
@@ -51,7 +51,7 @@ void GetColorbarLabelWidth(int show_slice_colorbar_local, int showcfast_local,
     patchdata *patchi;
     char boundary_colorlabel[256];
 
-    patchi = patchinfo+boundarytypes[iboundarytype];
+    patchi = global_scase.patchinfo+global_scase.boundarytypes[iboundarytype];
 
     *boundary_label_width = MAX(*boundary_label_width, GetStringWidth("BNDRYA"));
 
@@ -952,12 +952,12 @@ void ViewportInfo(int quad, GLint screen_left, GLint screen_down){
 
     if(mesh_xyz==NULL){
       sprintf(meshlabel,"mesh: %i",highlight_mesh+1);
-      mesh_xyz = meshinfo + highlight_mesh;
+      mesh_xyz = global_scase.meshescoll.meshinfo + highlight_mesh;
     }
     else{
       int imesh;
 
-      imesh = mesh_xyz-meshinfo+1;
+      imesh = mesh_xyz-global_scase.meshescoll.meshinfo+1;
       sprintf(meshlabel,"mesh: %i",imesh);
     }
     OutputText(VP_info.left+h_space,VP_info.down+v_space+info_lines*(v_space+VP_info.text_height), meshlabel);
@@ -980,20 +980,20 @@ void ViewportHrrPlot(int quad, GLint screen_left, GLint screen_down){
     float valmin, valmax;
 
     if(hrr_col>=0&&mlr_col>=0&&hoc_hrr==1&&(glui_hrr==hrr_col||glui_hrr==mlr_col)){
-      hi        = hrrinfo + mlr_col;
-      hi2       = hrrinfo + hrr_col;
+      hi        = global_scase.hrr_coll.hrrinfo + mlr_col;
+      hi2       = global_scase.hrr_coll.hrrinfo + hrr_col;
       vals2     = hi2->vals;
       quantity2 = hi2->label.longlabel;
       valmin    = MIN(hi->valmin, hi2->valmin);
       valmax    = MAX(hi->valmax, hi2->valmax);
     }
     else{
-      hi     = hrrinfo+glui_hrr;
+      hi     = global_scase.hrr_coll.hrrinfo+glui_hrr;
       valmin = hi->valmin;
       valmax = hi->valmax;
     }
 
-    hitime = hrrinfo+time_col;
+    hitime = global_scase.hrr_coll.hrrinfo+time_col;
 
     if(update_avg==1){
       TimeAveragePlot2DData(hitime->vals, hi->vals_orig, hi->vals, hi->nvals, plot2d_time_average);
@@ -1029,11 +1029,11 @@ void OutputSlicePlot(char *file){
     return;
   }
 
-  for(i = 0; i < slicecoll.nsliceinfo; i++){
+  for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
     slicedata *slicei;
     devicedata *devicei;
 
-    slicei = slicecoll.sliceinfo + i;
+    slicei = global_scase.slicecoll.sliceinfo + i;
     devicei = &(slicei->vals2d);
     if(slicei->loaded == 0 || devicei->valid == 0)continue;
     if(first == 1){
@@ -1048,11 +1048,11 @@ void OutputSlicePlot(char *file){
 
   for(j = -3;j < ntimes;j++){
     first = 1;
-    for(i = 0; i < slicecoll.nsliceinfo; i++){
+    for(i = 0; i < global_scase.slicecoll.nsliceinfo; i++){
       slicedata *slicei;
       devicedata *devicei;
 
-      slicei = slicecoll.sliceinfo + i;
+      slicei = global_scase.slicecoll.sliceinfo + i;
       devicei = &(slicei->vals2d);
       if(slicei->loaded == 0 || devicei->valid == 0)continue;
       if(j == -3){
@@ -1135,13 +1135,13 @@ void ViewportSlicePlot(int quad, GLint screen_left, GLint screen_down){
     int i, position;
 
     position = 0;
-    for(i = 0; i<slicecoll.nsliceinfo; i++){
+    for(i = 0; i<global_scase.slicecoll.nsliceinfo; i++){
       slicedata *slicei;
       devicedata *devicei;
       float valmin, valmax;
       float highlight_val;
 
-      slicei = slicecoll.sliceinfo+i;
+      slicei = global_scase.slicecoll.sliceinfo+i;
       devicei = &(slicei->vals2d);
       if(slicei->loaded==0||devicei->valid==0)continue;
 
@@ -1274,7 +1274,7 @@ void ViewportTimebar(int quad, GLint screen_left, GLint screen_down){
     float f_red, f_green, f_blue;
 
     if(hrrpuv_loaded == 1 && show_firecutoff == 1){
-      i_cutoff = (int)(global_hrrpuv_cutoff + 0.5);
+      i_cutoff = (int)(global_scase.global_hrrpuv_cutoff + 0.5);
       sprintf(cutoff_label, ">%i kW/m3", i_cutoff);
     }
     else{
@@ -1297,11 +1297,11 @@ void ViewportTimebar(int quad, GLint screen_left, GLint screen_down){
         icolor = 192;
       }
       else if(strcmp(fire_colorbar->menu_label, "fire 2") == 0){
-        icolor = 128 + 127*(global_hrrpuv_cutoff - global_hrrpuv_min) / (global_hrrpuv_max - global_hrrpuv_min);
+        icolor = 128 + 127*(global_scase.global_hrrpuv_cutoff - global_hrrpuv_min) / (global_hrrpuv_max - global_hrrpuv_min);
         icolor = CLAMP((icolor + 1), 0, 255);
       }
       else{
-        icolor = 255*(global_hrrpuv_cutoff-global_hrrpuv_min)/(global_hrrpuv_max-global_hrrpuv_min);
+        icolor = 255*(global_scase.global_hrrpuv_cutoff-global_hrrpuv_min)/(global_hrrpuv_max-global_hrrpuv_min);
         icolor = CLAMP((icolor + 1), 0, 255);
       }
       colors = fire_colorbar->colorbar_rgb;
@@ -1395,8 +1395,8 @@ int CompareMeshes(const void *arg1, const void *arg2){
 
   smoke3di = *(smoke3ddata **)arg1;
   smoke3dj = *(smoke3ddata **)arg2;
-  meshi = meshinfo + smoke3di->blocknumber;
-  meshj = meshinfo + smoke3dj->blocknumber;
+  meshi = global_scase.meshescoll.meshinfo + smoke3di->blocknumber;
+  meshj = global_scase.meshescoll.meshinfo + smoke3dj->blocknumber;
   if(meshi == meshj)return 0;
   xyzmini = meshi->boxmin;
   xyzmaxi = meshi->boxmax;
@@ -1476,8 +1476,8 @@ int CompareMeshes(const void *arg1, const void *arg2){
 /* ------------------ SortSmoke3dinfo ------------------------ */
 
 void SortSmoke3dinfo(void){
-  if(smoke3dcoll.nsmoke3dinfo > 1){
-    qsort((meshdata **)smoke3dcoll.smoke3dinfo_sorted, (size_t)smoke3dcoll.nsmoke3dinfo, sizeof(smoke3ddata *), CompareMeshes);
+  if(global_scase.smoke3dcoll.nsmoke3dinfo > 1){
+    qsort((meshdata **)global_scase.smoke3dcoll.smoke3dinfo_sorted, (size_t)global_scase.smoke3dcoll.nsmoke3dinfo, sizeof(smoke3ddata *), CompareMeshes);
   }
 }
 
@@ -1508,17 +1508,17 @@ void GetEyePos(float *mm){
   smv_eyepos[2] = -(mm[8]*mm[12] + mm[9]*mm[13] + mm[10]*mm[14])/mscale[2];
   SMV2FDS_XYZ(fds_eyepos, smv_eyepos);
 
-  for(i = 0; i<nmeshes; i++){
+  for(i = 0; i<global_scase.meshescoll.nmeshes; i++){
     meshdata *meshi;
 
-    meshi = meshinfo+i;
+    meshi = global_scase.meshescoll.meshinfo+i;
     scene_center[0] += meshi->boxmiddle[0];
     scene_center[1] += meshi->boxmiddle[1];
     scene_center[2] += meshi->boxmiddle[2];
   }
-  scene_center[0] /= nmeshes;
-  scene_center[1] /= nmeshes;
-  scene_center[2] /= nmeshes;
+  scene_center[0] /= global_scase.meshescoll.nmeshes;
+  scene_center[1] /= global_scase.meshescoll.nmeshes;
+  scene_center[2] /= global_scase.meshescoll.nmeshes;
   fds_viewdir[0] = scene_center[0] - fds_eyepos[0];
   fds_viewdir[1] = scene_center[1] - fds_eyepos[1];
   fds_viewdir[2] = scene_center[2] - fds_eyepos[2];
@@ -1583,14 +1583,14 @@ void GetVolSmokeDir(float *mm){
   eye_position_smv[1] = -DOT3(mm + 4, mm + 12) / mscale[1];
   eye_position_smv[2] = -DOT3(mm + 8, mm + 12) / mscale[2];
 
-  for(j = 0;j<nmeshes;j++){
+  for(j = 0;j<global_scase.meshescoll.nmeshes;j++){
     meshdata *meshj;
     int *inside;
     int *drawsides;
     float x0, x1, yy0, yy1, z0, z1;
     float xcen, ycen, zcen;
 
-    meshj = meshinfo + j;
+    meshj = global_scase.meshescoll.meshinfo + j;
 
     inside = &meshj->inside;
     drawsides = meshj->drawsides;
@@ -1686,12 +1686,12 @@ void GetVolSmokeDir(float *mm){
 
   // turn off drawing for mesh sides that are on the inside of a supermesh
   if(combine_meshes == 1){
-    for(i = 0;i<nmeshes;i++){
+    for(i = 0;i<global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       int *drawsides, *extsides;
       int jj;
 
-      meshi = meshinfo + i;
+      meshi = global_scase.meshescoll.meshinfo + i;
       drawsides = meshi->drawsides;
       extsides = meshi->extsides;
       for(jj = 0;jj<7;jj++){
@@ -1700,10 +1700,10 @@ void GetVolSmokeDir(float *mm){
         }
       }
     }
-    for(i = 0;i<nsupermeshinfo;i++){
+    for(i = 0;i<global_scase.nsupermeshinfo;i++){
       supermeshdata *smesh;
 
-      smesh = supermeshinfo + i;
+      smesh = global_scase.supermeshinfo + i;
       for(j = 0;j<7;j++){
         smesh->drawsides[j] = 0;
       }
@@ -1721,13 +1721,13 @@ void GetVolSmokeDir(float *mm){
 
   vi = volfacelistinfo;
   nvolfacelistinfo = 0;
-  for(i = 0;i<nmeshes;i++){
+  for(i = 0;i<global_scase.meshescoll.nmeshes;i++){
     meshdata *meshi;
     int facemap[7] = {12,6,0,0,3,9,15};
     volrenderdata *vr;
     int *drawsides;
 
-    meshi = meshinfo + i;
+    meshi = global_scase.meshescoll.meshinfo + i;
 
     drawsides = meshi->drawsides;
 
@@ -1786,13 +1786,13 @@ void GetSmokeDir(float *mm){
   eye_position_smv[1] = -DOT3(mm + 4, mm + 12) / mscale[1];
   eye_position_smv[2] = -DOT3(mm + 8, mm + 12) / mscale[2];
 
-  for(j = 0;j<nmeshes;j++){
+  for(j = 0;j<global_scase.meshescoll.nmeshes;j++){
     meshdata  *meshj;
     int i;
     float absangle, cosangle, minangle, mincosangle;
     int iminangle, alphadir, minalphadir;
 
-    meshj = meshinfo + j;
+    meshj = global_scase.meshescoll.meshinfo + j;
     dx = meshj->boxmiddle_scaled[0] - eye_position_smv[0];
     dy = meshj->boxmiddle_scaled[1] - eye_position_smv[1];
     dz = meshj->boxmiddle_scaled[2] - eye_position_smv[2];
@@ -2032,10 +2032,10 @@ void GetZoneSmokeDir(float *mm){
   eye_position_smv[1] = -(mm[4] * mm[12] + mm[5] * mm[13] + mm[6] * mm[14]) / mscale[1];
   eye_position_smv[2] = -(mm[8] * mm[12] + mm[9] * mm[13] + mm[10] * mm[14]) / mscale[2];
 
-  for(j = 0;j<nrooms;j++){
+  for(j = 0;j<global_scase.nrooms;j++){
     roomdata *roomj;
 
-    roomj = roominfo + j;
+    roomj = global_scase.roominfo + j;
 
     roomj->zoneinside = 0;
     if(
@@ -2330,11 +2330,11 @@ void GetMinMaxDepth(float *min_depth, float *max_depth){
   if(edittour==1){
     int i;
 
-    for(i = 0; i<tourcoll.ntourinfo; i++){
+    for(i = 0; i<global_scase.tourcoll.ntourinfo; i++){
       tourdata *touri;
       keyframe *keyj;
 
-      touri = tourcoll.tourinfo+i;
+      touri = global_scase.tourcoll.tourinfo+i;
       for(keyj = (touri->first_frame).next; keyj->next!=NULL; keyj = keyj->next){
         float dist, dx, dy, dz;
 
@@ -2374,7 +2374,7 @@ void ViewportScene(int quad, int view_mode, GLint screen_left, GLint screen_down
     if((tour_snap==1||viewtourfrompath==1)&&selectedtour_index>=0){
       tourdata *touri;
 
-      touri = tourcoll.tourinfo + selectedtour_index;
+      touri = global_scase.tourcoll.tourinfo + selectedtour_index;
       if(tour_snap==1){
         SetTourXYZView(tour_snap_time, touri);
       }
@@ -2409,7 +2409,7 @@ void ViewportScene(int quad, int view_mode, GLint screen_left, GLint screen_down
     float min_depth, max_depth;
 
     GetMinMaxDepth(&min_depth, &max_depth);
-    if(is_terrain_case==1){
+    if(global_scase.is_terrain_case==1){
       fnear = MAX(min_depth  -0.1,     0.00001);
       ffar  = MAX(max_depth + 0.1, fnear+2.0);
     }
@@ -2500,7 +2500,7 @@ void ViewportScene(int quad, int view_mode, GLint screen_left, GLint screen_down
 
       if(plotstate==DYNAMIC_PLOTS&&selected_tour!=NULL&&selected_tour->timeslist!=NULL){
         if((tour_snap==1||viewtourfrompath==1)&&selectedtour_index>=0){
-          touri = tourcoll.tourinfo + selectedtour_index;
+          touri = global_scase.tourcoll.tourinfo + selectedtour_index;
           if(tour_snap==1){
             SetTourXYZView(tour_snap_time, touri);
           }
@@ -2630,7 +2630,7 @@ void ViewportScene(int quad, int view_mode, GLint screen_left, GLint screen_down
     if(show_gslice_triangles==1||SHOW_gslice_data==1){
       UpdateGslicePlanes();
     }
-    if(nrooms>0){
+    if(global_scase.nrooms>0){
       GetZoneSmokeDir(modelview_scratch);
     }
     if(nvolrenderinfo>0&&showvolrender==1&&usevolrender==1){
@@ -2642,7 +2642,7 @@ void ViewportScene(int quad, int view_mode, GLint screen_left, GLint screen_down
       ComputeAllSmokecolors();
 #endif
     }
-    if(smoke3dcoll.nsmoke3dinfo>0&&show3dsmoke==1){
+    if(global_scase.smoke3dcoll.nsmoke3dinfo>0&&show3dsmoke==1){
       SortSmoke3dinfo();
       GetSmokeDir(modelview_scratch);
       SNIFF_ERRORS("after GetSmokeDir");

--- a/Source/smvq/smvq.c
+++ b/Source/smvq/smvq.c
@@ -10,6 +10,8 @@
 #include <sys/types.h>
 
 #include "dmalloc.h"
+#include "shared_structures.h"
+
 #include "smokeviewvars.h"
 #include "string_util.h"
 
@@ -44,109 +46,109 @@ char *GetBaseName(const char *input_file) {
   return result;
 }
 
-int SetGlobalFilenames(const char *fdsprefix_arg) {
-  int len_casename = strlen(fdsprefix_arg);
-  strcpy(movie_name, fdsprefix_arg);
-  strcpy(render_file_base, fdsprefix_arg);
-  strcpy(html_file_base, fdsprefix_arg);
+int SetGlobalFilenames() {
+  int len_casename = strlen(global_scase.fdsprefix);
+  strcpy(movie_name, global_scase.fdsprefix);
+  strcpy(render_file_base, global_scase.fdsprefix);
+  strcpy(html_file_base, global_scase.fdsprefix);
 
-  FREEMEMORY(log_filename);
-  NewMemory((void **)&log_filename, len_casename + strlen(".smvlog") + 1);
-  STRCPY(log_filename, fdsprefix_arg);
-  STRCAT(log_filename, ".smvlog");
+  FREEMEMORY(global_scase.paths.log_filename);
+  NewMemory((void **)&global_scase.paths.log_filename, len_casename + strlen(".smvlog") + 1);
+  STRCPY(global_scase.paths.log_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.log_filename, ".smvlog");
 
-  FREEMEMORY(caseini_filename);
-  NewMemory((void **)&caseini_filename, len_casename + strlen(".ini") + 1);
-  STRCPY(caseini_filename, fdsprefix_arg);
-  STRCAT(caseini_filename, ".ini");
+  FREEMEMORY(global_scase.paths.caseini_filename);
+  NewMemory((void **)&global_scase.paths.caseini_filename, len_casename + strlen(".ini") + 1);
+  STRCPY(global_scase.paths.caseini_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.caseini_filename, ".ini");
 
-  FREEMEMORY(expcsv_filename);
-  NewMemory((void **)&expcsv_filename, len_casename + strlen("_exp.csv") + 1);
-  STRCPY(expcsv_filename, fdsprefix_arg);
-  STRCAT(expcsv_filename, "_exp.csv");
+  FREEMEMORY(global_scase.paths.expcsv_filename);
+  NewMemory((void **)&global_scase.paths.expcsv_filename, len_casename + strlen("_exp.csv") + 1);
+  STRCPY(global_scase.paths.expcsv_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.expcsv_filename, "_exp.csv");
 
-  FREEMEMORY(dEcsv_filename);
-  NewMemory((void **)&dEcsv_filename, len_casename + strlen("_dE.csv") + 1);
-  STRCPY(dEcsv_filename, fdsprefix_arg);
-  STRCAT(dEcsv_filename, "_dE.csv");
+  FREEMEMORY(global_scase.paths.dEcsv_filename);
+  NewMemory((void **)&global_scase.paths.dEcsv_filename, len_casename + strlen("_dE.csv") + 1);
+  STRCPY(global_scase.paths.dEcsv_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.dEcsv_filename, "_dE.csv");
 
-  FREEMEMORY(html_filename);
-  NewMemory((void **)&html_filename, len_casename + strlen(".html") + 1);
-  STRCPY(html_filename, fdsprefix_arg);
-  STRCAT(html_filename, ".html");
+  FREEMEMORY(global_scase.paths.html_filename);
+  NewMemory((void **)&global_scase.paths.html_filename, len_casename + strlen(".html") + 1);
+  STRCPY(global_scase.paths.html_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.html_filename, ".html");
 
-  FREEMEMORY(smv_orig_filename);
-  NewMemory((void **)&smv_orig_filename, len_casename + strlen(".smo") + 1);
-  STRCPY(smv_orig_filename, fdsprefix_arg);
-  STRCAT(smv_orig_filename, ".smo");
+  FREEMEMORY(global_scase.paths.smv_orig_filename);
+  NewMemory((void **)&global_scase.paths.smv_orig_filename, len_casename + strlen(".smo") + 1);
+  STRCPY(global_scase.paths.smv_orig_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.smv_orig_filename, ".smo");
 
-  FREEMEMORY(hrr_filename);
-  NewMemory((void **)&hrr_filename, len_casename + strlen("_hrr.csv") + 1);
-  STRCPY(hrr_filename, fdsprefix_arg);
-  STRCAT(hrr_filename, "_hrr.csv");
+  FREEMEMORY(global_scase.paths.hrr_filename);
+  NewMemory((void **)&global_scase.paths.hrr_filename, len_casename + strlen("_hrr.csv") + 1);
+  STRCPY(global_scase.paths.hrr_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.hrr_filename, "_hrr.csv");
 
-  FREEMEMORY(htmlvr_filename);
-  NewMemory((void **)&htmlvr_filename, len_casename + strlen("_vr.html") + 1);
-  STRCPY(htmlvr_filename, fdsprefix_arg);
-  STRCAT(htmlvr_filename, "_vr.html");
+  FREEMEMORY(global_scase.paths.htmlvr_filename);
+  NewMemory((void **)&global_scase.paths.htmlvr_filename, len_casename + strlen("_vr.html") + 1);
+  STRCPY(global_scase.paths.htmlvr_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.htmlvr_filename, "_vr.html");
 
-  FREEMEMORY(htmlobst_filename);
-  NewMemory((void **)&htmlobst_filename,
+  FREEMEMORY(global_scase.paths.htmlobst_filename);
+  NewMemory((void **)&global_scase.paths.htmlobst_filename,
             len_casename + strlen("_obst.json") + 1);
-  STRCPY(htmlobst_filename, fdsprefix_arg);
-  STRCAT(htmlobst_filename, "_obst.json");
+  STRCPY(global_scase.paths.htmlobst_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.htmlobst_filename, "_obst.json");
 
-  FREEMEMORY(htmlslicenode_filename);
-  NewMemory((void **)&htmlslicenode_filename,
+  FREEMEMORY(global_scase.paths.htmlslicenode_filename);
+  NewMemory((void **)&global_scase.paths.htmlslicenode_filename,
             len_casename + strlen("_slicenode.json") + 1);
-  STRCPY(htmlslicenode_filename, fdsprefix_arg);
-  STRCAT(htmlslicenode_filename, "_slicenode.json");
+  STRCPY(global_scase.paths.htmlslicenode_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.htmlslicenode_filename, "_slicenode.json");
 
-  FREEMEMORY(htmlslicecell_filename);
-  NewMemory((void **)&htmlslicecell_filename,
+  FREEMEMORY(global_scase.paths.htmlslicecell_filename);
+  NewMemory((void **)&global_scase.paths.htmlslicecell_filename,
             len_casename + strlen("_slicecell.json") + 1);
-  STRCPY(htmlslicecell_filename, fdsprefix_arg);
-  STRCAT(htmlslicecell_filename, "_slicecell.json");
+  STRCPY(global_scase.paths.htmlslicecell_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.htmlslicecell_filename, "_slicecell.json");
 
-  FREEMEMORY(event_filename);
-  NewMemory((void **)&event_filename, len_casename + strlen("_events.csv") + 1);
-  STRCPY(event_filename, fdsprefix_arg);
-  STRCAT(event_filename, "_events.csv");
+  FREEMEMORY(global_scase.paths.event_filename);
+  NewMemory((void **)&global_scase.paths.event_filename, len_casename + strlen("_events.csv") + 1);
+  STRCPY(global_scase.paths.event_filename, global_scase.fdsprefix);
+  STRCAT(global_scase.paths.event_filename, "_events.csv");
 
-  if (ffmpeg_command_filename == NULL) {
-    NewMemory((void **)&ffmpeg_command_filename,
+  if (global_scase.paths.ffmpeg_command_filename == NULL) {
+    NewMemory((void **)&global_scase.paths.ffmpeg_command_filename,
               (unsigned int)(len_casename + 12));
-    STRCPY(ffmpeg_command_filename, fdsprefix_arg);
-    STRCAT(ffmpeg_command_filename, "_ffmpeg");
+    STRCPY(global_scase.paths.ffmpeg_command_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.ffmpeg_command_filename, "_ffmpeg");
 #ifdef WIN32
-    STRCAT(ffmpeg_command_filename, ".bat");
+    STRCAT(global_scase.paths.ffmpeg_command_filename, ".bat");
 #else
-    STRCAT(ffmpeg_command_filename, ".sh");
+    STRCAT(global_scase.paths.ffmpeg_command_filename, ".sh");
 #endif
   }
-  if (stop_filename == NULL) {
-    NewMemory((void **)&stop_filename,
+  if (global_scase.paths.stop_filename == NULL) {
+    NewMemory((void **)&global_scase.paths.stop_filename,
               (unsigned int)(len_casename + strlen(".stop") + 1));
-    STRCPY(stop_filename, fdsprefix_arg);
-    STRCAT(stop_filename, ".stop");
+    STRCPY(global_scase.paths.stop_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.stop_filename, ".stop");
   }
-  if (smvzip_filename == NULL) {
-    NewMemory((void **)&smvzip_filename,
+  if (global_scase.paths.smvzip_filename == NULL) {
+    NewMemory((void **)&global_scase.paths.smvzip_filename,
               (unsigned int)(len_casename + strlen(".smvzip") + 1));
-    STRCPY(smvzip_filename, fdsprefix_arg);
-    STRCAT(smvzip_filename, ".smvzip");
+    STRCPY(global_scase.paths.smvzip_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.smvzip_filename, ".smvzip");
   }
-  if (sliceinfo_filename == NULL) {
-    NewMemory((void **)&sliceinfo_filename,
-              strlen(fdsprefix_arg) + strlen(".sinfo") + 1);
-    STRCPY(sliceinfo_filename, fdsprefix_arg);
-    STRCAT(sliceinfo_filename, ".sinfo");
+  if (global_scase.paths.sliceinfo_filename == NULL) {
+    NewMemory((void **)&global_scase.paths.sliceinfo_filename,
+              strlen(global_scase.fdsprefix) + strlen(".sinfo") + 1);
+    STRCPY(global_scase.paths.sliceinfo_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.sliceinfo_filename, ".sinfo");
   }
-  if (deviceinfo_filename == NULL) {
-    NewMemory((void **)&deviceinfo_filename,
-              strlen(fdsprefix_arg) + strlen("_device.info") + 1);
-    STRCPY(deviceinfo_filename, fdsprefix_arg);
-    STRCAT(deviceinfo_filename, "_device.info");
+  if (global_scase.paths.deviceinfo_filename == NULL) {
+    NewMemory((void **)&global_scase.paths.deviceinfo_filename,
+              strlen(global_scase.fdsprefix) + strlen("_device.info") + 1);
+    STRCPY(global_scase.paths.deviceinfo_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.deviceinfo_filename, "_device.info");
   }
 
   // if smokezip created part2iso files then concatenate .smv entries found in
@@ -156,75 +158,54 @@ int SetGlobalFilenames(const char *fdsprefix_arg) {
   {
     FILE *stream_iso = NULL;
 
-    NewMemory((void **)&iso_filename, len_casename + strlen(".isosmv") + 1);
-    STRCPY(iso_filename, fdsprefix_arg);
-    STRCAT(iso_filename, ".isosmv");
-    stream_iso = fopen(iso_filename, "r");
+    NewMemory((void **)&global_scase.paths.iso_filename, len_casename + strlen(".isosmv") + 1);
+    STRCPY(global_scase.paths.iso_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.iso_filename, ".isosmv");
+    stream_iso = fopen(global_scase.paths.iso_filename, "r");
     if (stream_iso != NULL) {
       fclose(stream_iso);
     }
     else {
-      FREEMEMORY(iso_filename);
+      FREEMEMORY(global_scase.paths.iso_filename);
     }
   }
 
-  if (trainer_filename == NULL) {
-    NewMemory((void **)&trainer_filename, (unsigned int)(len_casename + 6));
-    STRCPY(trainer_filename, fdsprefix_arg);
-    STRCAT(trainer_filename, ".svd");
+  if (global_scase.paths.trainer_filename == NULL) {
+    NewMemory((void **)&global_scase.paths.trainer_filename, (unsigned int)(len_casename + 6));
+    STRCPY(global_scase.paths.trainer_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.trainer_filename, ".svd");
   }
-  if (test_filename == NULL) {
-    NewMemory((void **)&test_filename, (unsigned int)(len_casename + 6));
-    STRCPY(test_filename, fdsprefix_arg);
-    STRCAT(test_filename, ".svd");
+  if (global_scase.paths.test_filename == NULL) {
+    NewMemory((void **)&global_scase.paths.test_filename, (unsigned int)(len_casename + 6));
+    STRCPY(global_scase.paths.test_filename, global_scase.fdsprefix);
+    STRCAT(global_scase.paths.test_filename, ".svd");
   }
   return 0;
 }
 
-int RunBenchmark(char *input_file) {
-  initMALLOC();
-  InitVars();
-  SetGlobalFilenames(fdsprefix);
-
-  INIT_PRINT_TIMER(parse_time);
-  fprintf(stderr, "reading:\t%s\n", input_file);
-  {
-    bufferstreamdata *smv_streaminfo = GetSMVBuffer(input_file);
-    if (smv_streaminfo == NULL) {
-      fprintf(stderr, "could not open %s\n", input_file);
-      return 1;
-    }
-    INIT_PRINT_TIMER(ReadSMV_time);
-    int return_code = ReadSMV(smv_streaminfo);
-    STOP_TIMER(ReadSMV_time);
-    fprintf(stderr, "ReadSMV:\t%8.3f ms\n", ReadSMV_time * 1000);
-    if (smv_streaminfo != NULL) {
-      FCLOSE(smv_streaminfo);
-    }
-    if (return_code) return return_code;
-  }
-  show_timings = 1;
-  ReadSMVOrig();
-  INIT_PRINT_TIMER(ReadSMVDynamic_time);
-  ReadSMVDynamic(input_file);
-  STOP_TIMER(ReadSMVDynamic_time);
-  fprintf(stderr, "ReadSMVDynamic:\t%8.3f ms\n", ReadSMVDynamic_time * 1000);
-  STOP_TIMER(parse_time);
-  fprintf(stderr, "Total Time:\t%8.3f ms\n", parse_time * 1000);
+int PrintJson(smv_case *scase) {
   struct json_object *jobj = json_object_new_object();
   json_object_object_add(jobj, "version", json_object_new_int(1));
-  json_object_object_add(jobj, "chid", json_object_new_string(chidfilebase));
-  if (fds_title != NULL) {
-    json_object_object_add(jobj, "title", json_object_new_string(fds_title));
+  json_object_object_add(jobj, "chid",
+                         json_object_new_string(scase->paths.chidfilebase));
+  if(scase->paths.fds_filein != NULL) {
+    json_object_object_add(jobj, "input_file",
+                           json_object_new_string(scase->paths.fds_filein));
   }
+  if(scase->fds_title != NULL) {
+    json_object_object_add(jobj, "title",
+                           json_object_new_string(scase->fds_title));
+  }
+  if(scase->fds_version != NULL) {
   json_object_object_add(jobj, "fds_version",
-                         json_object_new_string(fds_version));
+                         json_object_new_string(scase->fds_version));
+  }
   struct json_object *mesh_array = json_object_new_array();
-  for (int i = 0; i < nmeshes; i++) {
-    meshdata *mesh = &meshinfo[i];
+  for(int i = 0; i < scase->meshescoll.nmeshes; i++) {
+    meshdata *mesh = &scase->meshescoll.meshinfo[i];
     struct json_object *mesh_obj = json_object_new_object();
     json_object_object_add(mesh_obj, "index", json_object_new_int(i + 1));
-    if (mesh->label != NULL) {
+    if(mesh->label != NULL) {
       json_object_object_add(mesh_obj, "id",
                              json_object_new_string(mesh->label));
     }
@@ -243,7 +224,7 @@ int RunBenchmark(char *input_file) {
                            json_object_new_double(mesh->x1));
     json_object_object_add(mesh_dimensions, "y_min",
                            json_object_new_double(mesh->y0));
-    json_object_object_add(mesh_dimensions, "y_ax",
+    json_object_object_add(mesh_dimensions, "y_max",
                            json_object_new_double(mesh->y1));
     json_object_object_add(mesh_dimensions, "z_min",
                            json_object_new_double(mesh->z0));
@@ -299,8 +280,8 @@ int RunBenchmark(char *input_file) {
   // TODO: the parse rejects CSV files that it doesn't find in it's own working
   // directory.
   struct json_object *csv_files = json_object_new_array();
-  for (int i = 0; i < ncsvfileinfo; i++) {
-    csvfiledata *csv_file = &csvfileinfo[i];
+  for(int i = 0; i < scase->csvcoll.ncsvfileinfo; i++) {
+    csvfiledata *csv_file = &scase->csvcoll.csvfileinfo[i];
     struct json_object *csv_obj = json_object_new_object();
     json_object_object_add(csv_obj, "index", json_object_new_int(i + 1));
     json_object_object_add(csv_obj, "filename",
@@ -313,8 +294,8 @@ int RunBenchmark(char *input_file) {
 
   // Add devices to JSON
   struct json_object *devices = json_object_new_array();
-  for (int i = 0; i < ndeviceinfo; i++) {
-    devicedata *device = &deviceinfo[i];
+  for(int i = 0; i < scase->devicecoll.ndeviceinfo; i++) {
+    devicedata *device = &scase->devicecoll.deviceinfo[i];
     struct json_object *device_obj = json_object_new_object();
     json_object_object_add(device_obj, "index", json_object_new_int(i + 1));
     json_object_object_add(device_obj, "id",
@@ -353,8 +334,8 @@ int RunBenchmark(char *input_file) {
 
   // Add slices to JSON
   struct json_object *slices = json_object_new_array();
-  for (int i = 0; i < slicecoll.nsliceinfo; i++) {
-    slicedata *slice = &slicecoll.sliceinfo[i];
+  for(int i = 0; i < scase->slicecoll.nsliceinfo; i++) {
+    slicedata *slice = &scase->slicecoll.sliceinfo[i];
     struct json_object *slice_obj = json_object_new_object();
     json_object_object_add(slice_obj, "index", json_object_new_int(i + 1));
     json_object_object_add(slice_obj, "mesh",
@@ -395,8 +376,8 @@ int RunBenchmark(char *input_file) {
 
   // Add surfaces to JSON
   struct json_object *surfaces = json_object_new_array();
-  for (int i = 0; i < nsurfinfo; i++) {
-    surfdata *surf = &surfinfo[i];
+  for(int i = 0; i < scase->surfcoll.nsurfinfo; i++) {
+    surfdata *surf = &scase->surfcoll.surfinfo[i];
     struct json_object *surf_obj = json_object_new_object();
     json_object_object_add(surf_obj, "index", json_object_new_int(i + 1));
     json_object_object_add(surf_obj, "id",
@@ -407,8 +388,8 @@ int RunBenchmark(char *input_file) {
 
   // Add materials to JSON
   struct json_object *materials = json_object_new_array();
-  for (int i = 0; i < nsurfinfo; i++) {
-    surfdata *surf = &surfinfo[i];
+  for(int i = 0; i < scase->surfcoll.nsurfinfo; i++) {
+    surfdata *surf = &scase->surfcoll.surfinfo[i];
     struct json_object *surf_obj = json_object_new_object();
     json_object_object_add(surf_obj, "index", json_object_new_int(i + 1));
     json_object_object_add(surf_obj, "id",
@@ -421,6 +402,41 @@ int RunBenchmark(char *input_file) {
       json_object_to_json_string_ext(jobj, JSON_C_TO_STRING_PRETTY);
   printf("%s\n", json_output);
   json_object_put(jobj);
+  return 0;
+}
+
+
+int RunBenchmark(char *input_file) {
+  initMALLOC();
+  InitVars();
+  SetGlobalFilenames();
+
+  INIT_PRINT_TIMER(parse_time);
+  fprintf(stderr, "reading:\t%s\n", input_file);
+  {
+    bufferstreamdata *smv_streaminfo = GetSMVBuffer(input_file);
+    if(smv_streaminfo == NULL) {
+      fprintf(stderr, "could not open %s\n", input_file);
+      return 1;
+    }
+    INIT_PRINT_TIMER(ReadSMV_time);
+    int return_code = ReadSMV(smv_streaminfo);
+    STOP_TIMER(ReadSMV_time);
+    fprintf(stderr, "ReadSMV:\t%8.3f ms\n", ReadSMV_time * 1000);
+    if(smv_streaminfo != NULL) {
+      FCLOSE(smv_streaminfo);
+    }
+    if(return_code) return return_code;
+  }
+  show_timings = 1;
+  ReadSMVOrig();
+  INIT_PRINT_TIMER(ReadSMVDynamic_time);
+  ReadSMVDynamic(input_file);
+  STOP_TIMER(ReadSMVDynamic_time);
+  fprintf(stderr, "ReadSMVDynamic:\t%8.3f ms\n", ReadSMVDynamic_time * 1000);
+  STOP_TIMER(parse_time);
+  fprintf(stderr, "Total Time:\t%8.3f ms\n", parse_time * 1000);
+  PrintJson(&global_scase);
   FreeVars();
   return 0;
 }
@@ -469,8 +485,7 @@ int main(int argc, char **argv) {
     fprintf(stderr, "No input file specified.\n");
     return 1;
   }
-  fdsprefix = GetBaseName(input_file);
+  global_scase.fdsprefix = GetBaseName(input_file);
   int result = RunBenchmark(input_file);
-  if (fdsprefix != NULL) free(fdsprefix);
   return result;
 }


### PR DESCRIPTION
This looks like a very large PR but only makes fairly simple change (just in many places).

Rather than accessing many disparate global variables, all simulation data is combined into a single struct (of type `smv_case`). Currently there is only a single global instance of this struct (`smv_case global_scase`). This means there is no behavioural change in this commit.

This completes a series of earlier commits which shifted functionality around.

Once this is changed functions can be used to take an smv_case as a parameter, but this can be done on a function-by-function basis without these large commits.

The intention is that this only includes simulation/case information and nothing that relates to the GUI etc. The intention is to gradually change everything in shared/ to take an `smv_case` as parameter while the smokeview GUI can continue to use a global struct.

This should make code easier to test and modify reliably.