### PR TITLE
remove use_bw

### DIFF
--- a/Source/shared/readobject.h
+++ b/Source/shared/readobject.h
@@ -321,13 +321,12 @@ int InitObjectCollection(object_collection *coll);
  * @param[inout] objectscoll Pointer to the location of the @ref
  * object_collection to read object definitions into. This @ref
  * object_collection
- * @param[in] setbw Set the colors to black and white.
  * @param[in] fdsprefix The fdsprefix. This is used to find case-specific object
  * files (e.g., "${fdsprefix}.svo"). If NULL, such files are never read.
  * @param[in] isZoneFireModel Is this model a zone fire model.
  */
 void ReadDefaultObjectCollection(object_collection *objectscoll,
-                                 const char *fdsprefix, int setbw,
+                                 const char *fdsprefix,
                                  int isZoneFireModel);
 
 /**
@@ -381,7 +380,7 @@ sv_object *GetSmvObjectType(object_collection *objectscoll, char *olabel,
  *
  * @returns The number of objects read
  */
-int ReadObjectDefs(object_collection *objectscoll, const char *file, int setbw);
+int ReadObjectDefs(object_collection *objectscoll, const char *file);
 // END MAIN API
 
 // These still need to be documented.

--- a/Source/shared/shared_structures.h
+++ b/Source/shared/shared_structures.h
@@ -37,7 +37,6 @@ typedef struct _tokendata {
  * This can form a node in a linked-list.
  */
 typedef struct _sv_object_frame {
-  int use_bw;
   int error;
   int *symbols, nsymbols;
   tokendata *tokens, **command_list;

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -2790,7 +2790,7 @@ void SmokeviewIniMenu(int value){
     WriteIni(LOCAL_INI,NULL);
     break;
   case MENU_READSVO:
-    ReadDefaultObjectCollection(&global_scase.objectscoll, global_scase.fdsprefix, setbw, global_scase.isZoneFireModel);
+    ReadDefaultObjectCollection(&global_scase.objectscoll, global_scase.fdsprefix, global_scase.isZoneFireModel);
     break;
   case MENU_DUMMY:
     break;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -7022,7 +7022,7 @@ int ReadSMV_Init(smv_case *scase){
   // read in device (.svo) definitions
 
   START_TIMER(timer_setup);
-  ReadDefaultObjectCollection(&scase->objectscoll, scase->fdsprefix, setbw, scase->isZoneFireModel);
+  ReadDefaultObjectCollection(&scase->objectscoll, scase->fdsprefix, scase->isZoneFireModel);
   PRINT_TIMER(timer_setup, "InitSurface");
 
   if(scase->noutlineinfo>0){

--- a/Tests/parse_objects.c
+++ b/Tests/parse_objects.c
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
     const char *file_path = argv[1];
     // Create an object collection, read in object definitions, then free it.
     object_collection *objectscoll = CreateObjectCollection();
-    int result = ReadObjectDefs(objectscoll, file_path, 0);
+    int result = ReadObjectDefs(objectscoll, file_path);
     // Two of the objects in this bad file are still parsable so we should
     // parse 2 object definitions.
     assert(result > 0);

--- a/Tests/test_labels.c
+++ b/Tests/test_labels.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
   //   const char *bad_file_path = argv[1];
   //   // Create an object collection, read in object definitions, then free it.
   //   object_collection *objectscoll = CreateObjectCollection();
-  //   int result = ReadObjectDefs(objectscoll, bad_file_path, 0);
+  //   int result = ReadObjectDefs(objectscoll, bad_file_path);
   //   // Two of the objects in this bad file are still parsable so we should
   //   // parse 2 object definitions.
   //   assert(result == 2);

--- a/Tests/test_objects.c
+++ b/Tests/test_objects.c
@@ -28,13 +28,13 @@ int main(int argc, char **argv) {
     object_collection *objectscoll = CreateObjectCollection();
     // There should be no objects to begin with
     assert(objectscoll->nobject_defs == 0);
-    ReadDefaultObjectCollection(objectscoll, NULL, 0, 0);
+    ReadDefaultObjectCollection(objectscoll, NULL, 0);
     FreeObjectCollection(objectscoll);
   }
   {
     // Create an object collection, read in object definitions, then free it.
     object_collection *objectscoll = CreateObjectCollection();
-    ReadDefaultObjectCollection(objectscoll, NULL, 0, 0);
+    ReadDefaultObjectCollection(objectscoll, NULL, 0);
     FreeObjectCollection(objectscoll);
   }
   return 0;


### PR DESCRIPTION
As display lists are no longer present, the `use_bw` property of objects is no longer used and can be removed. This also means that `setbw` no longer needs to be passed to the parser.

SETBW as a configuration option works separately.