### PR TITLE
fix to routine getting time interval when t=tend

### DIFF
--- a/Source/smokeview/smv_geometry.c
+++ b/Source/smokeview/smv_geometry.c
@@ -1016,7 +1016,7 @@ void GetScreenMapping(float *xyz0, float *screen_perm){
 int GetTimeInterval(float val, float *array, int n){
   if(n <= 1)return 0;
   if(val<array[1])return 0;
-  if(val>array[n-2])return n-2;
+  if(val>=array[n-1])return n-1;
   return GetInterval(val, array, n);
 }
 

--- a/Source/smokeview/update.c
+++ b/Source/smokeview/update.c
@@ -690,38 +690,6 @@ void UpdateShow(void){
   }
 }
 
-/* ------------------ GetItime ------------------------ */
-
-int GetItime(int n, int *timeslist, unsigned char *times_map, float *times, int ntimes){
-  int istart=0;
-
-  if(n>0)istart=timeslist[n-1];
-  if(times_map == NULL){
-    while(1){
-      if(istart < ntimes - 1 && times[istart] <= global_times[n]){
-        istart++;
-        continue;
-      }
-      break;
-    }
-  }
-  else{
-    while(1){
-      if(times_map != NULL && istart >= 0 && istart < ntimes - 1 && times_map[istart] == 0){
-        istart++;
-        continue;
-      }
-      if(istart < ntimes - 1 && times[istart] <= global_times[n]){
-        istart++;
-        continue;
-      }
-      break;
-    }
-  }
-  istart=CLAMP(istart,0,ntimes-1);
-  return istart;
-}
-
 /* ------------------ GetDataTimeFrame ------------------------ */
 
 int GetDataTimeFrame(float time, unsigned char *times_map, float *times, int ntimes){


### PR DESCRIPTION
note problem was occurring for all cases.  we just noticed it for the soborot case because the interval between visualization time steps was large.  I'll merge changes after smokebot passes