### PR TITLE
correction to PR #2155

### DIFF
--- a/Source/smokeview/IOgeometry.c
+++ b/Source/smokeview/IOgeometry.c
@@ -827,13 +827,13 @@ void DrawBoxMinMax(float *bbmin, float *bbmax, float *box_color){
 /* ------------------ DrawObstBoundingBox ------------------------ */
 
 void DrawObstBoundingBox(void){
-  if(obst_bounding_box[0]>obst_bounding_box[1])return;
-  if(obst_bounding_box[2]>obst_bounding_box[3])return;
-  if(obst_bounding_box[4]>obst_bounding_box[5])return;
+  if(global_scase.obst_bounding_box[0]>global_scase.obst_bounding_box[1])return;
+  if(global_scase.obst_bounding_box[2]>global_scase.obst_bounding_box[3])return;
+  if(global_scase.obst_bounding_box[4]>global_scase.obst_bounding_box[5])return;
   glPushMatrix();
   glScalef(SCALE2SMV(1.0), SCALE2SMV(1.0), SCALE2SMV(1.0));
   glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
-  DrawBoxOutline(obst_bounding_box, foregroundcolor);
+  DrawBoxOutline(global_scase.obst_bounding_box, foregroundcolor);
   glPopMatrix();
 }
 

--- a/Source/smokeview/IOiso.c
+++ b/Source/smokeview/IOiso.c
@@ -552,7 +552,7 @@ FILE_SIZE ReadIsoGeom(int ifile, int load_flag, int *geom_frame_index, int *erro
   surfi = global_scase.surfcoll.surfinfo + global_scase.surfcoll.nsurfinfo+1;
   UpdateIsoColors();
   if(strcmp(isoi->surface_label.shortlabel,"hrrpuv")==0){
-    surfi->color=GetColorPtr(hrrpuv_iso_color);
+    surfi->color=GetColorPtr(&global_scase, hrrpuv_iso_color);
   }
 
   meshi->isofilenum=ifile;
@@ -760,9 +760,9 @@ void ReadIsoOrig(const char *file, int ifile, int flag, int *errorcode){
     float fed_yellow[]={1.0,1.0,0.0,1.0};
     float fed_red[]={1.0,0.0,0.0,1.0};
 
-    fed_colors[0]=GetColorPtr(fed_blue);
-    fed_colors[1]=GetColorPtr(fed_yellow);
-    fed_colors[2]=GetColorPtr(fed_red);
+    fed_colors[0]=GetColorPtr(&global_scase, fed_blue);
+    fed_colors[1]=GetColorPtr(&global_scase, fed_yellow);
+    fed_colors[2]=GetColorPtr(&global_scase, fed_red);
   }
   asurface=meshi->animatedsurfaces;
   break_frame=0;

--- a/Source/smokeview/IOiso.c
+++ b/Source/smokeview/IOiso.c
@@ -588,7 +588,7 @@ FILE_SIZE ReadIsoGeom(int ifile, int load_flag, int *geom_frame_index, int *erro
   isoi->loaded=1;
   isoi->display=1;
   loaded_isomesh= GetLoadedIsoMesh();
-  UpdateIsoShowLevels();
+  UpdateIsoShowLevels(&global_scase, loaded_isomesh);
   ReadIsoFile=1;
   plotstate=GetPlotState(DYNAMIC_PLOTS);
   updatemenu=1;
@@ -694,7 +694,7 @@ void ReadIsoOrig(const char *file, int ifile, int flag, int *errorcode){
   if(flag==UNLOAD){
     updatemenu=1;
     loaded_isomesh= GetLoadedIsoMesh();
-    UpdateIsoShowLevels();
+    UpdateIsoShowLevels(&global_scase, loaded_isomesh);
     return;
   }
   meshi->isofilenum=ifile;
@@ -1054,7 +1054,7 @@ void ReadIsoOrig(const char *file, int ifile, int flag, int *errorcode){
   ib->loaded=1;
   ib->display=1;
   loaded_isomesh= GetLoadedIsoMesh();
-  UpdateIsoShowLevels();
+  UpdateIsoShowLevels(&global_scase, loaded_isomesh);
   ReadIsoFile=1;
   plotstate=GetPlotState(DYNAMIC_PLOTS);
   updatemenu=1;
@@ -1692,19 +1692,19 @@ void UpdateIsoMenuLabels(void){
 
 /* ------------------ UpdateIsoShowLevels ------------------------ */
 
-void UpdateIsoShowLevels(void){
+void UpdateIsoShowLevels(smv_case *scase, meshdata *isomesh){
   int nisolevels;
   int *showlevels;
   int i, j;
   meshdata *meshi;
 
-  if(loaded_isomesh==NULL)return;
+  if(isomesh==NULL)return;
 
-  nisolevels=loaded_isomesh->nisolevels;
-  showlevels=loaded_isomesh->showlevels;
+  nisolevels=isomesh->nisolevels;
+  showlevels=isomesh->showlevels;
 
-  for(j=0;j<global_scase.meshescoll.nmeshes;j++){
-    meshi = global_scase.meshescoll.meshinfo+j;
+  for(j=0;j<scase->meshescoll.nmeshes;j++){
+    meshi = scase->meshescoll.meshinfo+j;
     if(meshi->isofilenum==-1)continue;
     for(i=0;i<nisolevels;i++){
       if(i<meshi->nisolevels)meshi->showlevels[i]=showlevels[i];

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -6155,7 +6155,7 @@ void InitDevicePlane(devicedata *devicei){
     rgbcolor[1]=0.0;
     rgbcolor[2]=0.0;
     rgbcolor[3]=1.0;
-    devicei->color=GetColorPtr(rgbcolor);
+    devicei->color=GetColorPtr(&global_scase, rgbcolor);
   }
   colorindex=0;
   for(i=0;i<global_scase.meshescoll.nmeshes;i++){

--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -1732,7 +1732,7 @@ int Unloadall() {
     fprintf(scriptoutstream, "UNLOADALL\n");
   }
   if(global_scase.paths.hrr_csv_filename != NULL) {
-    ReadHRR(UNLOAD);
+    ReadHRR(&global_scase, UNLOAD);
   }
   if(nvolrenderinfo > 0) {
     LoadVolsmoke3DMenu(UNLOAD_ALL);

--- a/Source/smokeview/callbacks.c
+++ b/Source/smokeview/callbacks.c
@@ -3759,7 +3759,7 @@ void UpdatePlot3dTitle(void){
 void UpdateCurrentMesh(meshdata *meshi){
   current_mesh=meshi;
   loaded_isomesh= GetLoadedIsoMesh();
-  UpdateIsoShowLevels();
+  UpdateIsoShowLevels(&global_scase, loaded_isomesh);
   UpdatePlot3dTitle();
 }
 

--- a/Source/smokeview/drawGeometry.c
+++ b/Source/smokeview/drawGeometry.c
@@ -623,7 +623,7 @@ void UpdateIndexColors(void){
       if(bc->usecolorindex==1){
         colorindex=bc->colorindex;
         if(colorindex>=0){
-          bc->color = GetColorPtr(global_scase.rgb[global_scase.nrgb+colorindex]);
+          bc->color = GetColorPtr(&global_scase, global_scase.rgb[global_scase.nrgb+colorindex]);
         }
       }
     }
@@ -638,7 +638,7 @@ void UpdateIndexColors(void){
         s_color[1]=global_scase.rgb[global_scase.nrgb+colorindex][1];
         s_color[2]=global_scase.rgb[global_scase.nrgb+colorindex][2];
         s_color[3]=1.0;
-        vi->color = GetColorPtr(s_color);
+        vi->color = GetColorPtr(&global_scase, s_color);
       }
     }
   }

--- a/Source/smokeview/getdatacolors.c
+++ b/Source/smokeview/getdatacolors.c
@@ -1771,26 +1771,26 @@ void GetRGB(unsigned int val, unsigned char *rr, unsigned char *gg, unsigned cha
 
 /* ------------------ GetColorPtr ------------------------ */
 
-float *GetColorPtr(float *color){
+float *GetColorPtr(smv_case *scase, float *color){
   colordata *colorptr,*oldlastcolor,*lastcolor;
 
   int i;
 
-  if(firstcolor==NULL){
-    NewMemory((void *)&firstcolor,sizeof(colordata));
+  if(scase->firstcolor==NULL){
+    NewMemory((void *)&scase->firstcolor,sizeof(colordata));
     for(i=0;i<4;i++){
-      firstcolor->color[i]=color[i];
-      firstcolor->full_color[i]=color[i];
+      scase->firstcolor->color[i]=color[i];
+      scase->firstcolor->full_color[i]=color[i];
     }
-    firstcolor->bw_color[0] = TOBW(color);
-    firstcolor->bw_color[1] = firstcolor->bw_color[0];
-    firstcolor->bw_color[2] = firstcolor->bw_color[0];
-    firstcolor->bw_color[3] = color[3];
-    firstcolor->nextcolor=NULL;
-    return firstcolor->color;
+    scase->firstcolor->bw_color[0] = TOBW(color);
+    scase->firstcolor->bw_color[1] = scase->firstcolor->bw_color[0];
+    scase->firstcolor->bw_color[2] = scase->firstcolor->bw_color[0];
+    scase->firstcolor->bw_color[3] = color[3];
+    scase->firstcolor->nextcolor=NULL;
+    return scase->firstcolor->color;
   }
-  oldlastcolor = firstcolor;
-  for(colorptr = firstcolor; colorptr!=NULL; colorptr = colorptr->nextcolor){
+  oldlastcolor = scase->firstcolor;
+  for(colorptr = scase->firstcolor; colorptr!=NULL; colorptr = colorptr->nextcolor){
     oldlastcolor=colorptr;
     if(ABS(colorptr->color[0]-color[0])>0.0001)continue;
     if(ABS(colorptr->color[1]-color[1])>0.0001)continue;
@@ -1822,7 +1822,7 @@ float *GetColorTranPtr(float *color, float transparency){
   col[1] = color[1];
   col[2] = color[2];
   col[3] = transparency;
-  return GetColorPtr(col);
+  return GetColorPtr(&global_scase, col);
 }
 
   /* ------------------ ConvertColor ------------------------ */

--- a/Source/smokeview/glui_display.cpp
+++ b/Source/smokeview/glui_display.cpp
@@ -660,7 +660,7 @@ void SurfaceCB(int var){
         surfi->transparent_level = 1.0;
       }
       s_color[3] = surfi->transparent_level;
-      surfi->color = GetColorPtr(s_color);
+      surfi->color = GetColorPtr(&global_scase, s_color);
       updatefacelists = 1;
       global_scase.updatefaces = 1;
     }

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -3524,7 +3524,7 @@ void LoadUnloadMenu(int value){
 #endif
     THREADcontrol(compress_threads, THREAD_LOCK);
     if(global_scase.paths.hrr_csv_filename!=NULL){
-      ReadHRR(LOAD);
+      ReadHRR(&global_scase, LOAD);
     }
 
     //*** reload hvac file

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -1306,7 +1306,7 @@ void IsoShowMenu(int value){
       UpdateShow();
     }
   }
-  UpdateIsoShowLevels();
+  UpdateIsoShowLevels(&global_scase, loaded_isomesh);
   UpdateIsoTriangles(1);
 
   updatemenu=1;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -140,23 +140,23 @@ void GetHoc(smv_case *scase, float *hoc, char *name){
 
 /* ------------------ UpdateHoc ------------------------ */
 
-void UpdateHoc(void){
+void UpdateHoc(smv_case *scase){
   int i;
 
 // construct column for each MLR column by heat of combustion except for air and products
-  for(i = global_scase.hrr_coll.nhrrinfo-global_scase.hrr_coll.nhrrhcinfo; i<global_scase.hrr_coll.nhrrinfo; i++){
+  for(i = scase->hrr_coll.nhrrinfo-scase->hrr_coll.nhrrhcinfo; i<scase->hrr_coll.nhrrinfo; i++){
     hrrdata *hi;
 
-    hi = global_scase.hrr_coll.hrrinfo+i;
+    hi = scase->hrr_coll.hrrinfo+i;
     if(hi->base_col>=0){
       hrrdata *hi_from;
       int j;
 
-      hi_from = global_scase.hrr_coll.hrrinfo+hi->base_col;
+      hi_from = scase->hrr_coll.hrrinfo+hi->base_col;
       memcpy(hi->vals, hi_from->vals, hi_from->nvals*sizeof(float));
       hi->nvals = hi_from->nvals;
       for(j = 0; j<hi->nvals; j++){
-        hi->vals[j] *= global_scase.fuel_hoc;
+        hi->vals[j] *= scase->fuel_hoc;
       }
       memcpy(hi->vals_orig, hi->vals, hi->nvals*sizeof(float));
 
@@ -689,7 +689,7 @@ NewMemory((void **)&valids,                    global_scase.hrr_coll.nhrrinfo*si
     hi = global_scase.hrr_coll.hrrinfo+i;
     hi->nvals = nrows-2;
   }
-  UpdateHoc();
+  UpdateHoc(&global_scase);
   CheckMemory;
 
 //construct column of qradi/hrr

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -8206,7 +8206,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
     // Allocate a fixed-size collection large enough to hold each of the CADGEOM
     // definitions.
     int err = InitCADGeomCollection(&scase->cadgeomcoll, n_cadgeom_keywords);
-    if (err == 0) return 2;
+    if (err != 0) return 2;
   }
 
   if(scase->noutlineinfo>0){

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -52,9 +52,9 @@
 #define ZVENT_1ROOM 1
 #define ZVENT_2ROOM 2
 
-#define PARTBUFFER(len)    global_scase.part_buffer;    global_scase.part_buffer    += (len)
-#define SMOKE3DBUFFER(len) global_scase.smoke3d_buffer; global_scase.smoke3d_buffer += (len)
-#define SLICEBUFFER(len)   global_scase.slice_buffer;   global_scase.slice_buffer   += (len)
+#define PARTBUFFER(len)    scase->part_buffer;    scase->part_buffer    += (len)
+#define SMOKE3DBUFFER(len) scase->smoke3d_buffer; scase->smoke3d_buffer += (len)
+#define SLICEBUFFER(len)   scase->slice_buffer;   scase->slice_buffer   += (len)
 
 int GetNDevices(char *file);
 

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -6606,18 +6606,18 @@ void UpdateObstBoundingBox(smv_case *scase, float *XB){
 
 /* ------------------ GetBlockagePtr ------------------------ */
 
-blockagedata *GetBlockagePtr(float *xyz){
+blockagedata *GetBlockagePtr(smv_case *scase, float *xyz){
   float xyzcenter[3];
   int i;
 
   xyzcenter[0] = (xyz[0]+xyz[1])/2.0;
   xyzcenter[1] = (xyz[2]+xyz[3])/2.0;
   xyzcenter[2] = (xyz[4]+xyz[5])/2.0;
-  for(i=0;i<global_scase.meshescoll.nmeshes;i++){
+  for(i=0;i<scase->meshescoll.nmeshes;i++){
     meshdata *meshi;
     int j;
 
-    meshi = global_scase.meshescoll.meshinfo + i;
+    meshi = scase->meshescoll.meshinfo + i;
     if(xyzcenter[0]<meshi->boxmin[0]||xyzcenter[0]>meshi->boxmax[0])continue;
     if(xyzcenter[1]<meshi->boxmin[1]||xyzcenter[1]>meshi->boxmax[1])continue;
     if(xyzcenter[2]<meshi->boxmin[2]||xyzcenter[2]>meshi->boxmax[2])continue;
@@ -6754,7 +6754,7 @@ void ReadSMVOrig(smv_case *scase){
             if(obi->surf_index[j]>=0)obi->surfs[j] = scase->surfcoll.surfinfo + obi->surf_index[j];
           }
         }
-        obi->bc = GetBlockagePtr(obi->xyz);
+        obi->bc = GetBlockagePtr(scase, obi->xyz);
       }
       break;
     }

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -4381,7 +4381,7 @@ void ReadDeviceHeader(smv_case *scase, char *file, devicedata *devices, int ndev
 
 /* ------------------ SetSurfaceIndex ------------------------ */
 
-void SetSurfaceIndex(blockagedata *bc){
+void SetSurfaceIndex(smv_case *scase, blockagedata *bc){
   int i, j, jj;
   surfdata *surfj;
   char *surflabel, *bclabel;
@@ -4392,10 +4392,10 @@ void SetSurfaceIndex(blockagedata *bc){
     bc->surf_index[i] = -1;
     bclabel = bc->surf[i]->surfacelabel;
     if(bc->surf[i] == NULL)continue;
-    for(jj = 1; jj < global_scase.surfcoll.nsurfinfo + 1; jj++){
+    for(jj = 1; jj < scase->surfcoll.nsurfinfo + 1; jj++){
       j = jj;
-      if(jj == global_scase.surfcoll.nsurfinfo)j = 0;
-      surfj = global_scase.surfcoll.surfinfo + j;
+      if(jj == scase->surfcoll.nsurfinfo)j = 0;
+      surfj = scase->surfcoll.surfinfo + j;
       surflabel = surfj->surfacelabel;
       if(strcmp(bclabel, surflabel) != 0)continue;
       bc->surf_index[i] = j;
@@ -10716,7 +10716,7 @@ typedef struct {
         for(i=0;i<6;i++){
           bc->surf[i]->used_by_obst=1;
         }
-        SetSurfaceIndex(bc);
+        SetSurfaceIndex(scase, bc);
       }
 
       nn=-1;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -2110,7 +2110,7 @@ void InitDevice(devicedata *devicei, float *xyz, int is_beam, float *xyz1, float
       color[1] = params[1];
       color[2] = params[2];
       color[3] = 1.0;
-      devicei->color = GetColorPtr(color);
+      devicei->color = GetColorPtr(&global_scase, color);
     }
     if(nparams >= 4){
       devicei->line_width = params[3];
@@ -4745,7 +4745,7 @@ void ReadZVentData(zventdata *zvi, char *buffer, int flag){
       zvi->wall = TOP_WALL;
     }
   }
-  zvi->color = GetColorPtr(color);
+  zvi->color = GetColorPtr(&global_scase, color);
   zvi->area_fraction = area_fraction;
 }
 
@@ -6732,13 +6732,13 @@ void ReadSMVOrig(void){
           obi->invisible=1;
         }
         if(colorindex>=0){
-          obi->color = GetColorPtr(global_scase.rgb[global_scase.nrgb+colorindex]);
+          obi->color = GetColorPtr(&global_scase, global_scase.rgb[global_scase.nrgb+colorindex]);
           obi->usecolorindex=1;
           obi->colorindex=colorindex;
           global_scase.updateindexcolors=1;
         }
         if(colorindex==-3){
-          obi->color = GetColorPtr(s_color);
+          obi->color = GetColorPtr(&global_scase, s_color);
           global_scase.updateindexcolors=1;
         }
         obi->colorindex = colorindex;
@@ -8029,7 +8029,7 @@ int ReadSMV_Parse(bufferstreamdata *stream){
    rgb_class[1]=0.0;
    rgb_class[2]=0.0;
    rgb_class[3]=1.0;
-   partclassi->rgb=GetColorPtr(rgb_class);
+   partclassi->rgb=GetColorPtr(&global_scase, rgb_class);
 
    partclassi->ntypes=0;
    partclassi->xyz=NULL;
@@ -8501,7 +8501,7 @@ int ReadSMV_Parse(bufferstreamdata *stream){
               fcolors[2] = colors[2]/255.0;
               if(transparency<0.0)transparency = 1.0;
               fcolors[3] = transparency;
-              geomobji->color = GetColorPtr(fcolors);
+              geomobji->color = GetColorPtr(&global_scase, fcolors);
               geomobji->use_geom_color = 1;
             }
             geomobji->ntriangles = ntriangles;
@@ -8829,7 +8829,7 @@ int ReadSMV_Parse(bufferstreamdata *stream){
       FGETS(buffer,255,stream);
       sscanf(buffer,"%f %f %f",rgb_class,rgb_class+1,rgb_class+2);
       rgb_class[3]=1.0;
-      partclassi->rgb=GetColorPtr(rgb_class);
+      partclassi->rgb=GetColorPtr(&global_scase, rgb_class);
 
       partclassi->ntypes=0;
       partclassi->xyz=NULL;
@@ -9216,7 +9216,7 @@ int ReadSMV_Parse(bufferstreamdata *stream){
         surfi->invisible = 1;
         surfi->type = BLOCK_hidden;
       }
-      surfi->color = GetColorPtr(s_color);
+      surfi->color = GetColorPtr(&global_scase, s_color);
       if(s_color[3]<0.99){
         surfi->transparent=1;
         surfi->transparent_level = s_color[3];
@@ -10246,7 +10246,7 @@ int ReadSMV_Parse(bufferstreamdata *stream){
         default:
           assert(FFALSE);
         }
-        zvi->color = GetColorPtr(color);
+        zvi->color = GetColorPtr(&global_scase, color);
         zvi->area_fraction = area_fraction;
       }
       else if(vent_type==VFLOW_VENT){
@@ -10301,7 +10301,7 @@ int ReadSMV_Parse(bufferstreamdata *stream){
         zvi->vertical_vent_type = vertical_vent_type;
         zvi->area = vent_area;
         zvi->area_fraction = area_fraction;
-        zvi->color = GetColorPtr(color);
+        zvi->color = GetColorPtr(&global_scase, color);
       }
       else if(vent_type==MFLOW_VENT){
         global_scase.nzmvents++;
@@ -10841,14 +10841,14 @@ typedef struct {
             colorindex=-3;
           }
           if(s_color[0]>=0.0&&s_color[1]>=0.0&&s_color[2]>=0.0){
-            bc->color=GetColorPtr(s_color);
+            bc->color=GetColorPtr(&global_scase, s_color);
           }
           bc->nnodes=(ijk[1]+1-ijk[0])*(ijk[3]+1-ijk[2])*(ijk[5]+1-ijk[4]);
           bc->useblockcolor = 1;
         }
         else{
           if(colorindex>=0){
-            bc->color = GetColorPtr(global_scase.rgb[global_scase.nrgb+colorindex]);
+            bc->color = GetColorPtr(&global_scase, global_scase.rgb[global_scase.nrgb+colorindex]);
             bc->usecolorindex=1;
             bc->colorindex=colorindex;
             global_scase.updateindexcolors=1;
@@ -11035,7 +11035,7 @@ typedef struct {
           cvi->useventcolor=1;
         }
         s_color[3]=1.0; // set color to opaque until CVENT transparency is implemented
-        cvi->color = GetColorPtr(s_color);
+        cvi->color = GetColorPtr(&global_scase, s_color);
       }
       continue;
     }
@@ -11277,7 +11277,7 @@ typedef struct {
             vi->useventcolor=1;
             global_scase.updateindexcolors=1;
           }
-          vi->color = GetColorPtr(s_color);
+          vi->color = GetColorPtr(&global_scase, s_color);
         }
         else{
           iv1=0;
@@ -13020,7 +13020,7 @@ int ReadIni2(const char *inifile, int localfile){
       fgets(buffer, 255, stream);
       sscanf(buffer, "%f %f %f", dc, dc + 1, dc + 2);
       dc[3] = 1.0;
-      direction_color_ptr = GetColorPtr(direction_color);
+      direction_color_ptr = GetColorPtr(&global_scase, direction_color);
       GetSliceParmInfo(&sliceparminfo);
       UpdateSliceMenuShow(&sliceparminfo);
       continue;
@@ -14497,7 +14497,7 @@ int ReadIni2(const char *inifile, int localfile){
       fgets(buffer, 255, stream);
       sscanf(buffer, "%f %f %f", ventcolor_temp, ventcolor_temp + 1, ventcolor_temp + 2);
       ventcolor_temp[3] = 1.0;
-      ventcolor = GetColorPtr(ventcolor_temp);
+      ventcolor = GetColorPtr(&global_scase, ventcolor_temp);
       global_scase.updatefaces = 1;
       global_scase.updateindexcolors = 1;
       continue;
@@ -14593,7 +14593,7 @@ int ReadIni2(const char *inifile, int localfile){
         s_color[0] = CLAMP(s_color[0], 0.0, 1.0);
         s_color[1] = CLAMP(s_color[1], 0.0, 1.0);
         s_color[2] = CLAMP(s_color[2], 0.0, 1.0);
-        surfi->color = GetColorPtr(s_color);
+        surfi->color = GetColorPtr(&global_scase, s_color);
         surfi->transparent_level=s_color[3];
       }
       continue;
@@ -14629,7 +14629,7 @@ int ReadIni2(const char *inifile, int localfile){
       fgets(buffer, 255, stream);
       sscanf(buffer, "%f %f %f", blockcolor_temp, blockcolor_temp + 1, blockcolor_temp + 2);
       blockcolor_temp[3] = 1.0;
-      block_ambient2 = GetColorPtr(blockcolor_temp);
+      block_ambient2 = GetColorPtr(&global_scase, blockcolor_temp);
       global_scase.updatefaces = 1;
       global_scase.updateindexcolors = 1;
       continue;
@@ -14664,7 +14664,7 @@ int ReadIni2(const char *inifile, int localfile){
       fgets(buffer, 255, stream);
       sscanf(buffer, "%f %f %f", blockspec_temp, blockspec_temp + 1, blockspec_temp + 2);
       blockspec_temp[3] = 1.0;
-      block_specular2 = GetColorPtr(blockspec_temp);
+      block_specular2 = GetColorPtr(&global_scase, blockspec_temp);
       global_scase.updatefaces = 1;
       global_scase.updateindexcolors = 1;
       continue;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -6578,7 +6578,7 @@ void UpdateEvents(void){
 
 /* ------------------ UpdateObstBoundingBox ------------------------ */
 
-void UpdateObstBoundingBox(float *XB){
+void UpdateObstBoundingBox(smv_case *scase, float *XB){
   float XB0[6];
   int i;
 
@@ -6593,13 +6593,13 @@ void UpdateObstBoundingBox(float *XB){
 
     imin = 2*i;
     imax = 2*i+1;
-    if(obst_bounding_box[imin]>obst_bounding_box[imax]){
-      obst_bounding_box[imin] = XB0[imin];
-      obst_bounding_box[imax] = XB0[imax];
+    if(scase->obst_bounding_box[imin]>scase->obst_bounding_box[imax]){
+      scase->obst_bounding_box[imin] = XB0[imin];
+      scase->obst_bounding_box[imax] = XB0[imax];
     }
     else{
-      obst_bounding_box[imin] = MIN(obst_bounding_box[imin], XB0[imin]);
-      obst_bounding_box[imax] = MAX(obst_bounding_box[imax], XB0[imax]);
+      scase->obst_bounding_box[imin] = MIN(scase->obst_bounding_box[imin], XB0[imin]);
+      scase->obst_bounding_box[imax] = MAX(scase->obst_bounding_box[imax], XB0[imax]);
     }
   }
 }
@@ -10683,7 +10683,7 @@ typedef struct {
             &(bc->blockage_id),s_num+DOWN_X,s_num+UP_X,s_num+DOWN_Y,s_num+UP_Y,s_num+DOWN_Z,s_num+UP_Z,
             t_origin,t_origin+1,t_origin+2);
 
-          UpdateObstBoundingBox(xyzEXACT);
+          UpdateObstBoundingBox(&global_scase, xyzEXACT);
           bc->xmin=xyzEXACT[0];
           bc->xmax=xyzEXACT[1];
           bc->ymin=xyzEXACT[2];

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -4166,13 +4166,13 @@ void UpdateMeshCoords(void){
 
 /* ------------------ IsSliceDup ------------------------ */
 
-int IsSliceDup(slicedata *sd, int nslice){
+int IsSliceDup(smv_case *scase, slicedata *sd, int nslice){
   int i;
 
   for(i=0;i<nslice-1;i++){
     slicedata *slicei;
 
-    slicei = global_scase.slicecoll.sliceinfo + i;
+    slicei = scase->slicecoll.sliceinfo + i;
     if(slicei->ijk_min[0]!=sd->ijk_min[0]||slicei->ijk_max[0]!=sd->ijk_max[0])continue;
     if(slicei->ijk_min[1]!=sd->ijk_min[1]||slicei->ijk_max[1]!=sd->ijk_max[1])continue;
     if(slicei->ijk_min[2]!=sd->ijk_min[2]||slicei->ijk_max[2]!=sd->ijk_max[2])continue;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -2079,7 +2079,7 @@ propdata *GetPropID(smv_case *scase, char *prop_id){
 
 /* ----------------------- InitDevice ----------------------------- */
 
-void InitDevice(devicedata *devicei, float *xyz, int is_beam, float *xyz1, float *xyz2, float *xyzn, int state0, int nparams, float *params, char *labelptr){
+void InitDevice(smv_case *scase, devicedata *devicei, float *xyz, int is_beam, float *xyz1, float *xyz2, float *xyzn, int state0, int nparams, float *params, char *labelptr){
   float norm;
   int i;
 
@@ -2101,8 +2101,8 @@ void InitDevice(devicedata *devicei, float *xyz, int is_beam, float *xyz1, float
   if(STRCMP(devicei->object->label, "plane") == 0){
     float color[4];
 
-    NewMemory((void **)&devicei->plane_surface, global_scase.meshescoll.nmeshes * sizeof(isosurface *));
-    for(i = 0; i < global_scase.meshescoll.nmeshes; i++){
+    NewMemory((void **)&devicei->plane_surface, scase->meshescoll.nmeshes * sizeof(isosurface *));
+    for(i = 0; i < scase->meshescoll.nmeshes; i++){
       NewMemory((void **)&devicei->plane_surface[i], sizeof(isosurface));
     }
     if(nparams >= 3){
@@ -2137,8 +2137,8 @@ void InitDevice(devicedata *devicei, float *xyz, int is_beam, float *xyz1, float
     devicei->xyz2[2]   = xyz2[2];
     devicei->have_xyz2 = 1;
   }
-  if(xyz1!=NULL&&xyz2!=NULL)global_scase.have_object_box = 1;
-  if(is_beam == 1)global_scase.have_beam = 1;
+  if(xyz1!=NULL&&xyz2!=NULL)scase->have_object_box = 1;
+  if(is_beam == 1)scase->have_beam = 1;
   devicei->is_beam = is_beam;
   norm = sqrt(xyzn[0] * xyzn[0] + xyzn[1] * xyzn[1] + xyzn[2] * xyzn[2]);
   if(norm != 0.0){
@@ -2219,11 +2219,11 @@ void ParseDevicekeyword(smv_case *scase, BFILE *stream, devicedata *devicei){
   else{
     strcpy(devicei->deviceID, tok1);
   }
-  devicei->object = GetSmvObjectType(&global_scase.objectscoll,  tok1,global_scase.objectscoll.std_object_defs.missing_device);
-  if(devicei->object==global_scase.objectscoll.std_object_defs.missing_device&&tok3!=NULL){
-    devicei->object = GetSmvObjectType(&global_scase.objectscoll,  tok3,global_scase.objectscoll.std_object_defs.missing_device);
+  devicei->object = GetSmvObjectType(&scase->objectscoll,  tok1,scase->objectscoll.std_object_defs.missing_device);
+  if(devicei->object==scase->objectscoll.std_object_defs.missing_device&&tok3!=NULL){
+    devicei->object = GetSmvObjectType(&scase->objectscoll,  tok3,scase->objectscoll.std_object_defs.missing_device);
   }
-  if(devicei->object == global_scase.objectscoll.std_object_defs.missing_device)global_scase.have_missing_objects = 1;
+  if(devicei->object == scase->objectscoll.std_object_defs.missing_device)scase->have_missing_objects = 1;
   devicei->params=NULL;
   devicei->times=NULL;
   devicei->vals=NULL;
@@ -2284,7 +2284,7 @@ void ParseDevicekeyword(smv_case *scase, BFILE *stream, devicedata *devicei){
   }
 
   if(nparams<=0){
-    InitDevice(devicei,xyz,is_beam,xyz1,xyz2,xyzn,state0,0,NULL,labelptr);
+    InitDevice(scase, devicei,xyz,is_beam,xyz1,xyz2,xyzn,state0,0,NULL,labelptr);
   }
   else{
     float *params,*pc;
@@ -2300,7 +2300,7 @@ void ParseDevicekeyword(smv_case *scase, BFILE *stream, devicedata *devicei){
       sscanf(buffer,"%f %f %f %f %f %f",pc,pc+1,pc+2,pc+3,pc+4,pc+5);
       pc+=6;
     }
-    InitDevice(devicei,xyz,is_beam,xyz1,xyz2,xyzn,state0,nparams,params,labelptr);
+    InitDevice(scase, devicei,xyz,is_beam,xyz1,xyz2,xyzn,state0,nparams,params,labelptr);
   }
   GetElevAz(devicei->xyznorm,&devicei->dtheta,devicei->rotate_axis,NULL);
   if(nparams_textures>0){
@@ -2350,11 +2350,11 @@ void ParseDevicekeyword2(smv_case *scase, FILE *stream, devicedata *devicei){
   else{
     strcpy(devicei->deviceID, tok1);
   }
-  devicei->object = GetSmvObjectType(&global_scase.objectscoll,  tok1, global_scase.objectscoll.std_object_defs.missing_device);
-  if(devicei->object==global_scase.objectscoll.std_object_defs.missing_device&&tok3!=NULL){
-    devicei->object = GetSmvObjectType(&global_scase.objectscoll,  tok3, global_scase.objectscoll.std_object_defs.missing_device);
+  devicei->object = GetSmvObjectType(&scase->objectscoll,  tok1, scase->objectscoll.std_object_defs.missing_device);
+  if(devicei->object==scase->objectscoll.std_object_defs.missing_device&&tok3!=NULL){
+    devicei->object = GetSmvObjectType(&scase->objectscoll,  tok3, scase->objectscoll.std_object_defs.missing_device);
   }
-  if(devicei->object==global_scase.objectscoll.std_object_defs.missing_device)global_scase.have_missing_objects = 1;
+  if(devicei->object==scase->objectscoll.std_object_defs.missing_device)scase->have_missing_objects = 1;
   devicei->params = NULL;
   devicei->times = NULL;
   devicei->vals = NULL;
@@ -2412,7 +2412,7 @@ void ParseDevicekeyword2(smv_case *scase, FILE *stream, devicedata *devicei){
   }
 
   if(nparams<=0){
-    InitDevice(devicei, xyz, is_beam, xyz1, xyz2, xyzn, state0, 0, NULL, labelptr);
+    InitDevice(scase, devicei, xyz, is_beam, xyz1, xyz2, xyzn, state0, 0, NULL, labelptr);
   }
   else{
     float *params, *pc;
@@ -2428,7 +2428,7 @@ void ParseDevicekeyword2(smv_case *scase, FILE *stream, devicedata *devicei){
       sscanf(buffer, "%f %f %f %f %f %f", pc, pc+1, pc+2, pc+3, pc+4, pc+5);
       pc += 6;
     }
-    InitDevice(devicei, xyz, is_beam, xyz1, xyz2, xyzn, state0, nparams, params, labelptr);
+    InitDevice(scase, devicei, xyz, is_beam, xyz1, xyz2, xyzn, state0, nparams, params, labelptr);
   }
   GetElevAz(devicei->xyznorm, &devicei->dtheta, devicei->rotate_axis, NULL);
   if(nparams_textures>0){
@@ -9734,7 +9734,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
           }
           GetElevAz(xyznorm,&devicecopy->dtheta,devicecopy->rotate_axis,NULL);
 
-          InitDevice(devicecopy,xyz,0,NULL,NULL,xyznorm,0,0,NULL,"target");
+          InitDevice(scase, devicecopy,xyz,0,NULL,NULL,xyznorm,0,0,NULL,"target");
           devicecopy->prop=NULL;
 
           devicecopy++;
@@ -9811,7 +9811,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
           }
           GetElevAz(xyznorm,&devicecopy->dtheta,devicecopy->rotate_axis,NULL);
 
-          InitDevice(devicecopy,NULL,0,NULL,NULL,xyznorm,0,0,NULL,NULL);
+          InitDevice(scase, devicecopy,NULL,0,NULL,NULL,xyznorm,0,0,NULL,NULL);
 
           devicecopy++;
           scase->devicecoll.ndeviceinfo++;
@@ -9889,7 +9889,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
           }
           GetElevAz(xyznorm,&devicecopy->dtheta,devicecopy->rotate_axis,NULL);
 
-          InitDevice(devicecopy,NULL,0,NULL,NULL,xyznorm,0,0,NULL,NULL);
+          InitDevice(scase, devicecopy,NULL,0,NULL,NULL,xyznorm,0,0,NULL,NULL);
           devicecopy->prop=NULL;
 
           devicecopy++;
@@ -9948,7 +9948,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
         }
         GetElevAz(xyznorm,&devicecopy->dtheta,devicecopy->rotate_axis,NULL);
 
-        InitDevice(devicecopy,xyz,0,NULL,NULL,xyznorm,0,0,NULL,NULL);
+        InitDevice(scase, devicecopy,xyz,0,NULL,NULL,xyznorm,0,0,NULL,NULL);
 
         devicecopy++;
         scase->devicecoll.ndeviceinfo++;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -6638,12 +6638,12 @@ blockagedata *GetBlockagePtr(float *xyz){
 
 /* ------------------ ReadSMVOrig ------------------------ */
 
-void ReadSMVOrig(void){
+void ReadSMVOrig(smv_case *scase){
   FILE *stream=NULL;
 
-  stream = fopen(global_scase.paths.smv_orig_filename, "r");
+  stream = fopen(scase->paths.smv_orig_filename, "r");
   if(stream == NULL)return;
-  PRINTF("reading  %s\n", global_scase.paths.smv_orig_filename);
+  PRINTF("reading  %s\n", scase->paths.smv_orig_filename);
 
   for(;;){
     char buffer[255];
@@ -6681,15 +6681,15 @@ void ReadSMVOrig(void){
       float *xyz;
       int i;
 
-      FREEMEMORY(global_scase.obstcoll.obstinfo);
+      FREEMEMORY(scase->obstcoll.obstinfo);
       fgets(buffer, 255, stream);
-      sscanf(buffer, "%i", &global_scase.obstcoll.nobstinfo);
-      NewMemory((void **)&global_scase.obstcoll.obstinfo, global_scase.obstcoll.nobstinfo*sizeof(xbdata));
-      for(i = 0; i<global_scase.obstcoll.nobstinfo; i++){
+      sscanf(buffer, "%i", &scase->obstcoll.nobstinfo);
+      NewMemory((void **)&scase->obstcoll.obstinfo, scase->obstcoll.nobstinfo*sizeof(xbdata));
+      for(i = 0; i<scase->obstcoll.nobstinfo; i++){
         xbdata *obi;
         int blockid, *surf_index;
 
-        obi = global_scase.obstcoll.obstinfo+i;
+        obi = scase->obstcoll.obstinfo+i;
         xyz = obi->xyz;
         surf_index = obi->surf_index;
         fgets(buffer, 255, stream);
@@ -6698,13 +6698,13 @@ void ReadSMVOrig(void){
              &blockid,
              surf_index, surf_index+1, surf_index+2, surf_index+3, surf_index+4, surf_index+5);
       }
-      for(i = 0; i<global_scase.obstcoll.nobstinfo; i++){
+      for(i = 0; i<scase->obstcoll.nobstinfo; i++){
         xbdata *obi;
         int dummy[6];
         float s_color[4];
         int colorindex, blocktype;
 
-        obi = global_scase.obstcoll.obstinfo+i;
+        obi = scase->obstcoll.obstinfo+i;
         obi->transparent   = 0;
         obi->invisible     = 0;
         obi->usecolorindex = 0;
@@ -6732,14 +6732,14 @@ void ReadSMVOrig(void){
           obi->invisible=1;
         }
         if(colorindex>=0){
-          obi->color = GetColorPtr(&global_scase, global_scase.rgb[global_scase.nrgb+colorindex]);
+          obi->color = GetColorPtr(&global_scase, scase->rgb[scase->nrgb+colorindex]);
           obi->usecolorindex=1;
           obi->colorindex=colorindex;
-          global_scase.updateindexcolors=1;
+          scase->updateindexcolors=1;
         }
         if(colorindex==-3){
           obi->color = GetColorPtr(&global_scase, s_color);
-          global_scase.updateindexcolors=1;
+          scase->updateindexcolors=1;
         }
         obi->colorindex = colorindex;
         obi->blocktype = blocktype;
@@ -6749,9 +6749,9 @@ void ReadSMVOrig(void){
         for(j=0;j<6;j++){
           obi->surfs[0] = NULL;
         }
-        if(global_scase.surfcoll.surfinfo!=NULL){
+        if(scase->surfcoll.surfinfo!=NULL){
           for(j=0;j<6;j++){
-            if(obi->surf_index[j]>=0)obi->surfs[j] = global_scase.surfcoll.surfinfo + obi->surf_index[j];
+            if(obi->surf_index[j]>=0)obi->surfs[j] = scase->surfcoll.surfinfo + obi->surf_index[j];
           }
         }
         obi->bc = GetBlockagePtr(obi->xyz);

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -4671,7 +4671,7 @@ void ParseDatabase(smv_case *scase, char *file){
 
 /* ------------------ ReadZVentData ------------------------ */
 
-void ReadZVentData(zventdata *zvi, char *buffer, int flag){
+void ReadZVentData(smv_case *scase, zventdata *zvi, char *buffer, int flag){
   float dxyz[3];
   float xyz[6];
   float color[4];
@@ -10305,7 +10305,7 @@ int ReadSMV_Parse(bufferstreamdata *stream){
       }
       else if(vent_type==MFLOW_VENT){
         global_scase.nzmvents++;
-        ReadZVentData(zvi, buffer, ZVENT_1ROOM);
+        ReadZVentData(&global_scase, zvi, buffer, ZVENT_1ROOM);
       }
       CheckMemory;
       continue;
@@ -10331,15 +10331,15 @@ int ReadSMV_Parse(bufferstreamdata *stream){
       switch(vent_type){
       case HFLOW_VENT:
         global_scase.nzhvents++;
-        ReadZVentData(zvi, buffer,ZVENT_2ROOM);
+        ReadZVentData(&global_scase, zvi, buffer,ZVENT_2ROOM);
         break;
       case VFLOW_VENT:
         global_scase.nzvvents++;
-        ReadZVentData(zvi, buffer, ZVENT_2ROOM);
+        ReadZVentData(&global_scase, zvi, buffer, ZVENT_2ROOM);
         break;
       case MFLOW_VENT:
         global_scase.nzmvents++;
-        ReadZVentData(zvi, buffer, ZVENT_1ROOM);
+        ReadZVentData(&global_scase, zvi, buffer, ZVENT_1ROOM);
         break;
       default:
         assert(FFALSE);

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -4478,7 +4478,7 @@ void UpdateSortedSurfIdList(surf_collection *surfcoll){
 
 /* ------------------ ParseDatabase ------------------------ */
 // TODO: this needs to be renamed as it never actually parses a database
-void ParseDatabase(char *file){
+void ParseDatabase(smv_case *scase, char *file){
   FILE *stream;
   char buffer[1000], *buffer2 = NULL, *buffer3, *slashptr;
   size_t lenbuffer, lenbuffer2;
@@ -4493,23 +4493,23 @@ void ParseDatabase(char *file){
 
   /* free memory called before */
 
-  for(i = 0; i<global_scase.surfcoll.nsurfids; i++){
-    surf_id = global_scase.surfcoll.surfids[i].label;
+  for(i = 0; i<scase->surfcoll.nsurfids; i++){
+    surf_id = scase->surfcoll.surfids[i].label;
     FREEMEMORY(surf_id);
   }
-  FREEMEMORY(global_scase.surfcoll.surfids);
-  global_scase.surfcoll.nsurfids = 0;
+  FREEMEMORY(scase->surfcoll.surfids);
+  scase->surfcoll.nsurfids = 0;
 
 
   if(file==NULL||strlen(file)==0||(stream = fopen(file, "r"))==NULL){
-    NewMemory((void **)&global_scase.surfcoll.surfids, (global_scase.surfcoll.nsurfids+1)*sizeof(surfid));
+    NewMemory((void **)&scase->surfcoll.surfids, (scase->surfcoll.nsurfids+1)*sizeof(surfid));
     surf_id = NULL;
     NewMemory((void **)&surf_id, 6);
     strcpy(surf_id, "INERT");
-    global_scase.surfcoll.surfids[0].label = surf_id;
-    global_scase.surfcoll.surfids[0].location = 0;
-    global_scase.surfcoll.surfids[0].show = 1;
-    global_scase.surfcoll.nsurfids = 1;
+    scase->surfcoll.surfids[0].label = surf_id;
+    scase->surfcoll.surfids[0].location = 0;
+    scase->surfcoll.surfids[0].show = 1;
+    scase->surfcoll.nsurfids = 1;
   }
 
   else{
@@ -4539,24 +4539,24 @@ void ParseDatabase(char *file){
         buffer3 = buffer2;
       }
       start = STRSTR(buffer3, "ID");
-      if(start!=NULL)global_scase.surfcoll.nsurfids++;
+      if(start!=NULL)scase->surfcoll.nsurfids++;
     }
 
     /* allocate memory */
 
-    NewMemory((void **)&global_scase.surfcoll.surfids, (global_scase.surfcoll.nsurfids+1)*sizeof(surfid));
+    NewMemory((void **)&scase->surfcoll.surfids, (scase->surfcoll.nsurfids+1)*sizeof(surfid));
     surf_id = NULL;
     NewMemory((void **)&surf_id, 6);
     strcpy(surf_id, "INERT");
-    global_scase.surfcoll.surfids[0].label = surf_id;
-    global_scase.surfcoll.surfids[0].location = 0;
-    global_scase.surfcoll.surfids[0].show = 1;
+    scase->surfcoll.surfids[0].label = surf_id;
+    scase->surfcoll.surfids[0].location = 0;
+    scase->surfcoll.surfids[0].show = 1;
 
 
     /* now look for IDs and copy them into an array */
 
     rewind(stream);
-    global_scase.surfcoll.nsurfids = 1;
+    scase->surfcoll.nsurfids = 1;
     while(!feof(stream)){
       if(fgets(buffer, 1000, stream)==NULL)break;
       if(STRSTR(buffer, "&SURF")==NULL)continue;
@@ -4578,7 +4578,7 @@ void ParseDatabase(char *file){
         buffer3 = buffer2;
       }
       start = STRSTR(buffer3+3, "ID");
-      if(start!=NULL)global_scase.surfcoll.nsurfids++;
+      if(start!=NULL)scase->surfcoll.nsurfids++;
       surf_id = NULL;
       surf_id2 = NULL;
       for(c = start; c!=NULL&&*c!='\0'; c++){
@@ -4590,9 +4590,9 @@ void ParseDatabase(char *file){
           *c = '\0';
           NewMemory((void **)&surf_id2, strlen(surf_id)+1);
           strcpy(surf_id2, surf_id);
-          global_scase.surfcoll.surfids[ global_scase.surfcoll.nsurfids-1].label = surf_id2;
-          global_scase.surfcoll.surfids[ global_scase.surfcoll.nsurfids-1].location = 1;
-          global_scase.surfcoll.surfids[ global_scase.surfcoll.nsurfids-1].show = 1;
+          scase->surfcoll.surfids[ scase->surfcoll.nsurfids-1].label = surf_id2;
+          scase->surfcoll.surfids[ scase->surfcoll.nsurfids-1].location = 1;
+          scase->surfcoll.surfids[ scase->surfcoll.nsurfids-1].show = 1;
           break;
         }
       }
@@ -4604,11 +4604,11 @@ void ParseDatabase(char *file){
   /*** debug: make sure ->show is defined for all cases ***/
 
   nsurfids_shown = 0;
-  for(i = 0; i<global_scase.surfcoll.nsurfids; i++){
-    labeli = global_scase.surfcoll.surfids[i].label;
+  for(i = 0; i<scase->surfcoll.nsurfids; i++){
+    labeli = scase->surfcoll.surfids[i].label;
     nexti = 0;
-    for(j = 0; j<global_scase.surfcoll.nsurfinfo; j++){
-      surfj = global_scase.surfcoll.surfinfo+j;
+    for(j = 0; j<scase->surfcoll.nsurfinfo; j++){
+      surfj = scase->surfcoll.surfinfo+j;
       labelj = surfj->surfacelabel;
       if(strcmp(labeli, labelj)==0){
         nexti = 1;
@@ -4616,18 +4616,18 @@ void ParseDatabase(char *file){
       }
     }
     if(nexti==1){
-      global_scase.surfcoll.surfids[i].show = 0;
+      scase->surfcoll.surfids[i].show = 0;
       continue;
     }
     for(j = 0; j<i; j++){
-      labelj = global_scase.surfcoll.surfids[j].label;
+      labelj = scase->surfcoll.surfids[j].label;
       if(strcmp(labeli, labelj)==0){
         nexti = 1;
         break;
       }
     }
     if(nexti==1){
-      global_scase.surfcoll.surfids[i].show = 0;
+      scase->surfcoll.surfids[i].show = 0;
       continue;
     }
     nsurfids_shown++;
@@ -4637,34 +4637,34 @@ void ParseDatabase(char *file){
   /* add surfaces found in database to those surfaces defined in previous SURF lines */
 
   if(nsurfids_shown>0){
-    if(global_scase.surfcoll.nsurfinfo==0){
-      FREEMEMORY(global_scase.surfcoll.surfinfo);
-      FREEMEMORY(global_scase.texture_coll.textureinfo);
-      NewMemory((void **)&global_scase.surfcoll.surfinfo, (nsurfids_shown+MAX_ISO_COLORS+1)*sizeof(surfdata));
-      NewMemory((void **)&global_scase.texture_coll.textureinfo, nsurfids_shown*sizeof(texturedata));
+    if(scase->surfcoll.nsurfinfo==0){
+      FREEMEMORY(scase->surfcoll.surfinfo);
+      FREEMEMORY(scase->texture_coll.textureinfo);
+      NewMemory((void **)&scase->surfcoll.surfinfo, (nsurfids_shown+MAX_ISO_COLORS+1)*sizeof(surfdata));
+      NewMemory((void **)&scase->texture_coll.textureinfo, nsurfids_shown*sizeof(texturedata));
     }
-    if(global_scase.surfcoll.nsurfinfo>0){
-      if(global_scase.surfcoll.surfinfo==NULL){
-        NewMemory((void **)&global_scase.surfcoll.surfinfo, (nsurfids_shown+global_scase.surfcoll.nsurfinfo+MAX_ISO_COLORS+1)*sizeof(surfdata));
+    if(scase->surfcoll.nsurfinfo>0){
+      if(scase->surfcoll.surfinfo==NULL){
+        NewMemory((void **)&scase->surfcoll.surfinfo, (nsurfids_shown+scase->surfcoll.nsurfinfo+MAX_ISO_COLORS+1)*sizeof(surfdata));
       }
       else{
-        ResizeMemory((void **)&global_scase.surfcoll.surfinfo, (nsurfids_shown+global_scase.surfcoll.nsurfinfo+MAX_ISO_COLORS+1)*sizeof(surfdata));
+        ResizeMemory((void **)&scase->surfcoll.surfinfo, (nsurfids_shown+scase->surfcoll.nsurfinfo+MAX_ISO_COLORS+1)*sizeof(surfdata));
       }
-      if(global_scase.texture_coll.textureinfo==NULL){
-        NewMemory((void **)&global_scase.texture_coll.textureinfo, (nsurfids_shown+global_scase.surfcoll.nsurfinfo)*sizeof(texturedata));
+      if(scase->texture_coll.textureinfo==NULL){
+        NewMemory((void **)&scase->texture_coll.textureinfo, (nsurfids_shown+scase->surfcoll.nsurfinfo)*sizeof(texturedata));
       }
       else{
-        ResizeMemory((void **)&global_scase.texture_coll.textureinfo, (nsurfids_shown+global_scase.surfcoll.nsurfinfo)*sizeof(texturedata));
+        ResizeMemory((void **)&scase->texture_coll.textureinfo, (nsurfids_shown+scase->surfcoll.nsurfinfo)*sizeof(texturedata));
       }
     }
-    surfj = global_scase.surfcoll.surfinfo+global_scase.surfcoll.nsurfinfo-1;
-    for(j = 0; j<global_scase.surfcoll.nsurfids; j++){
-      if(global_scase.surfcoll.surfids[j].show==0)continue;
+    surfj = scase->surfcoll.surfinfo+scase->surfcoll.nsurfinfo-1;
+    for(j = 0; j<scase->surfcoll.nsurfids; j++){
+      if(scase->surfcoll.surfids[j].show==0)continue;
       surfj++;
       InitSurface(surfj);
-      surfj->surfacelabel = global_scase.surfcoll.surfids[j].label;
+      surfj->surfacelabel = scase->surfcoll.surfids[j].label;
     }
-    global_scase.surfcoll.nsurfinfo += nsurfids_shown;
+    scase->surfcoll.nsurfinfo += nsurfids_shown;
   }
   UpdateSortedSurfIdList(&global_scase.surfcoll);
 }
@@ -9495,7 +9495,7 @@ int ReadSMV_Parse(bufferstreamdata *stream){
   START_TIMER(pass3_time);
 
   CheckMemory;
-  ParseDatabase(NULL);
+  ParseDatabase(&global_scase, NULL);
 
   if(setGRID==0){
     meshdata *meshi;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -4237,7 +4237,7 @@ surfdata *GetSurface(smv_case *scase, const char *label){
 
 /* ------------------ InitObst ------------------------ */
 
-void InitObst(blockagedata *bc, surfdata *surf, int index, int meshindex){
+void InitObst(smv_case *scase, blockagedata *bc, surfdata *surf, int index, int meshindex){
   int colorindex, blocktype;
   int i;
   char blocklabel[255];
@@ -4258,9 +4258,9 @@ void InitObst(blockagedata *bc, surfdata *surf, int index, int meshindex){
   bc->meshindex = meshindex;
   bc->hidden = 0;
   bc->invisible = 0;
-  bc->texture_origin[0] = global_scase.texture_origin[0];
-  bc->texture_origin[1] = global_scase.texture_origin[1];
-  bc->texture_origin[2] = global_scase.texture_origin[2];
+  bc->texture_origin[0] = scase->texture_origin[0];
+  bc->texture_origin[1] = scase->texture_origin[1];
+  bc->texture_origin[2] = scase->texture_origin[2];
 
   /*
   new OBST format:
@@ -10629,7 +10629,7 @@ typedef struct {
         nn++;
         meshi->blockageinfoptrs[nn] = meshi->blockageinfo + nn;
         bc=meshi->blockageinfoptrs[nn];
-        InitObst(bc,surfacedefault,nn+1,iobst-1);
+        InitObst(scase,bc,surfacedefault,nn+1,iobst-1);
         FGETS(buffer,255,stream);
 
         char id_label[100], *id_labelptr;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -60,14 +60,14 @@ int GetNDevices(char *file);
 
 /* ------------------ GetHrrCsvCol ------------------------ */
 
-int GetHrrCsvCol(char *label){
+int GetHrrCsvCol(smv_case *scase, char *label){
   int i;
 
-  if(label==NULL||strlen(label)==0||global_scase.hrr_coll.nhrrinfo==0)return -1;
-  for(i = 0; i<global_scase.hrr_coll.nhrrinfo; i++){
+  if(label==NULL||strlen(label)==0||scase->hrr_coll.nhrrinfo==0)return -1;
+  for(i = 0; i<scase->hrr_coll.nhrrinfo; i++){
     hrrdata *hi;
 
-    hi = global_scase.hrr_coll.hrrinfo+i;
+    hi = scase->hrr_coll.hrrinfo+i;
     if(hi->label.shortlabel==NULL)continue;
     if(strcmp(hi->label.shortlabel, label)==0)return i;
   }
@@ -604,13 +604,13 @@ NewMemory((void **)&valids,                    global_scase.hrr_coll.nhrrinfo*si
 
 // find column index of several quantities
 
-  time_col  = GetHrrCsvCol("Time");
+  time_col  = GetHrrCsvCol(&global_scase, "Time");
   if(time_col>=0)timeptr = global_scase.hrr_coll.hrrinfo+time_col;
 
-  hrr_col   = GetHrrCsvCol("HRR");
+  hrr_col   = GetHrrCsvCol(&global_scase, "HRR");
   if(hrr_col>=0&&time_col>=0)hrrptr = global_scase.hrr_coll.hrrinfo+hrr_col;
 
-  qradi_col = GetHrrCsvCol("Q_RADI");
+  qradi_col = GetHrrCsvCol(&global_scase, "Q_RADI");
   CheckMemory;
 
 // define column for each MLR column by heat of combustion except for air and products

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -745,7 +745,7 @@ EXTERNCPP void SetSliceMax(int set_valmax, float valmax, char *buffer2);
 EXTERNCPP void SetSliceParmInfo(sliceparmdata *sp);
 EXTERNCPP void *SetupAllIsosurfaces(void *arg);
 EXTERNCPP void UpdateBlockType(void);
-EXTERNCPP void UpdateHoc(void);
+EXTERNCPP void UpdateHoc(smv_case *scase);
 EXTERNCPP void UpdateLoadedLists(void);
 EXTERNCPP void UpdateSMVDynamic(char *file);
 EXTERNCPP void UpdateUseTextures(void);

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -731,7 +731,7 @@ EXTERNCPP void InitCellMeshInfo(void);
 EXTERNCPP FILE_SIZE ReadAllCSVFiles(int flag);
 EXTERNCPP int  ReadBinIni(void);
 EXTERNCPP FILE_SIZE ReadCSVFile(csvfiledata *csvfi, int flag);
-EXTERNCPP void ReadHRR(int flag);
+EXTERNCPP void ReadHRR(smv_case *scase, int flag);
 EXTERNCPP int  ReadIni(char *inifile);
 EXTERNCPP int  ReadSMV(bufferstreamdata *stream);
 EXTERNCPP void ReadSMVDynamic(smv_case *scase, char *file);

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -434,7 +434,7 @@ EXTERNCPP void UpdateIsoMenuLabels(void);
 EXTERNCPP void UpdateIsoTriangles(int flag);
 EXTERNCPP void UpdateIsoType(void);
 EXTERNCPP void UpdateIsoTypes(void);
-EXTERNCPP void UpdateIsoShowLevels(void);
+EXTERNCPP void UpdateIsoShowLevels(smv_case *scase, meshdata *isomesh);
 EXTERNCPP void *UpdateTrianglesAll(void *arg);
 
 //*** IOpart.c headers

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -318,7 +318,7 @@ EXTERNCPP void GetBoundaryLabels(
               char **labels, float *boundaryvaluespatch, float *tvals256, int nlevel);
 EXTERNCPP void GetColorbarLabels(float tmin, float tmax, int nlevel,
               char labels[12][11],float *tlevels256);
-EXTERNCPP float *GetColorPtr(float *color);
+EXTERNCPP float *GetColorPtr(smv_case *scase, float *color);
 EXTERNCPP float *GetColorTranPtr(float *color, float transparency);
 EXTERNCPP void GetPartColors(partdata *parti, int nlevels, int flag);
 EXTERNCPP void GetPlot3DColors(int iplot, float *ttmin, float *ttmax,

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -735,7 +735,7 @@ EXTERNCPP void ReadHRR(int flag);
 EXTERNCPP int  ReadIni(char *inifile);
 EXTERNCPP int  ReadSMV(bufferstreamdata *stream);
 EXTERNCPP void ReadSMVDynamic(char *file);
-EXTERNCPP void ReadSMVOrig(void);
+EXTERNCPP void ReadSMVOrig(smv_case *scase);
 EXTERNCPP void SetBoundBounds(int set_valmin, float valmin, int set_valmax, float valmax, char *buffer2);
 EXTERNCPP void SetPatchMin(int set_valmin, float valmin, char *buffer2);
 EXTERNCPP void SetPatchMax(int set_valmax, float valmax, char *buffer2);

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -734,7 +734,7 @@ EXTERNCPP FILE_SIZE ReadCSVFile(csvfiledata *csvfi, int flag);
 EXTERNCPP void ReadHRR(int flag);
 EXTERNCPP int  ReadIni(char *inifile);
 EXTERNCPP int  ReadSMV(bufferstreamdata *stream);
-EXTERNCPP void ReadSMVDynamic(char *file);
+EXTERNCPP void ReadSMVDynamic(smv_case *scase, char *file);
 EXTERNCPP void ReadSMVOrig(smv_case *scase);
 EXTERNCPP void SetBoundBounds(int set_valmin, float valmin, int set_valmax, float valmax, char *buffer2);
 EXTERNCPP void SetPatchMin(int set_valmin, float valmin, char *buffer2);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -2100,7 +2100,6 @@ SVEXTERN int surface_indices_bak[7];
 SVEXTERN int SVDECL(wall_case,0);
 SVEXTERN surfdata SVDECL(*surfacedefault,NULL), SVDECL(*vent_surfacedefault,NULL);
 SVEXTERN int ntotalfaces;
-SVEXTERN colordata SVDECL(*firstcolor,NULL);
 SVEXTERN texturedata SVDECL(*textureinfo,NULL), SVDECL(*terrain_textures,NULL);
 #ifdef pp_SKY
 SVEXTERN texturedata SVDECL(*sky_texture, NULL);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -168,14 +168,12 @@ SVEXTERN int SVDECL(update_slicexyz, 0);
 SVEXTERN int SVDECL(update_splitcolorbar, 0);
 SVEXTERN int SVDECL(slice_plot_bound_option, 1);
 #ifdef INMAIN
-SVEXTERN float obst_bounding_box[6] = {1.0,0.0,1.0,0.0,1.0,0.0};
 SVEXTERN float geom_bounding_box[6] = {1000000000.0, -1000000000.0,
                                        1000000000.0, -1000000000.0,
                                        1000000000.0, -1000000000.0
                                       };
 SVEXTERN int glui_surface_color[4] = {255, 255, 255, 255};
 #else
-SVEXTERN float obst_bounding_box[6];
 SVEXTERN float geom_bounding_box[6];
 SVEXTERN int glui_surface_color[4];
 #endif
@@ -1820,6 +1818,7 @@ SVEXTERN smv_case global_scase = {.tourcoll = {.ntourinfo = 0,
                            .nrgb = NRGB,
                            .linewidth = 2.0,
                            .ventlinewidth = 2.0,
+                           .obst_bounding_box = {1.0,0.0,1.0,0.0,1.0,0.0},
                            .hvaccoll = {
                               .hvacductvar_index= -1,
                               .hvacnodevar_index= -1,

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -267,7 +267,7 @@ int SetupCase(char *filename){
     }
 
   // read casename.smo (only OBST lines) to define a one mesh version of OBST's
-    ReadSMVOrig();
+    ReadSMVOrig(&global_scase);
   }
   if(return_code==0&&trainer_mode==1){
     GLUIShowTrainer();

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -1421,31 +1421,31 @@ void InitVars(void){
   mat_specular_orig[1]=0.5f;
   mat_specular_orig[2]=0.2f;
   mat_specular_orig[3]=1.0f;
-  mat_specular2=GetColorPtr(mat_specular_orig);
+  mat_specular2=GetColorPtr(&global_scase, mat_specular_orig);
 
   mat_ambient_orig[0] = 0.5f;
   mat_ambient_orig[1] = 0.5f;
   mat_ambient_orig[2] = 0.2f;
   mat_ambient_orig[3] = 1.0f;
-  mat_ambient2=GetColorPtr(mat_ambient_orig);
+  mat_ambient2=GetColorPtr(&global_scase, mat_ambient_orig);
 
   ventcolor_orig[0]=1.0;
   ventcolor_orig[1]=0.0;
   ventcolor_orig[2]=1.0;
   ventcolor_orig[3]=1.0;
-  ventcolor=GetColorPtr(ventcolor_orig);
+  ventcolor=GetColorPtr(&global_scase, ventcolor_orig);
 
   block_ambient_orig[0] = 1.0;
   block_ambient_orig[1] = 0.8;
   block_ambient_orig[2] = 0.4;
   block_ambient_orig[3] = 1.0;
-  block_ambient2=GetColorPtr(block_ambient_orig);
+  block_ambient2=GetColorPtr(&global_scase, block_ambient_orig);
 
   block_specular_orig[0] = 0.0;
   block_specular_orig[1] = 0.0;
   block_specular_orig[2] = 0.0;
   block_specular_orig[3] = 1.0;
-  block_specular2=GetColorPtr(block_specular_orig);
+  block_specular2=GetColorPtr(&global_scase, block_specular_orig);
 
   for(i=0;i<256;i++){
     boundarylevels256[i]=(float)i/255.0;
@@ -1473,7 +1473,7 @@ void InitVars(void){
   direction_color[1]=64.0/255.0;
   direction_color[2]=139.0/255.0;
   direction_color[3]=1.0;
-  direction_color_ptr=GetColorPtr(direction_color);
+  direction_color_ptr=GetColorPtr(&global_scase, direction_color);
 
   GetGitInfo(smv_githash,smv_gitdate);
 

--- a/Source/smvq/smvq.c
+++ b/Source/smvq/smvq.c
@@ -429,7 +429,7 @@ int RunBenchmark(char *input_file) {
     if(return_code) return return_code;
   }
   show_timings = 1;
-  ReadSMVOrig();
+  ReadSMVOrig(&global_scase);
   INIT_PRINT_TIMER(ReadSMVDynamic_time);
   ReadSMVDynamic(input_file);
   STOP_TIMER(ReadSMVDynamic_time);

--- a/Source/smvq/smvq.c
+++ b/Source/smvq/smvq.c
@@ -431,7 +431,7 @@ int RunBenchmark(char *input_file) {
   show_timings = 1;
   ReadSMVOrig(&global_scase);
   INIT_PRINT_TIMER(ReadSMVDynamic_time);
-  ReadSMVDynamic(input_file);
+  ReadSMVDynamic(&global_scase, input_file);
   STOP_TIMER(ReadSMVDynamic_time);
   fprintf(stderr, "ReadSMVDynamic:\t%8.3f ms\n", ReadSMVDynamic_time * 1000);
   STOP_TIMER(parse_time);


### PR DESCRIPTION
#2155 previously overwrote an earlier change during a rebase. This corrects that and produces conforming images when running cad_test.ssf.

I have reviewed the rest of the PR and it only includes `scase`/`global_scase` changes.