### PR TITLE
remove references to __glutFont

### DIFF
--- a/Source/smokeview/output.c
+++ b/Source/smokeview/output.c
@@ -185,29 +185,6 @@ void Output3Text(float *color, float x, float y, float z, char *string){
   }
 }
 
-/* ------------------ GetCharAdvance ------------------------ */
-
-float GetCharAdvance(GLUTbitmapFont font, int c){
-  const BitmapCharRec *ch;
-  BitmapFontPtr fontinfo;
-
-#if defined(_WIN32)
-  extern void *__glutFont(void *font);
-  fontinfo = (BitmapFontPtr)__glutFont(font);
-#else
-  fontinfo = (BitmapFontPtr)font;
-#endif
-
-  if(c < fontinfo->first ||
-     c >= fontinfo->first + fontinfo->num_chars)
-    return 0.0;
-  ch = fontinfo->ch[c - fontinfo->first];
-  if(ch){
-    return ch->advance;
-  }
-  return 0.0;
-}
-
 /* ------------------ GetStringLength ------------------------ */
 
 float GetStringLength(char *string){
@@ -220,7 +197,7 @@ float GetStringLength(char *string){
     char *c;
 
     c = string + i;
-    length += GetCharAdvance(font_ptr, *c);
+    length += glutBitmapWidth(font_ptr, *c);
   }
   return length;
 }
@@ -268,55 +245,6 @@ int GetStringWidth(char *string){
   return length;
 }
 
-/* ------------------ glutBitmapCharacterShiftLeft ------------------------ */
-
-void glutBitmapCharacterShiftLeft(GLUTbitmapFont font, int c, float advance){
-  const BitmapCharRec *ch;
-  BitmapFontPtr fontinfo;
-  GLint swapbytes, lsbfirst, rowlength;
-  GLint skiprows, skippixels, alignment;
-
-#if defined(_WIN32)
-  extern void *__glutFont(void *font);
-  fontinfo = (BitmapFontPtr)__glutFont(font);
-#else
-  fontinfo = (BitmapFontPtr)font;
-#endif
-
-  if(c < fontinfo->first ||
-     c >= fontinfo->first + fontinfo->num_chars)
-    return;
-  ch = fontinfo->ch[c - fontinfo->first];
-  if(ch){
-    /* Save current modes. */
-    glGetIntegerv(GL_UNPACK_SWAP_BYTES, &swapbytes);
-    glGetIntegerv(GL_UNPACK_LSB_FIRST, &lsbfirst);
-    glGetIntegerv(GL_UNPACK_ROW_LENGTH, &rowlength);
-    glGetIntegerv(GL_UNPACK_SKIP_ROWS, &skiprows);
-    glGetIntegerv(GL_UNPACK_SKIP_PIXELS, &skippixels);
-    glGetIntegerv(GL_UNPACK_ALIGNMENT, &alignment);
-    /* Little endian machines (DEC Alpha for example) could
-       benefit from setting GL_UNPACK_LSB_FIRST to GL_TRUE
-       instead of GL_FALSE, but this would require changing the
-       generated bitmaps too. */
-    glPixelStorei(GL_UNPACK_SWAP_BYTES, GL_FALSE);
-    glPixelStorei(GL_UNPACK_LSB_FIRST, GL_FALSE);
-    glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
-    glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
-    glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-    glBitmap(ch->width, ch->height, ch->xorig, ch->yorig,
-             advance, 0, ch->bitmap);
-    /* Restore saved modes. */
-    glPixelStorei(GL_UNPACK_SWAP_BYTES, swapbytes);
-    glPixelStorei(GL_UNPACK_LSB_FIRST, lsbfirst);
-    glPixelStorei(GL_UNPACK_ROW_LENGTH, rowlength);
-    glPixelStorei(GL_UNPACK_SKIP_ROWS, skiprows);
-    glPixelStorei(GL_UNPACK_SKIP_PIXELS, skippixels);
-    glPixelStorei(GL_UNPACK_ALIGNMENT, alignment);
-    }
-  }
-
 /* ------------------ Output3TextRight ------------------------ */
 
 void Output3TextRight(float *color, float x, float y, float z, char *string, float pad_length){
@@ -336,13 +264,13 @@ void Output3TextRight(float *color, float x, float y, float z, char *string, flo
 
     blank = ' ';
     glRasterPos3f(x, y, z);
-    blank_advance = GetCharAdvance(font_ptr, blank);
+    blank_advance = glutBitmapWidth(font_ptr, blank);
     int count;
 
     count = pad_length / blank_advance + 1;
     if(pad_length > 0.0){
       for(i = 0; i < count; i++){
-        glutBitmapCharacterShiftLeft(font_ptr, blank, -blank_advance);
+        glBitmap(0,0,0.0,0.0,-blank_advance,0.0,NULL);
       }
     }
     for(i = 0; i<strlen(string); i++){


### PR DESCRIPTION
`__glutFont` is a private function of GLUT and not exposed as part of the API. This causes issues when not building with the vendored GLUT code.

This change instead uses only the functions exposed via the GLUT and GL APIs.