### PR TITLE
initialise hardcoded colour defaults at compile time

### DIFF
--- a/Source/shared/colorbars.h
+++ b/Source/shared/colorbars.h
@@ -3,7 +3,11 @@
 #define COLORBARS_H_DEFINED
 
 #include "options.h"
-
+#if defined(WIN32)
+#include <windows.h>
+#endif
+#include GLU_H
+#include GL_H
 #define FILE_UPDATE 6
 
 #define CB_RAINBOW 0
@@ -16,6 +20,21 @@
 #define CB_OTHER 7
 #define INTERP_RGB 0
 #define INTERP_LAB 1
+
+// Define a number of readonly color defaults.
+#ifdef INMAIN
+SVEXTERN float mat_ambient_orig[4] = {0.5f, 0.5f, 0.2f, 1.0f};
+SVEXTERN float mat_specular_orig[4] = {0.5f, 0.5f, 0.2f, 1.0f};
+SVEXTERN float ventcolor_orig[4] = {1.0, 0.0, 1.0, 1.0};
+SVEXTERN float block_ambient_orig[4] = {1.0, 0.8, 0.4, 1.0};
+SVEXTERN float block_specular_orig[4] = {0.0, 0.0, 0.0, 1.0};
+#else
+SVEXTERN float mat_ambient_orig[4];
+SVEXTERN float mat_specular_orig[4];
+SVEXTERN float ventcolor_orig[4];
+SVEXTERN float block_ambient_orig[4];
+SVEXTERN float block_specular_orig[4];
+#endif
 
 /* --------------------------  colordata ------------------------------------ */
 

--- a/Source/shared/shared_structures.h
+++ b/Source/shared/shared_structures.h
@@ -1747,6 +1747,15 @@ typedef struct {
   labeldata *label_last_ptr;
 } labels_collection;
 
+struct color_defaults {
+  float *block_ambient2;
+  float *ventcolor;
+  float *mat_specular2;
+  float *mat_ambient2;
+  float *block_specular2;
+  GLfloat block_shininess;
+};
+
 /* --------------------------  smv_case ------------------------------------ */
 
 typedef struct {
@@ -1965,6 +1974,8 @@ typedef struct {
   int visFloor;
   int visWalls;
   int visCeiling;
+
+  struct color_defaults color_defs;
 
   float getfilelist_time;
   float pass0_time;

--- a/Source/smokeview/IOgeometry.c
+++ b/Source/smokeview/IOgeometry.c
@@ -921,7 +921,7 @@ void DrawGeom(int flag, int timestate){
     ENABLE_LIGHTING;
     glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,iso_specular);
     glMaterialf(GL_FRONT_AND_BACK,GL_SHININESS,iso_shininess);
-    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,block_ambient2);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,global_scase.color_defs.block_ambient2);
     glEnable(GL_COLOR_MATERIAL);
 
     glPushMatrix();
@@ -4092,7 +4092,7 @@ void DrawGeomData(int flag, slicedata *sd, patchdata *patchi, int geom_type){
       glBindTexture(GL_TEXTURE_1D, texture_slice_colorbar_id);
       glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR,            iso_specular);
       glMaterialf(GL_FRONT_AND_BACK,  GL_SHININESS,           iso_shininess);
-      glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, block_ambient2);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, global_scase.color_defs.block_ambient2);
       glEnable(GL_COLOR_MATERIAL);
 
       glPushMatrix();
@@ -4649,7 +4649,7 @@ void DrawCGeom(int flag, geomdata *cgeom){
       ENABLE_LIGHTING;
       glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, iso_specular);
       glMaterialf(GL_FRONT_AND_BACK, GL_SHININESS, iso_shininess);
-      glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, block_ambient2);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, global_scase.color_defs.block_ambient2);
       glEnable(GL_COLOR_MATERIAL);
 
       glPushMatrix();

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -642,8 +642,8 @@ void DrawWindRose(windrosedata *wr,int orientation){
     maxr = maxr_windrose;
   }
   ENABLE_LIGHTING;
-  glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
-  glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, block_ambient2);
+  glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &global_scase.color_defs.block_shininess);
+  glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, global_scase.color_defs.block_ambient2);
   glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, specular);
   glEnable(GL_COLOR_MATERIAL);
 
@@ -3471,8 +3471,8 @@ void DrawDevices(int mode){
     if(object_box==1){
       if(object_outlines==0){
         ENABLE_LIGHTING;
-        glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
-        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, block_ambient2);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &global_scase.color_defs.block_shininess);
+        glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, global_scase.color_defs.block_ambient2);
         glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, specular);
         glEnable(GL_COLOR_MATERIAL);
       }
@@ -3523,8 +3523,8 @@ void DrawDevices(int mode){
     int j;
 
     ENABLE_LIGHTING;
-    glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
-    glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, block_ambient2);
+    glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &global_scase.color_defs.block_shininess);
+    glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, global_scase.color_defs.block_ambient2);
     glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, specular);
     glEnable(GL_COLOR_MATERIAL);
 
@@ -4138,8 +4138,8 @@ void DrawSmvObject(sv_object *object_dev, int iframe_local, propdata *prop, int 
   if(select_device_color_ptr == NULL&&recurse_level == 0){
     ENABLE_LIGHTING;
 
-    glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
-    glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, block_ambient2);
+    glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &global_scase.color_defs.block_shininess);
+    glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, global_scase.color_defs.block_ambient2);
     glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, specular);
 
     glEnable(GL_COLOR_MATERIAL);

--- a/Source/smokeview/IOwui.c
+++ b/Source/smokeview/IOwui.c
@@ -1519,7 +1519,7 @@ void DrawTerrainOBSTSides(meshdata *meshi){
   glTranslatef(-global_scase.xbar0, -global_scase.ybar0, -global_scase.zbar0);
 
   ENABLE_LIGHTING;
-  glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
+  glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &global_scase.color_defs.block_shininess);
 
   glEnable(GL_COLOR_MATERIAL);
   glColor4fv(terrain_color);
@@ -1660,7 +1660,7 @@ void DrawTerrainOBSTTexture(terraindata *terri){
   glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
 
   ENABLE_LIGHTING;
-  glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
+  glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&global_scase.color_defs.block_shininess);
   glTexEnvf(GL_TEXTURE_ENV,GL_TEXTURE_ENV_MODE,GL_MODULATE);
   glEnable(GL_TEXTURE_2D);
   glBindTexture(GL_TEXTURE_2D,global_scase.terrain_texture_coll.terrain_textures[iterrain_textures].name);

--- a/Source/smokeview/c_api.c
+++ b/Source/smokeview/c_api.c
@@ -2135,9 +2135,9 @@ int SetBackgroundcolor(float r, float g, float b) {
 } // BACKGROUNDCOLOR
 
 int SetBlockcolor(float r, float g, float b) {
-  block_ambient2[0] = r;
-  block_ambient2[1] = g;
-  block_ambient2[2] = b;
+  global_scase.color_defs.block_ambient2[0] = r;
+  global_scase.color_defs.block_ambient2[1] = g;
+  global_scase.color_defs.block_ambient2[2] = b;
   return 0;
 } // BLOCKCOLOR
 

--- a/Source/smokeview/drawGeometry.c
+++ b/Source/smokeview/drawGeometry.c
@@ -606,17 +606,17 @@ void UpdateIndexColors(void){
   global_scase.updateindexcolors=0;
 
   if(strcmp(global_scase.surfacedefault->surfacelabel,"INERT")==0){
-    global_scase.surfacedefault->color=block_ambient2;
+    global_scase.surfacedefault->color=global_scase.color_defs.block_ambient2;
   }
   for(i=0;i<global_scase.surfcoll.nsurfinfo;i++){
     surfdata *surfi;
 
     surfi = global_scase.surfcoll.surfinfo + i;
     if(strcmp(surfi->surfacelabel,"INERT")==0){
-      surfi->color=block_ambient2;
+      surfi->color=global_scase.color_defs.block_ambient2;
     }
     if(strcmp(surfi->surfacelabel,"OPEN")==0){
-      surfi->color=ventcolor;
+      surfi->color=global_scase.color_defs.ventcolor;
     }
   }
 
@@ -1674,8 +1674,8 @@ void DrawCADGeom(const cadgeomdata *cd){
   if(cullfaces==1)glDisable(GL_CULL_FACE);
 
   ENABLE_LIGHTING;
-  glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
-  glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,block_specular2);
+  glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&global_scase.color_defs.block_shininess);
+  glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,global_scase.color_defs.block_specular2);
   glEnable(GL_COLOR_MATERIAL);
   glBegin(GL_QUADS);
   for(i=0;i<cd->nquads;i++){
@@ -1737,7 +1737,7 @@ void DrawCAD2Geom(const cadgeomdata *cd, int trans_flag){
 
   glEnable(GL_COLOR_MATERIAL);
   glColorMaterial(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE);
-  glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,block_specular2);
+  glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,global_scase.color_defs.block_specular2);
   ENABLE_LIGHTING;
   if(trans_flag==DRAW_TRANSPARENT)TransparentOn();
   glBegin(GL_QUADS);
@@ -1817,7 +1817,7 @@ void DrawCAD2Geom(const cadgeomdata *cd, int trans_flag){
   glEnd();
 
   if(visCadTextures==1){
-    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&global_scase.color_defs.block_shininess);
     glTexEnvf(GL_TEXTURE_ENV,GL_TEXTURE_ENV_MODE,enable_texture_lighting? GL_MODULATE : GL_REPLACE);
     glEnable(GL_TEXTURE_2D);
     glColor4ub(255, 255, 255, 255);
@@ -2070,7 +2070,7 @@ void ObstOrVent2Faces(const meshdata *meshi, blockagedata *bc,
         break;
       case FFALSE:
         if(bc->surf[j]==global_scase.surfacedefault){
-         // faceptr->color=block_ambient2;
+         // faceptr->color=global_scase.color_defs.block_ambient2;
           faceptr->color=global_scase.surfacedefault->color;  /* fix ?? */
           faceptr->transparent=global_scase.surfacedefault->transparent;
         }
@@ -3024,7 +3024,7 @@ void DrawSelectFaces(){
           new_color=facei->color;\
         }\
         else{\
-          if(visNormalEditColors==0)new_color=block_ambient2;\
+          if(visNormalEditColors==0)new_color=global_scase.color_defs.block_ambient2;\
           if(visNormalEditColors==1)new_color=facei->color;\
           if(highlight_block==facei->blockageindex&&highlight_mesh==facei->meshindex){\
             new_color=DEFeditcolor;\
@@ -3051,9 +3051,9 @@ void DrawObstsDebug(void){
   glTranslatef(-global_scase.xbar0,-global_scase.ybar0,-global_scase.zbar0);
   if(light_faces == 1){
     ENABLE_LIGHTING;
-    glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
-    glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, block_ambient2);
-    glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, block_specular2);
+    glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &global_scase.color_defs.block_shininess);
+    glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, global_scase.color_defs.block_ambient2);
+    glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, global_scase.color_defs.block_specular2);
     glEnable(GL_COLOR_MATERIAL);
   }
   for(i = 1; i <= global_scase.meshescoll.nmeshes; i++){
@@ -3107,9 +3107,9 @@ void DrawFacesOLD(int option){
     glEnable(GL_CULL_FACE);
     if(light_faces == 1){
       ENABLE_LIGHTING;
-      glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
-      glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, block_ambient2);
-      glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, block_specular2);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &global_scase.color_defs.block_shininess);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, global_scase.color_defs.block_ambient2);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, global_scase.color_defs.block_specular2);
       glEnable(GL_COLOR_MATERIAL);
     }
     glBegin(GL_TRIANGLES);
@@ -3142,7 +3142,7 @@ void DrawFacesOLD(int option){
           new_color = facei->color;
         }
         else{
-          if(visNormalEditColors == 0)new_color = block_ambient2;
+          if(visNormalEditColors == 0)new_color = global_scase.color_defs.block_ambient2;
           if(visNormalEditColors == 1)new_color = facei->color;
           if(highlight_block == facei->blockageindex && highlight_mesh == facei->meshindex){
             new_color = highlight_color;
@@ -3189,9 +3189,9 @@ void DrawFacesOLD(int option){
 
     if(light_faces == 1){
       ENABLE_LIGHTING;
-      glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
-      glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, block_ambient2);
-      glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, block_specular2);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &global_scase.color_defs.block_shininess);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, global_scase.color_defs.block_ambient2);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, global_scase.color_defs.block_specular2);
       glEnable(GL_COLOR_MATERIAL);
     }
     if(cullfaces == 1)glDisable(GL_CULL_FACE);
@@ -3225,7 +3225,7 @@ void DrawFacesOLD(int option){
           new_color = facei->color;
         }
         else{
-          if(visNormalEditColors == 0)new_color = block_ambient2;
+          if(visNormalEditColors == 0)new_color = global_scase.color_defs.block_ambient2;
           if(visNormalEditColors == 1)new_color = facei->color;
           if(highlight_block == facei->blockageindex && highlight_mesh == facei->meshindex){
             new_color = highlight_color;
@@ -3341,8 +3341,8 @@ void DrawFacesOLD(int option){
     glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, enable_texture_lighting?GL_MODULATE:GL_REPLACE);
     if(light_faces == 1){
       glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
-      glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &block_shininess);
-      glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, block_specular2);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_SHININESS, &global_scase.color_defs.block_shininess);
+      glMaterialfv(GL_FRONT_AND_BACK, GL_SPECULAR, global_scase.color_defs.block_specular2);
     }
     glEnable(GL_TEXTURE_2D);
     glColor4ub(255, 255, 255, 255);
@@ -3423,9 +3423,9 @@ void DrawFaces(){
     int j;
 
     ENABLE_LIGHTING;
-    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
-    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,block_ambient2);
-    glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,block_specular2);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&global_scase.color_defs.block_shininess);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,global_scase.color_defs.block_ambient2);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,global_scase.color_defs.block_specular2);
     glEnable(GL_COLOR_MATERIAL);
     glBegin(GL_TRIANGLES);
     for(j=0;j<global_scase.meshescoll.nmeshes;j++){
@@ -3505,9 +3505,9 @@ void DrawFaces(){
     new_color = NULL;
     old_color = NULL;
     ENABLE_LIGHTING;
-    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
-    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,block_ambient2);
-    glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,block_specular2);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&global_scase.color_defs.block_shininess);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,global_scase.color_defs.block_ambient2);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,global_scase.color_defs.block_specular2);
     glEnable(GL_COLOR_MATERIAL);
     if(cullfaces==1)glDisable(GL_CULL_FACE);
     glBegin(GL_QUADS);
@@ -3534,7 +3534,7 @@ void DrawFaces(){
           new_color=facei->color;
         }
         else{
-          if(visNormalEditColors==0)new_color=block_ambient2;
+          if(visNormalEditColors==0)new_color=global_scase.color_defs.block_ambient2;
           if(visNormalEditColors==1)new_color=facei->color;
           if(highlight_block==facei->blockageindex&&highlight_mesh==facei->meshindex){
             new_color=highlight_color;
@@ -3637,8 +3637,8 @@ void DrawFaces(){
     ENABLE_LIGHTING;
     glEnable(GL_COLOR_MATERIAL);
     glTexEnvf(GL_TEXTURE_ENV,GL_TEXTURE_ENV_MODE,enable_texture_lighting? GL_MODULATE : GL_REPLACE);
-    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
-    glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,block_specular2);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&global_scase.color_defs.block_shininess);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,global_scase.color_defs.block_specular2);
     glEnable(GL_TEXTURE_2D);
     glColor4ub(255, 255, 255, 255);
     for(j=0;j<global_scase.meshescoll.nmeshes;j++){
@@ -3755,10 +3755,10 @@ void DrawTransparentFaces(){
   if(nface_transparent>0){
     int i;
 
-    new_color=block_ambient2;
+    new_color=global_scase.color_defs.block_ambient2;
     ENABLE_LIGHTING;
-    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
-    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,block_ambient2);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&global_scase.color_defs.block_shininess);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,global_scase.color_defs.block_ambient2);
     glEnable(GL_COLOR_MATERIAL);
     glBegin(GL_QUADS);
     for(i=0;i<nface_transparent;i++){
@@ -3779,7 +3779,7 @@ void DrawTransparentFaces(){
         new_color=facei->color;
       }
       else{
-        if(visNormalEditColors==0)new_color=block_ambient2;
+        if(visNormalEditColors==0)new_color=global_scase.color_defs.block_ambient2;
         if(visNormalEditColors==1)new_color=facei->color;
         if(highlight_block==facei->blockageindex&&highlight_mesh==facei->meshindex){
           new_color=highlight_color;
@@ -3831,8 +3831,8 @@ void DrawTransparentFaces(){
     int j;
 
     ENABLE_LIGHTING;
-    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
-    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,block_ambient2);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&global_scase.color_defs.block_shininess);
+    glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,global_scase.color_defs.block_ambient2);
     glEnable(GL_COLOR_MATERIAL);
     if(cullfaces==1)glDisable(GL_CULL_FACE);
     glBegin(GL_QUADS);
@@ -4325,8 +4325,8 @@ void DrawDemo(int nlat, int nlong){
 //#define COLOR(x) (1.0+((x)-0.2143)/0.3)/2.0
 #define COLOR(x) 0.0
       ENABLE_LIGHTING;
-      glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&block_shininess);
-      glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,block_ambient2);
+      glMaterialfv(GL_FRONT_AND_BACK,GL_SHININESS,&global_scase.color_defs.block_shininess);
+      glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,global_scase.color_defs.block_ambient2);
       glMaterialfv(GL_FRONT_AND_BACK,GL_SPECULAR,specular);
       glEnable(GL_COLOR_MATERIAL);
       for(j=0;j<nlong;j++){

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -604,13 +604,13 @@ void ReadHRR(smv_case *scase, int flag){
 
 // find column index of several quantities
 
-  scase->time_col  = GetHrrCsvCol(&global_scase, "Time");
+  scase->time_col  = GetHrrCsvCol(scase, "Time");
   if(scase->time_col>=0)scase->timeptr = scase->hrr_coll.hrrinfo+scase->time_col;
 
-  scase->hrr_col   = GetHrrCsvCol(&global_scase, "HRR");
+  scase->hrr_col   = GetHrrCsvCol(scase, "HRR");
   if(scase->hrr_col>=0&&scase->time_col>=0)scase->hrrptr = scase->hrr_coll.hrrinfo+scase->hrr_col;
 
-  scase->qradi_col = GetHrrCsvCol(&global_scase, "Q_RADI");
+  scase->qradi_col = GetHrrCsvCol(scase, "Q_RADI");
   CheckMemory;
 
 // define column for each MLR column by heat of combustion except for air and products
@@ -689,7 +689,7 @@ void ReadHRR(smv_case *scase, int flag){
     hi = scase->hrr_coll.hrrinfo+i;
     hi->nvals = nrows-2;
   }
-  UpdateHoc(&global_scase);
+  UpdateHoc(scase);
   CheckMemory;
 
 //construct column of qradi/hrr
@@ -1979,7 +1979,7 @@ void InitDevice(smv_case *scase, devicedata *devicei, float *xyz, int is_beam, f
       color[1] = params[1];
       color[2] = params[2];
       color[3] = 1.0;
-      devicei->color = GetColorPtr(&global_scase, color);
+      devicei->color = GetColorPtr(scase, color);
     }
     if(nparams >= 4){
       devicei->line_width = params[3];
@@ -2118,7 +2118,7 @@ void ParseDevicekeyword(smv_case *scase, BFILE *stream, devicedata *devicei){
   devicei->is_beam = is_beam;
 
   GetLabels(buffer,&prop_id,NULL);
-  devicei->prop=GetPropID(&global_scase, prop_id);
+  devicei->prop=GetPropID(scase, prop_id);
   if(prop_id!=NULL&&devicei->prop!=NULL&&devicei->prop->smv_object!=NULL){
     devicei->object=devicei->prop->smv_object;
   }
@@ -2246,7 +2246,7 @@ void ParseDevicekeyword2(smv_case *scase, FILE *stream, devicedata *devicei){
   devicei->is_beam = is_beam;
 
   GetLabels(buffer, &prop_id, NULL);
-  devicei->prop = GetPropID(&global_scase, prop_id);
+  devicei->prop = GetPropID(scase, prop_id);
   if(prop_id!=NULL&&devicei->prop!=NULL&&devicei->prop->smv_object!=NULL){
     devicei->object = devicei->prop->smv_object;
   }
@@ -4151,7 +4151,7 @@ void InitObst(smv_case *scase, blockagedata *bc, surfdata *surf, int index, int 
 
 /* ------------------ InitSurface ------------------------ */
 
-void InitSurface(surfdata *surf){
+void InitSurface(surfdata *surf, float *color){
   surf->in_color_dialog = 0;
   surf->iso_level = -1;
   surf->used_by_obst = 0;
@@ -4164,7 +4164,7 @@ void InitSurface(surfdata *surf){
   surf->surfacelabel = NULL;
   surf->texturefile = NULL;
   surf->textureinfo = NULL;
-  surf->color = block_ambient2;
+  surf->color = color;
   surf->t_width = 1.0;
   surf->t_height = 1.0;
   surf->type = BLOCK_regular;
@@ -4176,13 +4176,13 @@ void InitSurface(surfdata *surf){
 
 /* ------------------ InitVentSurface ------------------------ */
 
-void InitVentSurface(surfdata *surf){
+void InitVentSurface(surfdata *surf, float color[4]){
   surf->emis = 1.0;
   surf->temp_ignition = TEMP_IGNITION_MAX;
   surf->surfacelabel = NULL;
   surf->texturefile = NULL;
   surf->textureinfo = NULL;
-  surf->color = ventcolor;
+  surf->color = color;
   surf->t_width = 1.0;
   surf->t_height = 1.0;
   surf->type = BLOCK_outline;
@@ -4503,7 +4503,7 @@ void ParseDatabase(smv_case *scase, char *file){
     for(j = 0; j<scase->surfcoll.nsurfids; j++){
       if(scase->surfcoll.surfids[j].show==0)continue;
       surfj++;
-      InitSurface(surfj);
+      InitSurface(surfj, scase->color_defs.block_ambient2);
       surfj->surfacelabel = scase->surfcoll.surfids[j].label;
     }
     scase->surfcoll.nsurfinfo += nsurfids_shown;
@@ -4587,7 +4587,7 @@ void ReadZVentData(smv_case *scase, zventdata *zvi, char *buffer, int flag){
       zvi->wall = TOP_WALL;
     }
   }
-  zvi->color = GetColorPtr(&global_scase, color);
+  zvi->color = GetColorPtr(scase, color);
   zvi->area_fraction = area_fraction;
 }
 
@@ -6848,6 +6848,7 @@ void SetSliceParmInfo(sliceparmdata *sp){
   sp->nmultivsliceinfo = global_scase.slicecoll.nmultivsliceinfo;
 }
 
+
 /* ------------------ ReadSMV_Init ------------------------ */
 
 /// @brief Initialise any global variables necessary to being parsing an SMV
@@ -6882,7 +6883,7 @@ int ReadSMV_Init(smv_case *scase){
 
   scase->propcoll.npropinfo=1; // the 0'th prop is the default human property
 
-  FREEMEMORY(global_scase.fds_title);
+  FREEMEMORY(scase->fds_title);
 
   FREEMEMORY(scase->treeinfo);
   scase->ntreeinfo=0;
@@ -6957,21 +6958,21 @@ int ReadSMV_Init(smv_case *scase){
   scase->nrooms=0;
 
   START_TIMER(timer_setup);
-  InitSurface(&scase->sdefault);
+  InitSurface(&scase->sdefault, scase->color_defs.block_ambient2);
   PRINT_TIMER(timer_setup, "InitSurface");
   NewMemory((void **)&scase->sdefault.surfacelabel,(5+1));
   strcpy(scase->sdefault.surfacelabel,"INERT");
 
-  InitVentSurface(&scase->v_surfacedefault);
+  InitVentSurface(&scase->v_surfacedefault, scase->color_defs.ventcolor);
   PRINT_TIMER(timer_setup, "InitVentSurface");
   NewMemory((void **)&scase->v_surfacedefault.surfacelabel,(4+1));
   strcpy(scase->v_surfacedefault.surfacelabel,"VENT");
 
-  InitSurface(&scase->e_surfacedefault);
+  InitSurface(&scase->e_surfacedefault, scase->color_defs.block_ambient2);
   PRINT_TIMER(timer_setup, "InitSurface");
   NewMemory((void **)&scase->e_surfacedefault.surfacelabel,(8+1));
   strcpy(scase->e_surfacedefault.surfacelabel,"EXTERIOR");
-  scase->e_surfacedefault.color=mat_ambient2;
+  scase->e_surfacedefault.color=scase->color_defs.block_ambient2;
 
   // free memory for particle class
 
@@ -7048,7 +7049,7 @@ int ReadSMV_Init(smv_case *scase){
 
       for(i=0;i<scase->smoke3dcoll.nsmoke3dinfo;i++){
         smoke3di = scase->smoke3dcoll.smoke3dinfo + i;
-        FreeSmoke3D(&global_scase, smoke3di);
+        FreeSmoke3D(scase, smoke3di);
         FREEMEMORY(smoke3di->comp_file);
         FREEMEMORY(smoke3di->reg_file);
       }
@@ -7380,8 +7381,8 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
       if(fds_title_local==NULL)continue;
       len_title = strlen(fds_title_local);
       if(len_title==0)continue;
-      NewMemory((void **)&global_scase.fds_title, len_title+1);
-      strcpy(global_scase.fds_title, fds_title_local);
+      NewMemory((void **)&scase->fds_title, len_title+1);
+      strcpy(scase->fds_title, fds_title_local);
       continue;
     }
     if(MatchSMV(buffer, "SOLID_HT3D")==1){
@@ -8950,7 +8951,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
       }
       bufferptr=TrimFrontBack(buffer);
       if (FileExistsCaseDir(scase, bufferptr) == YES) {
-        ReadCADGeomToCollection(&scase->cadgeomcoll, bufferptr, block_shininess);
+        ReadCADGeomToCollection(&scase->cadgeomcoll, bufferptr, scase->color_defs.block_shininess);
       }
       else {
         PRINTF(_("***Error: CAD geometry file: %s could not be opened"),
@@ -8995,7 +8996,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
       char *buffer3;
 
       surfi = scase->surfcoll.surfinfo + scase->surfcoll.nsurfinfo;
-      InitSurface(surfi);
+      InitSurface(surfi, scase->color_defs.block_ambient2);
       FGETS(buffer,255,stream);
       TrimBack(buffer);
       len=strlen(buffer);
@@ -9136,7 +9137,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
       }
       else{
         FGETS(buffer,255,stream);
-        sscanf(buffer,"%i %i %i %i %i %i %i %i %i",&ibartemp,&jbartemp,&kbartemp, 
+        sscanf(buffer,"%i %i %i %i %i %i %i %i %i",&ibartemp,&jbartemp,&kbartemp,
           mesh_nabors, mesh_nabors+1, mesh_nabors+2, mesh_nabors+3, mesh_nabors+4, mesh_nabors+5);
           if(mesh_nabors[5]>=-1)have_mesh_nabors = 1;
       }
@@ -9285,7 +9286,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
       roomdata *roomi;
 
       scase->isZoneFireModel=1;
-      global_scase.visFrame=0;
+      scase->visFrame=0;
       roomdefined=1;
       iroom++;
       roomi = scase->roominfo + iroom - 1;
@@ -9578,17 +9579,17 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
 
   */
 
-  global_scase.surfacedefault=&scase->sdefault;
+  scase->surfacedefault=&scase->sdefault;
   for(i=0;i<scase->surfcoll.nsurfinfo;i++){
     if(strcmp(scase->surfacedefaultlabel,scase->surfcoll.surfinfo[i].surfacelabel)==0){
-      global_scase.surfacedefault=scase->surfcoll.surfinfo+i;
+      scase->surfacedefault=scase->surfcoll.surfinfo+i;
       break;
     }
   }
-  global_scase.vent_surfacedefault=&scase->v_surfacedefault;
+  scase->vent_surfacedefault=&scase->v_surfacedefault;
   for(i=0;i<scase->surfcoll.nsurfinfo;i++){
-    if(strcmp(global_scase.vent_surfacedefault->surfacelabel,scase->surfcoll.surfinfo[i].surfacelabel)==0){
-      global_scase.vent_surfacedefault=scase->surfcoll.surfinfo+i;
+    if(strcmp(scase->vent_surfacedefault->surfacelabel,scase->surfcoll.surfinfo[i].surfacelabel)==0){
+      scase->vent_surfacedefault=scase->surfcoll.surfinfo+i;
       break;
     }
   }
@@ -10181,7 +10182,7 @@ typedef struct {
           bc = meshi->blockageinfoptrs[nn];
         }
         if(bc == NULL)continue;
-        InitObst(scase,bc,global_scase.surfacedefault,nn+1,iobst-1);
+        InitObst(scase,bc,scase->surfacedefault,nn+1,iobst-1);
         FGETS(buffer,255,stream);
 
         char id_label[100], *id_labelptr;
@@ -10485,7 +10486,7 @@ typedef struct {
 
         cvi = meshi->cventinfo + j;
         cvi->isOpenvent=0;
-        cvi->surf[0]=global_scase.vent_surfacedefault;
+        cvi->surf[0]=scase->vent_surfacedefault;
         cvi->textureinfo[0]=NULL;
         cvi->texture_origin[0]=scase->texture_origin[0];
         cvi->texture_origin[1]=scase->texture_origin[1];
@@ -10651,9 +10652,9 @@ typedef struct {
       scase->ndummyvents=0;
       sscanf(buffer,"%i %i",&nvents,&scase->ndummyvents);
       if(scase->ndummyvents!=0){
-        global_scase.visFloor=0;
-        global_scase.visCeiling=0;
-        global_scase.visWalls=0;
+        scase->visFloor=0;
+        scase->visCeiling=0;
+        scase->visWalls=0;
       }
       meshi->nvents=nvents;
       meshi->ndummyvents=scase->ndummyvents;
@@ -10678,7 +10679,7 @@ typedef struct {
         vi->wall_type = INTERIORwall;
         vi->isMirrorvent = 0;
         vi->hideboundary=0;
-        vi->surf[0]=global_scase.vent_surfacedefault;
+        vi->surf[0]=scase->vent_surfacedefault;
         vi->textureinfo[0]=NULL;
         vi->texture_origin[0]=scase->texture_origin[0];
         vi->texture_origin[1]=scase->texture_origin[1];
@@ -10918,7 +10919,7 @@ typedef struct {
         vi->kmin = kv1;
         vi->kmax = kv2;
         if(nn>=nvents&&nn<nvents+6){
-          vi->color=foregroundcolor;
+          vi->color=scase->color_defs.ventcolor;
         }
         assert(vi->color!=NULL);
       }
@@ -11729,12 +11730,95 @@ int ReadSMV_Configure(){
   return 0;
 }
 
+/// @brief Initialize a smokeview case (smv_case) which has already been
+/// allocated. This should be avoided and CreateScase/DestroyScase should be
+/// used instead.
+/// @param scase An uninitialized scase
+void InitScase(smv_case *scase) {
+  // set all of the defaults that are non-zero
+  scase->tourcoll.ntourinfo = 0;
+  scase->tourcoll.tourinfo = NULL;
+  scase->tourcoll.tour_ntimes = 1000;
+  scase->tourcoll.tour_t = NULL;
+  scase->tourcoll.tour_t2 = NULL;
+  scase->tourcoll.tour_dist = NULL;
+  scase->tourcoll.tour_dist2 = NULL;
+  scase->tourcoll.tour_dist3 = NULL;
+  scase->tourcoll.tour_tstart = 0.0;
+  scase->tourcoll.tour_tstop = 100.0;
+  scase->fuel_hoc = -1.0;
+  scase->fuel_hoc_default = -1.0;
+  scase->have_cface_normals = CFACE_NORMALS_NO;
+  scase->gvecphys[2] =  -9.8;
+  scase->gvecunit[2] =  -1.0;
+  scase->global_tbegin = 1.0;
+  scase->load_hrrpuv_cutoff = 200.0;
+  scase->global_hrrpuv_cutoff = 200.0;
+  scase->global_hrrpuv_cutoff_default = 200.0;
+  scase->smoke_albedo = 0.3;
+  scase->smoke_albedo_base = 0.3;
+  scase->xbar = 1.0;
+  scase->ybar = 1.0;
+  scase->zbar = 1.0;
+  scase->show_slice_in_obst = ONLY_IN_GAS;
+  scase->use_iblank = 1;
+  scase->visOtherVents = 1;
+  scase->visOtherVentsSAVE = 1;
+  scase->hvac_duct_color[0] = 63;
+  scase->hvac_duct_color[1] = 0;
+  scase->hvac_duct_color[2] = 15;
+  scase->hvac_node_color[0] = 63;
+  scase->hvac_node_color[1] = 0;
+  scase->hvac_node_color[2] = 15;
+  scase->nrgb2 = 8;
+  scase->pref = 101325.0;
+  scase->pamb = 0.0;
+  scase->tamb = 293.15;
+  scase->nrgb = NRGB;
+  scase->linewidth = 2.0;
+  scase->ventlinewidth = 2.0;
+  scase->obst_bounding_box[0] = 1.0;
+  scase->obst_bounding_box[2] = 1.0;
+  scase->obst_bounding_box[4] = 1.0;
+  scase->hvaccoll.hvacductvar_index = -1;
+  scase->hvaccoll.hvacnodevar_index = -1;
+  // Initialize default colors
+  scase->color_defs.block_shininess = 100.0;
+  scase->color_defs.mat_specular2=GetColorPtr(scase, mat_specular_orig);
+  scase->color_defs.mat_ambient2=GetColorPtr(scase, mat_ambient_orig);
+  scase->color_defs.ventcolor=GetColorPtr(scase, ventcolor_orig);
+  scase->color_defs.block_ambient2=GetColorPtr(scase, block_ambient_orig);
+  scase->color_defs.block_specular2=GetColorPtr(scase, block_specular_orig);
+
+  InitLabelsCollection(&scase->labelscoll);
+
+  InitObjectCollection(&scase->objectscoll);
+}
+
+/// @brief Create and initalize and a smokeview case (smv_case).
+/// @return An initialized smv_case.
+smv_case *CreateScase() {
+  smv_case *scase;
+  NewMemory((void **)&scase, sizeof(smv_case));
+  InitScase(scase);
+  return scase;
+}
+
+/// @brief Cleanup and free the memory of an smv_case.
+/// @param scase An smv_case created with CreateScase.
+void DestroyScase(smv_case *scase) {
+  FreeObjectCollection(&scase->objectscoll);
+  FreeCADGeomCollection(&scase->cadgeomcoll);
+  FreeLabelsCollection(&scase->labelscoll);
+}
+
 /* ------------------ ReadSMV ------------------------ */
 
 /// @brief Parse an SMV file.
 /// @param stream the file stream to parse.
 /// @return zero on sucess, non-zero on error
 int ReadSMV(bufferstreamdata *stream){
+  InitScase(&global_scase);
   ReadSMV_Init(&global_scase);
   ReadSMV_Parse(&global_scase, stream);
   ReadSMV_Configure();
@@ -14072,7 +14156,7 @@ int ReadIni2(const char *inifile, int localfile){
       fgets(buffer, 255, stream);
       sscanf(buffer, "%f %f %f", ventcolor_temp, ventcolor_temp + 1, ventcolor_temp + 2);
       ventcolor_temp[3] = 1.0;
-      ventcolor = GetColorPtr(&global_scase, ventcolor_temp);
+      global_scase.color_defs.ventcolor = GetColorPtr(&global_scase, ventcolor_temp);
       global_scase.updatefaces = 1;
       global_scase.updateindexcolors = 1;
       continue;
@@ -14220,14 +14304,14 @@ int ReadIni2(const char *inifile, int localfile){
       fgets(buffer, 255, stream);
       sscanf(buffer, "%f %f %f", blockcolor_temp, blockcolor_temp + 1, blockcolor_temp + 2);
       blockcolor_temp[3] = 1.0;
-      block_ambient2 = GetColorPtr(&global_scase, blockcolor_temp);
+      global_scase.color_defs.block_ambient2 = GetColorPtr(&global_scase, blockcolor_temp);
       global_scase.updatefaces = 1;
       global_scase.updateindexcolors = 1;
       continue;
     }
     if(MatchINI(buffer, "BLOCKSHININESS") == 1){
       fgets(buffer, 255, stream);
-      sscanf(buffer, "%f", &block_shininess);
+      sscanf(buffer, "%f", &global_scase.color_defs.block_shininess);
       global_scase.updatefaces = 1;
       global_scase.updateindexcolors = 1;
       continue;
@@ -14238,7 +14322,7 @@ int ReadIni2(const char *inifile, int localfile){
       fgets(buffer, 255, stream);
       sscanf(buffer, "%f %f %f", blockspec_temp, blockspec_temp + 1, blockspec_temp + 2);
       blockspec_temp[3] = 1.0;
-      block_specular2 = GetColorPtr(&global_scase, blockspec_temp);
+      global_scase.color_defs.block_specular2 = GetColorPtr(&global_scase, blockspec_temp);
       global_scase.updatefaces = 1;
       global_scase.updateindexcolors = 1;
       continue;
@@ -14815,7 +14899,7 @@ int ReadIni2(const char *inifile, int localfile){
       }
       if(MatchINI(buffer, "SMOKESKIP") == 1){
         int smokeskippm1_local;
-        
+
         if(fgets(buffer, 255, stream) == NULL)break;
         sscanf(buffer, "%i %i %i %i %i", &smokeskippm1_local, &smoke3d_skip, &smoke3d_skipx, &smoke3d_skipy, &smoke3d_skipz);
         if(smokeskippm1_local<0)smokeskippm1_local = 0;
@@ -16083,7 +16167,7 @@ void WriteIniLocal(FILE *fileout){
                     plot2d_size_factor, vis_slice_plot, slice_plot_bound_option,
                     slice_dxyz[0], slice_dxyz[1], slice_dxyz[2], average_plot2d_slice_region, show_plot2d_slice_position
                     );
-  
+
   for(i = global_scase.ntickinfo_smv; i < global_scase.ntickinfo; i++){
     float *begt;
     float *endt;
@@ -16409,11 +16493,11 @@ void WriteIni(int flag,char *filename){
   fprintf(fileout, "BACKGROUNDCOLOR\n");
   fprintf(fileout, " %f %f %f\n", backgroundbasecolor[0], backgroundbasecolor[1], backgroundbasecolor[2]);
   fprintf(fileout, "BLOCKCOLOR\n");
-  fprintf(fileout, " %f %f %f\n", block_ambient2[0], block_ambient2[1], block_ambient2[2]);
+  fprintf(fileout, " %f %f %f\n", global_scase.color_defs.block_ambient2[0], global_scase.color_defs.block_ambient2[1], global_scase.color_defs.block_ambient2[2]);
   fprintf(fileout, "BLOCKSHININESS\n");
-  fprintf(fileout, " %f\n", block_shininess);
+  fprintf(fileout, " %f\n", global_scase.color_defs.block_shininess);
   fprintf(fileout, "BLOCKSPECULAR\n");
-  fprintf(fileout, " %f %f %f\n", block_specular2[0], block_specular2[1], block_specular2[2]);
+  fprintf(fileout, " %f %f %f\n", global_scase.color_defs.block_specular2[0], global_scase.color_defs.block_specular2[1], global_scase.color_defs.block_specular2[2]);
   fprintf(fileout, "BOUNDCOLOR\n");
   fprintf(fileout, " %f %f %f\n", boundcolor[0], boundcolor[1], boundcolor[2]);
   fprintf(fileout, "COLORBAR\n");
@@ -16560,7 +16644,7 @@ void WriteIni(int flag,char *filename){
   fprintf(fileout, "TIMEBARCOLOR\n");
   fprintf(fileout, " %f %f %f\n", timebarcolor[0], timebarcolor[1], timebarcolor[2]);
   fprintf(fileout, "VENTCOLOR\n");
-  fprintf(fileout," %f %f %f\n",ventcolor[0],ventcolor[1],ventcolor[2]);
+  fprintf(fileout," %f %f %f\n",global_scase.color_defs.ventcolor[0],global_scase.color_defs.ventcolor[1],global_scase.color_defs.ventcolor[2]);
 
   fprintf(fileout, "\n   *** SIZES/OFFSETS ***\n\n");
 

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -339,6 +339,9 @@ EXTERNCPP void GetSliceColors(const float *t, int nt, unsigned char *it,
 EXTERNCPP int  GetZoneColor(float t, float tmin, float tmax, int nlevel);
 EXTERNCPP void InitCadColors(void);
 EXTERNCPP void InitRGB(void);
+EXTERNCPP void InitScase(smv_case *scase);
+EXTERNCPP smv_case * CreateScase();
+EXTERNCPP void DestroyScase(smv_case *scase);
 EXTERNCPP void MakeColorLabels(char colorlabels[12][11], float colorvalues[12], float tmin_arg, float tmax_arg, int nlevel);
 EXTERNCPP void UpdateAllBoundaryColors(int flag);
 EXTERNCPP void UpdateChopColors(void);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -1060,9 +1060,6 @@ SVEXTERN float tourcol_pathknots[3];
 SVEXTERN float tourcol_text[3];
 SVEXTERN float tourcol_avatar[3];
 #endif
-SVEXTERN float mat_ambient_orig[4];
-SVEXTERN float mat_specular_orig[4];
-SVEXTERN float SVDECL(*mat_ambient2,NULL), SVDECL(*mat_specular2,NULL);
 
 #ifdef INMAIN
 SVEXTERN GLfloat iso_specular[4]={0.7,0.7,0.7,1.0};
@@ -1071,11 +1068,6 @@ SVEXTERN GLfloat iso_specular[4];
 #endif
 SVEXTERN GLfloat SVDECL(iso_shininess, 50.0), SVDECL(glui_shininess, 50.0);
 
-SVEXTERN float block_ambient_orig[4];
-SVEXTERN float SVDECL(*block_ambient2,NULL);
-SVEXTERN float block_specular_orig[4];
-SVEXTERN float SVDECL(*block_specular2,NULL);
-SVEXTERN GLfloat SVDECL(block_shininess,100.0);
 
 #ifdef INMAIN
 SVEXTERN GLfloat light_position0[4]={1.0,1.0,1.0,0.0};
@@ -1626,8 +1618,6 @@ SVEXTERN int SVDECL(show_gslice_triangulation,0);
 SVEXTERN int SVDECL(show_gslice_normal,0),SVDECL(show_gslice_normal_keyboard,0);
 
 
-SVEXTERN float ventcolor_orig[4];
-SVEXTERN float SVDECL(*ventcolor,NULL);
 #ifdef INMAIN
 SVEXTERN float static_color[4]={0.0,1.0,0.0,1.0};
 SVEXTERN float sensorcolor[4]={1.0,1.0,0.0,1.0};
@@ -1719,138 +1709,7 @@ SVEXTERN int SVDECL(output_slicedata,0),SVDECL(output_patchdata,0);
 SVEXTERN f_units SVDECL(*unitclasses,NULL),SVDECL(*unitclasses_default,NULL),SVDECL(*unitclasses_ini,NULL);
 SVEXTERN int SVDECL(nunitclasses,0),SVDECL(nunitclasses_default,0),SVDECL(nunitclasses_ini,0);
 #ifdef INMAIN
-SVEXTERN smv_case global_scase = {
-                           .cadgeomcoll = {
-                                            .capacity=0,
-                                            .ncadgeom=0,
-                                            .cadgeominfo=NULL
-                                       },
-                           .csvcoll = {
-                                          .ncsvfileinfo=0,
-                                           .csvfileinfo=NULL
-                                       },
-                           .devicecoll = {
-                                           .ndeviceinfo=0,
-                                           .nvdeviceinfo=0,
-                                           .ndeviceinfo_exp=0,
-                                           .deviceinfo=NULL,
-                                           .vdeviceinfo=NULL,
-                                           .vdevices_sorted=NULL
-                                       },
-                           .device_texture_list_coll = {
-                                           .ndevice_texture_list=0,
-                                           .device_texture_list=NULL,
-                                           .device_texture_list_index=NULL
-                                       },
-                           .filelist_coll = {
-                                            .nini_filelist=0,
-                                            .ini_filelist=NULL,
-                                            .nfilelist_casename=0,
-                                            .filelist_casename=NULL,
-                                            .nfilelist_casedir=0,
-                                            .filelist_casedir=NULL
-                                       },
-                           .hrr_coll = {
-                                          .nhrrinfo=0,
-                                          .nhrrhcinfo=0,
-                                          .hrrinfo=NULL
-                                       },
-                           .meshescoll = {
-                                           .meshinfo=NULL,
-                                           .nmeshes=0,
-                                       },
-                           .obstcoll = {
-                                          .nobstinfo=0,
-                                          .obstinfo=NULL
-                                       },
-                           .propcoll = {
-                                          .npropinfo=0,
-                                          .propinfo=NULL
-                                       },
-                           .slicecoll = {
-                                          .nsliceinfo=0,
-                                          .sliceinfo=NULL,
-                                          .nmultisliceinfo=0,
-                                          .multisliceinfo=NULL,
-                                          .nvsliceinfo=0,
-                                          .vsliceinfo=NULL,
-                                          .nmultivsliceinfo=0,
-                                          .multivsliceinfo=NULL
-                                       },
-                           .smoke3dcoll = {
-                                         .nsmoke3dinfo=0,
-                                         .smoke3dinfo=NULL,
-                                         .smoke3dinfo_sorted=NULL,
-                                         .nsmoke3dtypes=0,
-                                         .smoke3d_other=0,
-                                         .smoke3dtypes=NULL
-                                       },
-                           .surfcoll = {
-                                           .nsurfinfo=0,
-                                           .surfinfo=NULL,
-                                           .nsurfids=0,
-                                           .surfids=NULL,
-                                           .nsorted_surfidlist=0,
-                                           .sorted_surfidlist=NULL,
-                                           .inv_sorted_surfidlist=NULL
-                                       },
-                           .terrain_texture_coll = {
-                                          .nterrain_textures=0,
-                                          .terrain_textures=NULL
-                                       },
-                           .texture_coll = {
-                                          .ntextureinfo=0,
-                                          .textureinfo=NULL
-                                       },
-                           .tourcoll = {
-                                        .ntourinfo = 0,
-                                        .tourinfo = NULL,
-                                        .tour_ntimes = 1000,
-                                        .tour_t = NULL,
-                                        .tour_t2 = NULL,
-                                        .tour_dist = NULL,
-                                        .tour_dist2 = NULL,
-                                        .tour_dist3 = NULL,
-                                        .tour_tstart = 0.0,
-                                        .tour_tstop = 100.0
-                                       },
-                           .fuel_hoc = -1.0,
-                           .fuel_hoc_default = -1.0,
-                           .have_cface_normals = CFACE_NORMALS_NO,
-                           .gvecphys = {0.0, 0.0, -9.8},
-                           .gvecunit = {0.0, 0.0, -1.0},
-                           .global_tbegin = 1.0,
-                           .global_tend = 0.0,
-                           .tload_begin = 0.0,
-                           .tload_end = 0.0,
-                           .load_hrrpuv_cutoff = 200.0,
-                           .global_hrrpuv_cutoff = 200.0,
-                           .global_hrrpuv_cutoff_default = 200.0,
-                           .smoke_albedo = 0.3,
-                           .smoke_albedo_base = 0.3,
-                           .xbar = 1.0,
-                           .ybar = 1.0,
-                           .zbar = 1.0,
-                           .show_slice_in_obst = ONLY_IN_GAS,
-                           .use_iblank = 1,
-                           .visOtherVents = 1,
-                           .visOtherVentsSAVE = 1,
-                           .hvac_duct_color = {63, 0, 15},
-                           .hvac_node_color = {63, 0, 15},
-                           .nrgb2 = 8,
-                           .pref = 101325.0,
-                           .pamb = 0.0,
-                           .tamb = 293.15,
-                           .nrgb = NRGB,
-                           .linewidth = 2.0,
-                           .ventlinewidth = 2.0,
-                           .obst_bounding_box = {1.0,0.0,1.0,0.0,1.0,0.0},
-                           .hvaccoll = {
-                              .hvacductvar_index= -1,
-                              .hvacnodevar_index= -1,
-                              0
-                            }
-                          };
+SVEXTERN smv_case global_scase = {0};
 parse_options parse_opts = {
     .smoke3d_only = 0,
     .setup_only = 0,

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -139,10 +139,10 @@ void InitMisc(void){
   thistime=0;
   lasttime=0;
 
-  block_ambient2[3] = 1.0;
-  block_specular2[3] = 1.0;
-  mat_ambient2[3] = 1.0;
-  mat_specular2[3] = 1.0;
+  global_scase.color_defs.block_ambient2[3] = 1.0;
+  global_scase.color_defs.block_specular2[3] = 1.0;
+  global_scase.color_defs.mat_ambient2[3] = 1.0;
+  global_scase.color_defs.mat_specular2[3] = 1.0;
 
   glui_curve_default.use_foreground_color = 1;
   glui_curve_default.color[0]           = 0;
@@ -1278,6 +1278,8 @@ void InitVars(void){
   int i;
   char *queue_list = NULL, *queue=NULL, *htmldir=NULL, *email=NULL;
 
+  InitScase(&global_scase);
+
 #ifdef pp_OSX_HIGHRES
   double_scale = 1;
 #endif
@@ -1383,8 +1385,6 @@ void InitVars(void){
   strcpy((char *)degC,"C");
   strcpy((char *)degF,"F");
 
-  InitLabelsCollection(&global_scase.labelscoll);
-
   {
     labeldata *gl;
 
@@ -1417,35 +1417,6 @@ void InitVars(void){
   }
 
   strcpy(startup_lang_code,"en");
-  mat_specular_orig[0]=0.5f;
-  mat_specular_orig[1]=0.5f;
-  mat_specular_orig[2]=0.2f;
-  mat_specular_orig[3]=1.0f;
-  mat_specular2=GetColorPtr(&global_scase, mat_specular_orig);
-
-  mat_ambient_orig[0] = 0.5f;
-  mat_ambient_orig[1] = 0.5f;
-  mat_ambient_orig[2] = 0.2f;
-  mat_ambient_orig[3] = 1.0f;
-  mat_ambient2=GetColorPtr(&global_scase, mat_ambient_orig);
-
-  ventcolor_orig[0]=1.0;
-  ventcolor_orig[1]=0.0;
-  ventcolor_orig[2]=1.0;
-  ventcolor_orig[3]=1.0;
-  ventcolor=GetColorPtr(&global_scase, ventcolor_orig);
-
-  block_ambient_orig[0] = 1.0;
-  block_ambient_orig[1] = 0.8;
-  block_ambient_orig[2] = 0.4;
-  block_ambient_orig[3] = 1.0;
-  block_ambient2=GetColorPtr(&global_scase, block_ambient_orig);
-
-  block_specular_orig[0] = 0.0;
-  block_specular_orig[1] = 0.0;
-  block_specular_orig[2] = 0.0;
-  block_specular_orig[3] = 1.0;
-  block_specular2=GetColorPtr(&global_scase, block_specular_orig);
 
   for(i=0;i<256;i++){
     boundarylevels256[i]=(float)i/255.0;
@@ -1580,7 +1551,6 @@ void InitVars(void){
   strcpy(global_scase.surfacedefaultlabel,"");
   if(streak_index>=0)float_streak5value=streak_rvalue[streak_index];
 
-  InitObjectCollection(&global_scase.objectscoll);
 
   GetTitle("Smokeview ", release_title);
   GetTitle("Smokeview ", plot3d_title);

--- a/Tests/sort_surfs.c
+++ b/Tests/sort_surfs.c
@@ -22,7 +22,7 @@
 #include <assert.h>
 
 void UpdateSortedSurfIdList(surf_collection *surfcoll);
-void InitSurface(surfdata *surf);
+void InitSurface(surfdata *surf, float *color);
 
 int show_help;
 int hash_option;
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
   NewMemory((void **)&surfcoll.surfinfo, N_SURFS * sizeof(surfdata));
   for(int i = 0; i < N_SURFS; i++) {
     surfdata *sd = surfcoll.surfinfo + i;
-    InitSurface(sd);
+    InitSurface(sd, block_ambient_orig);
     sd->surfacelabel = surf_names[i];
   }
   UpdateSortedSurfIdList(&surfcoll);


### PR DESCRIPTION
Some default colours are hardcoded, but only initilised in the `startup` routine. This commit initialises these values at compile time. This means these values do not rely on startup functions being called in a certain order.

This also moves some color data into smv_case.