### PR TITLE
add CAD parsing geometry to cmake tests

### DIFF
--- a/Source/shared/readcad.c
+++ b/Source/shared/readcad.c
@@ -415,9 +415,9 @@ int ReadCADGeomToCollection(cadgeom_collection *coll, const char *file,
     fprintf(stderr, "CADGeomCollection has exceeded capacity");
     return -1;
   }
-  ReadCADGeom(&coll->cadgeominfo[coll->ncadgeom], file, block_shininess);
+  int res = ReadCADGeom(&coll->cadgeominfo[coll->ncadgeom], file, block_shininess);
   coll->ncadgeom++;
-  return 0;
+  return res;
 }
 
 /* ------------------ InitCADGeomCollection ------------------------ */

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -298,7 +298,7 @@ add_test(NAME "Simple PL3d - Complete"
     COMMAND parse_simple_pl3d ${FIG_DIR}/smv/Tests/simple_pl3d.q)
 
 add_test(NAME "Parse CAD"
-    COMMAND parse_cad)
+    COMMAND parse_cad ${CMAKE_SOURCE_DIR}/Verification/Visualization/cad_test.ge1)
 
 add_test(NAME "Test Object API"
     COMMAND test_objects)

--- a/Tests/parse_cad.c
+++ b/Tests/parse_cad.c
@@ -12,9 +12,17 @@ int show_version;
 char append_string[1024];
 
 int main(int argc, char **argv) {
+  if(argc < 2) {
+    fprintf(stderr, "error: insufficient arguments");
+  }
   initMALLOC();
+  char *input_path = argv[1];
   cadgeom_collection *coll = CreateCADGeomCollection(20);
   assert(NCADGeom(coll) == 0);
+  int res = ReadCADGeomToCollection(coll, input_path, 100.0);
+  fprintf(stderr, "#CAD defs: %i\n", NCADGeom(coll));
+  assert(res == 0);
+  assert(NCADGeom(coll) == 1);
   FreeCADGeomCollection(coll);
   return 0;
 }


### PR DESCRIPTION
This takes advantage of the CAD geometry file added to the repo to test CAD parsing code during the cmake tests (which run in CI).