### PR TITLE
runbatch: add missing include

### DIFF
--- a/Source/runbatch/main.c
+++ b/Source/runbatch/main.c
@@ -1,3 +1,4 @@
+#include <io.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
On Windows, `_access` needs `io.h` (https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/access-waccess?view=msvc-170)