### PR TITLE
remove code for rendering objects with displaylists

### DIFF
--- a/Source/shared/readobject.c
+++ b/Source/shared/readobject.c
@@ -25,8 +25,7 @@
 
 #define BOX_CLIPPLANES 0
 
-int GetTokenId(char *token, int *opptr, int *num_opptr, int *num_outopptr,
-               int *use_displaylist);
+int GetTokenId(char *token, int *opptr, int *num_opptr, int *num_outopptr);
 void ParseSmvObjectString(object_collection *objectscoll, char *string,
                           char **tokens, int *ntokens, int setbw);
 sv_object *InitSmvObject1(object_collection *objectscoll, const char *label,
@@ -370,14 +369,13 @@ char *ParseObjectFrame(object_collection *objectscoll, const char *buffer_in,
     toki->is_texturefile = 0;
     toki->next = NULL;
     if((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')){
-      int use_displaylist;
       int nargs_actual, noutargs_actual;
       tokendata *this_token, *last_token;
       int error_code;
 
       toki->type = TOKEN_COMMAND;
       error_code = GetTokenId(toki->token, &toki->command, &toki->nvars,
-                              &toki->noutvars, &use_displaylist);
+                              &toki->noutvars);
       toki->included_frame = 0;
       toki->included_object = NULL;
       if(error_code == 1){
@@ -389,8 +387,6 @@ char *ParseObjectFrame(object_collection *objectscoll, const char *buffer_in,
         fprintf(stderr, "      %s\n\n", object_buffer);
       }
       frame->command_list[ncommands] = toki;
-      if(frame->device != NULL)
-        frame->device->use_displaylist = use_displaylist;
       if(ncommands > 0){
         this_token = toki;
         last_token = frame->command_list[ncommands - 1];
@@ -615,13 +611,11 @@ char *ParseObjectFrame(object_collection *objectscoll, const char *buffer_in,
 
 /* ----------------------- GetTokenId ----------------------------- */
 
-int GetTokenId(char *token, int *opptr, int *num_opptr, int *num_outopptr,
-               int *use_displaylist){
+int GetTokenId(char *token, int *opptr, int *num_opptr, int *num_outopptr){
 
   int op, num_op, num_outop;
   int return_val;
 
-  *use_displaylist = 0;
 
   return_val = 0;
   if(STRCMP(token, "translate") == 0){
@@ -832,7 +826,6 @@ int GetTokenId(char *token, int *opptr, int *num_opptr, int *num_outopptr,
   }
   else if(STRCMP(token, "drawtsphere") == 0){
     op = SV_DRAWTSPHERE;
-    *use_displaylist = 0;
     num_op = SV_DRAWTSPHERE_NUMARGS;
     num_outop = SV_DRAWTSPHERE_NUMOUTARGS;
   }
@@ -1003,49 +996,41 @@ int GetTokenId(char *token, int *opptr, int *num_opptr, int *num_outopptr,
   }
   else if(STRCMP(token, "multiaddt") == 0){
     op = SV_MULTIADDT;
-    *use_displaylist = 0;
     num_op = SV_MULTIADDT_NUMARGS;
     num_outop = SV_MULTIADDT_NUMOUTARGS;
   }
   else if(STRCMP(token, "clip") == 0){
     op = SV_CLIP;
-    *use_displaylist = 0;
     num_op = SV_CLIP_NUMARGS;
     num_outop = SV_CLIP_NUMOUTARGS;
   }
   else if(STRCMP(token, "clipx") == 0){
     op = SV_CLIP;
-    *use_displaylist = 0;
     num_op = SV_CLIP_NUMARGS;
     num_outop = SV_CLIP_NUMOUTARGS;
   }
   else if(STRCMP(token, "clipy") == 0){
     op = SV_CLIP;
-    *use_displaylist = 0;
     num_op = SV_CLIP_NUMARGS;
     num_outop = SV_CLIP_NUMOUTARGS;
   }
   else if(STRCMP(token, "clipz") == 0){
     op = SV_CLIP;
-    *use_displaylist = 0;
     num_op = SV_CLIP_NUMARGS;
     num_outop = SV_CLIP_NUMOUTARGS;
   }
   else if(STRCMP(token, "clipoff") == 0){
     op = SV_CLIP;
-    *use_displaylist = 0;
     num_op = SV_CLIP_NUMARGS;
     num_outop = SV_CLIP_NUMOUTARGS;
   }
   else if(STRCMP(token, "mirrorclip") == 0){
     op = SV_MIRRORCLIP;
-    *use_displaylist = 0;
     num_op = SV_MIRRORCLIP_NUMARGS;
     num_outop = SV_MIRRORCLIP_NUMOUTARGS;
   }
   else if(STRCMP(token, "periodicclip") == 0){
     op = SV_PERIODICCLIP;
-    *use_displaylist = 0;
     num_op = SV_PERIODICCLIP_NUMARGS;
     num_outop = SV_PERIODICCLIP_NUMOUTARGS;
   }
@@ -1088,7 +1073,6 @@ sv_object *InitSmvObject2(object_collection *objectscoll, const char *label,
   int i;
 
   NewMemory((void **)&object, sizeof(sv_object));
-  object->use_displaylist = 1;
   object->select_mode = 0;
   object->used = 0;
   object->visible = visible;
@@ -1108,7 +1092,6 @@ sv_object *InitSmvObject2(object_collection *objectscoll, const char *label,
       framei->error = 0;
       framei->device = object;
       ParseObjectFrame(objectscoll, commandsoff, NULL, &eof, framei, setbw);
-      framei->display_list_ID = -1;
       framei->use_bw = setbw;
       framei->ntextures = 0;
     }
@@ -1118,7 +1101,6 @@ sv_object *InitSmvObject2(object_collection *objectscoll, const char *label,
       framei->device = object;
       ParseObjectFrame(objectscoll, commandson, NULL, &eof, framei, setbw);
       framei->error = 0;
-      framei->display_list_ID = -1;
       framei->use_bw = setbw;
       framei->ntextures = 0;
     }
@@ -1135,7 +1117,6 @@ sv_object *InitSmvObject1(object_collection *objectscoll, const char *label,
   int eof;
 
   NewMemory((void **)&object, sizeof(sv_object));
-  object->use_displaylist = 1;
   object->select_mode = 0;
   object->used = 0;
   object->visible = visible;
@@ -1149,7 +1130,6 @@ sv_object *InitSmvObject1(object_collection *objectscoll, const char *label,
   object->obj_frames[0] = framei;
   framei->device = object;
   ParseObjectFrame(objectscoll, commands, NULL, &eof, framei, setbw);
-  framei->display_list_ID = -1;
   framei->error = 0;
   framei->use_bw = setbw;
   framei->ntextures = 0;
@@ -1242,7 +1222,6 @@ int ReadObjectDefs(object_collection *objectscoll, const char *file,
 
       NewMemory((void **)&current_object, sizeof(sv_object));
       current_object->used = 0;
-      current_object->use_displaylist = 1;
       current_object->select_mode = 0;
       strcpy(current_object->label, label);
       prev_object = objectscoll->object_def_last.prev;
@@ -1285,7 +1264,6 @@ int ReadObjectDefs(object_collection *objectscoll, const char *file,
       current_frame->next = next_frame;
       current_frame->prev = prev_frame;
 
-      current_frame->display_list_ID = -1;
       current_frame->use_bw = setbw;
       current_frame->device = current_object;
       current_object->nframes++;

--- a/Source/shared/shared_structures.h
+++ b/Source/shared/shared_structures.h
@@ -39,7 +39,6 @@ typedef struct _tokendata {
 typedef struct _sv_object_frame {
   int use_bw;
   int error;
-  int display_list_ID;
   int *symbols, nsymbols;
   tokendata *tokens, **command_list;
   int ntokens, ncommands, ntextures;
@@ -59,7 +58,6 @@ typedef struct _sv_object {
   int type;
   int visible;
   int used, used_by_device;
-  int use_displaylist;
   int select_mode;
   /** @brief The number of frames (i.e., possible states) associated with this
    * object. */

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -3817,7 +3817,6 @@ void DrawDevices(int mode){
   for(ii = 0;ii < global_scase.devicecoll.ndeviceinfo;ii++){
     devicedata *devicei;
     int tagval;
-    int save_use_displaylist;
     propdata *prop;
     int j;
     float dpsi;
@@ -3831,7 +3830,6 @@ void DrawDevices(int mode){
     if(global_scase.isZoneFireModel == 1 && STRCMP(devicei->object->label, "target") == 0 && visSensor == 0)continue;
     if(devicei->in_zone_csv == 1&&strcmp(devicei->deviceID,"TARGET")!=0)continue;
     if(global_scase.isZoneFireModel == 1 && STRCMP(devicei->deviceID, "TIME") == 0)continue;
-    save_use_displaylist = devicei->object->use_displaylist;
     tagval = ii + 1;
     if(select_device == 1 && show_mode == SELECTOBJECT){
 
@@ -3839,7 +3837,6 @@ void DrawDevices(int mode){
       select_device_color[1] = tagval >> nbluebits;
       select_device_color[2] = tagval&rgbmask[nbluebits - 1];
       select_device_color_ptr = select_device_color;
-      devicei->object->use_displaylist = 0;
     }
     else{
       if(devicei->selected==1 && select_device == 1){
@@ -3847,7 +3844,6 @@ void DrawDevices(int mode){
         select_device_color[0] = 255;
         select_device_color[1] = 0;
         select_device_color[2] = 0;
-        devicei->object->use_displaylist = 0;
       }
       else{
         select_device_color_ptr = NULL;
@@ -3991,7 +3987,6 @@ void DrawDevices(int mode){
     if(devicei->nparams > 0 && prop != NULL){
       prop->nvars_indep = 0;
     }
-    devicei->object->use_displaylist = save_use_displaylist;
     glPopMatrix();
   }
 
@@ -4007,7 +4002,6 @@ void DrawSmvObject(sv_object *object_dev, int iframe_local, propdata *prop, int 
   tokendata *toknext;
   unsigned char *rgbptr_local;
   unsigned char rgbcolor[4];
-  int displaylist_id = 0;
   int ii;
   sv_object *object;
   int use_material;
@@ -4085,25 +4079,6 @@ void DrawSmvObject(sv_object *object_dev, int iframe_local, propdata *prop, int 
       }
     }
 
-  }
-
-  if(framei->display_list_ID != -1 && object->use_displaylist == 1){
-    if(framei->use_bw == setbw){
-      glCallList(framei->display_list_ID);
-      glPopMatrix();
-      return;
-    }
-    framei->use_bw = setbw;
-    glDeleteLists(framei->display_list_ID, 1);
-    framei->display_list_ID = -1;
-  }
-
-  if(object->use_displaylist == 1){
-    displaylist_id = glGenLists(1);
-    if(displaylist_id != 0){
-      framei->display_list_ID = displaylist_id;
-      glNewList(displaylist_id, GL_COMPILE_AND_EXECUTE);
-    }
   }
 
   use_material = 0;
@@ -4765,10 +4740,6 @@ void DrawSmvObject(sv_object *object_dev, int iframe_local, propdata *prop, int 
   if(use_material == 1 && recurse_level == 0){
     glDisable(GL_COLOR_MATERIAL);
     DISABLE_LIGHTING;
-  }
-
-  if(object->use_displaylist == 1 && displaylist_id != 0){
-    glEndList();
   }
 
   glPopMatrix();


### PR DESCRIPTION
Objects contained a `use_displaylist` option, however, the parser always sets this to zero and the code is never triggered. This commit removes `use_displaylist` and any code that branches on it.

The use of displaylists has been deprecated in OpenGL so it is unlikely that this is a feature that will be added later.

None of the cases in smokebot trigger displaylists and the only way it would be triggered is if the object definition (e.g. in objects.svo) has no keywords, which doesn't seem possible.

Removing this simplifies things and will allow trimming some other dead code.