### PR TITLE
update smv_case and move a few functions

### DIFF
--- a/Source/shared/colorbars.c
+++ b/Source/shared/colorbars.c
@@ -9,6 +9,7 @@
 #include "dmalloc.h"
 #include "colorbars.h"
 #include "datadefs.h"
+#include "shared_structures.h"
 
 #include "file_util.h"
 #include "string_util.h"
@@ -757,4 +758,43 @@ EXTERNCPP void InitDefaultColorbars(colorbar_collection *colorbars, int nini,
   memcpy(colorbarcopy, colorbars->colorbarinfo,
          colorbars->ncolorbars * sizeof(colorbardata));
   *colorbarcopyinfoptr = colorbarcopy;
+}
+
+
+/* ------------------ GetColorPtr ------------------------ */
+
+float *GetColorPtr(smv_case *scase, float *color){
+  colordata *colorptr,*oldlastcolor,*lastcolor;
+
+  if(scase->firstcolor==NULL){
+    NewMemory((void *)&scase->firstcolor,sizeof(colordata));
+    memcpy(scase->firstcolor->color,      color, 4*sizeof(float));
+    memcpy(scase->firstcolor->full_color, color, 4*sizeof(float));
+    scase->firstcolor->bw_color[0] = TOBW(color);
+    scase->firstcolor->bw_color[1] = scase->firstcolor->bw_color[0];
+    scase->firstcolor->bw_color[2] = scase->firstcolor->bw_color[0];
+    scase->firstcolor->bw_color[3] = color[3];
+    scase->firstcolor->nextcolor=NULL;
+    return scase->firstcolor->color;
+  }
+  oldlastcolor = scase->firstcolor;
+  for(colorptr = scase->firstcolor; colorptr!=NULL; colorptr = colorptr->nextcolor){
+    oldlastcolor=colorptr;
+    if(ABS(colorptr->color[0]-color[0])>0.0001)continue;
+    if(ABS(colorptr->color[1]-color[1])>0.0001)continue;
+    if(ABS(colorptr->color[2]-color[2])>0.0001)continue;
+    if(ABS(colorptr->color[3]-color[3])>0.0001)continue;
+    return colorptr->color;
+  }
+  lastcolor=NULL;
+  NewMemory((void *)&lastcolor,sizeof(colordata));
+  oldlastcolor->nextcolor=lastcolor;
+  memcpy(lastcolor->color,      color, 4*sizeof(float));
+  memcpy(lastcolor->full_color, color, 4*sizeof(float));
+  lastcolor->bw_color[0] = TOBW(color);
+  lastcolor->bw_color[1] = lastcolor->bw_color[0];
+  lastcolor->bw_color[2] = lastcolor->bw_color[0];
+  lastcolor->bw_color[3] = color[3];
+  lastcolor->nextcolor=NULL;
+  return lastcolor->color;
 }

--- a/Source/shared/datadefs.h
+++ b/Source/shared/datadefs.h
@@ -264,4 +264,6 @@
 
 #define PI           3.14159265359f
 
+#define TOBW(col) ( 0.299*(col)[0] + 0.587*(col)[1] + 0.114*(col)[2])
+
 #endif

--- a/Source/shared/readgeom.c
+++ b/Source/shared/readgeom.c
@@ -1112,3 +1112,28 @@ void InitCircle(unsigned int npoints, circdata *circinfo){
   circinfo->ycirc = ycirc;
   circinfo->ncirc = npoints;
 }
+
+/* ------------------ Normalize ------------------------ */
+
+void Normalize(float *xyz, int n){
+  float norm,norm2;
+  int i;
+
+  norm2 = 0.0;
+
+  for(i=0;i<n;i++){
+    norm2 += xyz[i]*xyz[i];
+  }
+  norm = sqrt(norm2);
+  if(norm<0.00001){
+    for(i=0;i<n-1;i++){
+      xyz[i]=0.0;
+    }
+    xyz[n-1]=1.0;
+  }
+  else{
+    for(i=0;i<n;i++){
+      xyz[i]/=norm;
+    }
+  }
+}

--- a/Source/shared/readlabel.c
+++ b/Source/shared/readlabel.c
@@ -11,6 +11,7 @@
 #include "readlabel.h"
 #include "shared_structures.h"
 #include "string_util.h"
+#include "datadefs.h"
 
 /* ------------------ LabelGet ------------------------ */
 

--- a/Source/shared/readlabel.h
+++ b/Source/shared/readlabel.h
@@ -31,4 +31,5 @@ static inline int FileExistsCaseDir(smv_case *scase, char *filename) {
                     scase->filelist_coll.filelist_casedir,
                     scase->filelist_coll.nfilelist_casedir);
 }
+
 #endif

--- a/Source/shared/readobject.c
+++ b/Source/shared/readobject.c
@@ -1681,3 +1681,38 @@ void UpdatePartClassDepend(partclassdata *partclassi){
     partclassi->vars_dep_index[nvar-1]= GetObjectFrameTokenLoc("B",obj_frame);
   }
 }
+
+/* ----------------------- GetNDevices ----------------------------- */
+#define BUFFER_LEN 255
+int GetNDevices(char *file){
+  FILE *stream;
+  char buffer[BUFFER_LEN], *comma;
+  int buffer_len = BUFFER_LEN, nd = 0;
+
+  if(file == NULL) return 0;
+  stream = fopen(file, "r");
+  if(stream == NULL) return 0;
+  fgets(buffer, buffer_len, stream);
+  comma = strchr(buffer, ',');
+  if(comma != NULL) *comma = 0;
+  TrimBack(buffer);
+  if(strcmp(buffer, "//HEADER") != 0){
+    fclose(stream);
+    return 0;
+  }
+
+  while(!feof(stream)){
+    fgets(buffer, buffer_len, stream);
+    comma = strchr(buffer, ',');
+    if(comma != NULL) *comma = 0;
+    TrimBack(buffer);
+    if(strcmp(buffer, "//DATA") == 0){
+      break;
+    }
+    if(strcmp(buffer, "DEVICE") == 0){
+      nd++;
+    }
+  }
+  fclose(stream);
+  return nd;
+}

--- a/Source/shared/readtour.c
+++ b/Source/shared/readtour.c
@@ -194,28 +194,6 @@ void GetTourXYZView(float time, float *times, float *vals, int n, float *val3) {
   val3[2] = (1.0 - factor) * v1[2] + factor * v2[2];
 }
 
- /* ------------------ SetTourXYZView ------------------------ */
-
-void SetTourXYZView(float t, tourdata *touri) {
-  keyframe *this_key, *first_key, *last_key;
-
-  first_key = touri->first_frame.next;
-  last_key = touri->last_frame.prev;
-  if(t < first_key->time) {
-    memcpy(touri->xyz_smv, first_key->xyz_smv, 3 * sizeof(float));
-    memcpy(touri->view_smv, first_key->view_smv, 3 * sizeof(float));
-    return;
-  }
-  if(t >= last_key->time) {
-    memcpy(touri->xyz_smv, last_key->xyz_smv, 3 * sizeof(float));
-    memcpy(touri->view_smv, last_key->view_smv, 3 * sizeof(float));
-    return;
-  }
-  this_key = GetKeyFrame(touri, t);
-  GetKeyXYZ(t, this_key, touri->xyz_smv);
-  GetKeyView(t, this_key, touri->view_smv);
-}
-
 /* ------------------ CopyFrame ------------------------ */
 
 keyframe *CopyFrame(const keyframe *framei) {

--- a/Source/shared/shared_structures.h
+++ b/Source/shared/shared_structures.h
@@ -1964,6 +1964,9 @@ typedef struct {
   int have_animate_blockages;
   int have_removable_obsts;
 
+  texturedata *sky_texture;
+  int nsky_texture;
+
   slicedata **sliceinfoptrs;
   int *subslice_menuindex;
   int *subvslice_menuindex;

--- a/Source/shared/shared_structures.h
+++ b/Source/shared/shared_structures.h
@@ -1963,6 +1963,7 @@ typedef struct {
 
   int have_animate_blockages;
   int have_removable_obsts;
+  int have_mesh_nabors;
 
   texturedata *sky_texture;
   int nsky_texture;

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -5236,42 +5236,6 @@ char *GetDeviceLabel(char *buffer){
   return label_present;
 }
 
-
-/* ----------------------- GetNDevices ----------------------------- */
-#define BUFFER_LEN 255
-int GetNDevices(char *file){
-  FILE *stream;
-  char buffer[BUFFER_LEN], *comma;
-  int buffer_len = BUFFER_LEN, nd = 0;
-
-  if(file == NULL) return 0;
-  stream = fopen(file, "r");
-  if(stream == NULL) return 0;
-  fgets(buffer, buffer_len, stream);
-  comma = strchr(buffer, ',');
-  if(comma != NULL) *comma = 0;
-  TrimBack(buffer);
-  if(strcmp(buffer, "//HEADER") != 0){
-    fclose(stream);
-    return 0;
-  }
-
-  while(!feof(stream)){
-    fgets(buffer, buffer_len, stream);
-    comma = strchr(buffer, ',');
-    if(comma != NULL) *comma = 0;
-    TrimBack(buffer);
-    if(strcmp(buffer, "//DATA") == 0){
-      break;
-    }
-    if(strcmp(buffer, "DEVICE") == 0){
-      nd++;
-    }
-  }
-  fclose(stream);
-  return nd;
-}
-
 void RewindDeviceFile(FILE *stream){
 #define BUFFER_LEN 255
   char buffer[BUFFER_LEN], *comma;

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -6221,28 +6221,3 @@ void InitDevicePlane(devicedata *devicei){
   }
 
 }
-
-/* ------------------ Normalize ------------------------ */
-
-void Normalize(float *xyz, int n){
-  float norm,norm2;
-  int i;
-
-  norm2 = 0.0;
-
-  for(i=0;i<n;i++){
-    norm2 += xyz[i]*xyz[i];
-  }
-  norm = sqrt(norm2);
-  if(norm<0.00001){
-    for(i=0;i<n-1;i++){
-      xyz[i]=0.0;
-    }
-    xyz[n-1]=1.0;
-  }
-  else{
-    for(i=0;i<n;i++){
-      xyz[i]/=norm;
-    }
-  }
-}

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -1611,11 +1611,11 @@ void DrawHalfSphere(void){
   int use_sky;
 
   use_sky = 0;
-  if(nsky_texture > 0 && sky_texture != NULL && sky_texture->loaded == 1 && sky_texture->display == 1&& visSkySpheretexture==1)use_sky = 1;
+  if(global_scase.nsky_texture > 0 && global_scase.sky_texture != NULL && global_scase.sky_texture->loaded == 1 && global_scase.sky_texture->display == 1&& visSkySpheretexture==1)use_sky = 1;
   if(use_sky == 1){
     glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
     glEnable(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, sky_texture->name);
+    glBindTexture(GL_TEXTURE_2D, global_scase.sky_texture->name);
   }
 
   glBegin(GL_QUADS);

--- a/Source/smokeview/IOtour.c
+++ b/Source/smokeview/IOtour.c
@@ -452,6 +452,28 @@ void GetKeyXYZ(float t, keyframe *this_key, float *xyz){
   }
 }
 
+/* ------------------ SetTourXYZView ------------------------ */
+
+void SetTourXYZView(float t, tourdata *touri) {
+  keyframe *this_key, *first_key, *last_key;
+
+  first_key = touri->first_frame.next;
+  last_key = touri->last_frame.prev;
+  if(t < first_key->time) {
+    memcpy(touri->xyz_smv, first_key->xyz_smv, 3 * sizeof(float));
+    memcpy(touri->view_smv, first_key->view_smv, 3 * sizeof(float));
+    return;
+  }
+  if(t >= last_key->time) {
+    memcpy(touri->xyz_smv, last_key->xyz_smv, 3 * sizeof(float));
+    memcpy(touri->view_smv, last_key->view_smv, 3 * sizeof(float));
+    return;
+  }
+  this_key = GetKeyFrame(touri, t);
+  GetKeyXYZ(t, this_key, touri->xyz_smv);
+  GetKeyView(t, this_key, touri->view_smv);
+}
+
 /* ------------------ GetTourTimeBounds ------------------------ */
 
 void GetTourTimeBounds(tourdata *touri, float *tour_tstart, float *tour_tstop){

--- a/Source/smokeview/IOvolsmoke.c
+++ b/Source/smokeview/IOvolsmoke.c
@@ -1057,7 +1057,7 @@ void *InitNabors(void *arg){
   int i;
 
   INIT_PRINT_TIMER(timer_init_nabors);
-  if(have_mesh_nabors == 0){
+  if(global_scase.have_mesh_nabors == 0){
     for(i = 0;i < global_scase.meshescoll.nmeshes;i++){
       meshdata *meshi;
       int j;

--- a/Source/smokeview/getdatacolors.c
+++ b/Source/smokeview/getdatacolors.c
@@ -1758,45 +1758,6 @@ void GetRGB(unsigned int val, unsigned char *rr, unsigned char *gg, unsigned cha
   *rr=r; *gg=g; *bb=b;
 }
 
-
-/* ------------------ GetColorPtr ------------------------ */
-
-float *GetColorPtr(smv_case *scase, float *color){
-  colordata *colorptr,*oldlastcolor,*lastcolor;
-
-  if(scase->firstcolor==NULL){
-    NewMemory((void *)&scase->firstcolor,sizeof(colordata));
-    memcpy(scase->firstcolor->color,      color, 4*sizeof(float));
-    memcpy(scase->firstcolor->full_color, color, 4*sizeof(float));
-    scase->firstcolor->bw_color[0] = TOBW(color);
-    scase->firstcolor->bw_color[1] = scase->firstcolor->bw_color[0];
-    scase->firstcolor->bw_color[2] = scase->firstcolor->bw_color[0];
-    scase->firstcolor->bw_color[3] = color[3];
-    scase->firstcolor->nextcolor=NULL;
-    return scase->firstcolor->color;
-  }
-  oldlastcolor = scase->firstcolor;
-  for(colorptr = scase->firstcolor; colorptr!=NULL; colorptr = colorptr->nextcolor){
-    oldlastcolor=colorptr;
-    if(ABS(colorptr->color[0]-color[0])>0.0001)continue;
-    if(ABS(colorptr->color[1]-color[1])>0.0001)continue;
-    if(ABS(colorptr->color[2]-color[2])>0.0001)continue;
-    if(ABS(colorptr->color[3]-color[3])>0.0001)continue;
-    return colorptr->color;
-  }
-  lastcolor=NULL;
-  NewMemory((void *)&lastcolor,sizeof(colordata));
-  oldlastcolor->nextcolor=lastcolor;
-  memcpy(lastcolor->color,      color, 4*sizeof(float));
-  memcpy(lastcolor->full_color, color, 4*sizeof(float));
-  lastcolor->bw_color[0] = TOBW(color);
-  lastcolor->bw_color[1] = lastcolor->bw_color[0];
-  lastcolor->bw_color[2] = lastcolor->bw_color[0];
-  lastcolor->bw_color[3] = color[3];
-  lastcolor->nextcolor=NULL;
-  return lastcolor->color;
-}
-
 /* ------------------ GetColorTranPtr ------------------------ */
 
 float *GetColorTranPtr(float *color, float transparency){

--- a/Source/smokeview/glui_display.cpp
+++ b/Source/smokeview/glui_display.cpp
@@ -1223,7 +1223,7 @@ extern "C" void GLUIDisplaySetup(int main_window){
   CHECKBOX_visSkysphere = glui_labels->add_checkbox_to_panel(PANEL_sphere, _("show"), &visSkysphere, SKY_SPHERE, GLUISkyCB);
   CHECKBOX_visSkyground = glui_labels->add_checkbox_to_panel(PANEL_sphere, _("show ground"), &visSkyground, SKY_SPHERE, GLUISkyCB);
   SPINNER_sky_diam = glui_labels->add_spinner_to_panel(PANEL_sphere, _("diameter"), GLUI_SPINNER_FLOAT, &sky_diam, SKY_BOX, GLUISkyCB);
-  if(sky_texture != NULL){
+  if(global_scase.sky_texture != NULL){
     glui_labels->add_checkbox_to_panel(PANEL_sphere, _("show texture"), &visSkySpheretexture, SKY_SPHERE, GLUISkyCB);
   }
 

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -4081,7 +4081,7 @@ surfdata *GetSurface(smv_case *scase, const char *label){
     surfi = scase->surfcoll.surfinfo + i;
     if(strcmp(surfi->surfacelabel, label) == 0)return surfi;
   }
-  return global_scase.surfacedefault;
+  return scase->surfacedefault;
 }
 
 /* ------------------ InitObst ------------------------ */

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -1216,6 +1216,10 @@ ventdata *GetCloseVent(meshdata *ventmesh, int ivent){
 /// @param file The path to the *.smv file.
 void UpdateSMVDynamic(char *file){
   INIT_PRINT_TIMER(smv_timer1);
+  // As we are going to re-read the smv file and update some values we need to
+  // set these two flags to ensure the GUI updates itself appropriately.
+  updatefacelists=1;
+  updatemenu=1;
   ReadSMVDynamic(&global_scase, file);
   PRINT_TIMER(smv_timer1, "ReadSMVDynamic");
   INIT_PRINT_TIMER(smv_timer2);
@@ -1240,8 +1244,6 @@ void ReadSMVDynamic(smv_case *scase, char *file){
 
   nplot3dinfo_old=scase->nplot3dinfo;
 
-  updatefacelists=1;
-  updatemenu=1;
   if(scase->nplot3dinfo>0){
     int n;
 

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -55,6 +55,14 @@
 
 int GetNDevices(char *file);
 
+parse_options parse_opts = {
+  .smoke3d_only = 0,
+  .setup_only = 0,
+  .fast_startup = 1,
+  .lookfor_compressed_files = 0,
+  .handle_slice_files = 1
+};
+
 /* ------------------ GetHrrCsvCol ------------------------ */
 
 int GetHrrCsvCol(smv_case *scase, char *label){

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -6875,14 +6875,6 @@ int ReadSMV_Init(smv_case *scase){
 #ifdef pp_ISOFRAME
   use_isosurface_threads = 0;
 #endif
-//** initialize multi-threading
-  if(runscript == 1){
-    use_checkfiles_threads  = 0;
-    use_ffmpeg_threads      = 0;
-    use_readallgeom_threads = 0;
-    use_isosurface_threads  = 0;
-    use_meshnabors_threads  = 0;
-  }
 
   START_TIMER(scase->getfilelist_time);
   MakeFileLists(scase);
@@ -11829,6 +11821,14 @@ void DestroyScase(smv_case *scase) {
 /// @return zero on sucess, non-zero on error
 int ReadSMV(bufferstreamdata *stream){
   InitScase(&global_scase);
+  //** initialize multi-threading
+  if(runscript == 1){
+    use_checkfiles_threads  = 0;
+    use_ffmpeg_threads      = 0;
+    use_readallgeom_threads = 0;
+    use_isosurface_threads  = 0;
+    use_meshnabors_threads  = 0;
+  }
   ReadSMV_Init(&global_scase);
   ReadSMV_Parse(&global_scase, stream);
   ReadSMV_Configure();

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -2699,14 +2699,14 @@ void InitTextures0(void){
 
   // define sky texture
 
-  if(nsky_texture > 0){
+  if(global_scase.nsky_texture > 0){
     texturedata *tt;
     unsigned char *floortex=NULL;
     int texwid, texht;
 
     int is_transparent;
 
-    tt                 = sky_texture;
+    tt                 = global_scase.sky_texture;
     tt->loaded         = 0;
     tt->used           = 0;
     tt->display        = 0;
@@ -7229,15 +7229,15 @@ void GetSkyBoxTextures(void){
 
 void GetSkyImageTexture(void){
   char buffer[256];
-  
+
   strcpy(buffer, global_scase.fdsprefix);
   strcat(buffer, "_sky.jpg");
-  if(sky_texture != NULL || FileExistsOrig(buffer) == 0)return;
-  
-  nsky_texture = 1;
-  NewMemory((void **)&sky_texture, nsky_texture * sizeof(texturedata));
-  NewMemory((void **)&sky_texture->file, (strlen(buffer) + 1) * sizeof(char));
-  strcpy(sky_texture->file, buffer);
+  if(global_scase.sky_texture != NULL || FileExistsOrig(buffer) == 0)return;
+
+  global_scase.nsky_texture = 1;
+  NewMemory((void **)&global_scase.sky_texture, global_scase.nsky_texture * sizeof(texturedata));
+  NewMemory((void **)&global_scase.sky_texture->file, (strlen(buffer) + 1) * sizeof(char));
+  strcpy(global_scase.sky_texture->file, buffer);
 }
 
 /* ------------------ ReadSMV_Parse ------------------------ */
@@ -7536,19 +7536,19 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
       char *buff2;
       int len_buffer;
 
-      if(sky_texture != NULL){
-        FREEMEMORY(sky_texture->file);
-        FREEMEMORY(sky_texture);
+      if(scase->sky_texture != NULL){
+        FREEMEMORY(scase->sky_texture->file);
+        FREEMEMORY(scase->sky_texture);
       }
-      nsky_texture = 1;
-      NewMemory((void **)&sky_texture, nsky_texture * sizeof(texturedata));
+      scase->nsky_texture = 1;
+      NewMemory((void **)&scase->sky_texture, scase->nsky_texture * sizeof(texturedata));
       FGETS(buffer, 255, stream);
       buff2 = TrimFrontBack(buffer);
       len_buffer = strlen(buff2);
-      sky_texture->file = NULL;
+      scase->sky_texture->file = NULL;
       if(len_buffer > 0 && strcmp(buff2, "null") != 0){
-         NewMemory((void **)&sky_texture->file, (len_buffer + 1) * sizeof(char));
-         strcpy(sky_texture->file, buff2);
+         NewMemory((void **)&scase->sky_texture->file, (len_buffer + 1) * sizeof(char));
+         strcpy(scase->sky_texture->file, buff2);
       }
       continue;
     }

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -9139,7 +9139,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
         FGETS(buffer,255,stream);
         sscanf(buffer,"%i %i %i %i %i %i %i %i %i",&ibartemp,&jbartemp,&kbartemp,
           mesh_nabors, mesh_nabors+1, mesh_nabors+2, mesh_nabors+3, mesh_nabors+4, mesh_nabors+5);
-          if(mesh_nabors[5]>=-1)have_mesh_nabors = 1;
+          if(mesh_nabors[5]>=-1)scase->have_mesh_nabors = 1;
       }
       if(ibartemp<1)ibartemp=1;
       if(jbartemp<1)jbartemp=1;
@@ -9191,7 +9191,7 @@ int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream){
         meshi->n_jmap = 0;
         meshi->kmap = kmap;
         meshi->n_kmap = 0;
-        if(have_mesh_nabors == 1){
+        if(scase->have_mesh_nabors == 1){
           for(i = 0; i < 6; i++){
             if(mesh_nabors[i] >= 1 && mesh_nabors[i] <= scase->meshescoll.nmeshes){
               meshi->nabors[i] = scase->meshescoll.meshinfo + mesh_nabors[i]-1;

--- a/Source/smokeview/smokeviewdefs.h
+++ b/Source/smokeview/smokeviewdefs.h
@@ -250,8 +250,6 @@ EXTERNCPP void _Sniff_Errors(const char *whereat, const char *file, int line);
 #define STOP_TICKS(a) a = glutGet(GLUT_ELAPSED_TIME) - a
 #endif
 
-#define TOBW(col) ( 0.299*(col)[0] + 0.587*(col)[1] + 0.114*(col)[2])
-
 #define TMAX 1000000000.0
 
 #define PARTFILE_LOADALL   -11

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -42,7 +42,6 @@ SVEXTERN threaderdata SVDECL(*sliceparms_threads, NULL);
 //***meshnabors
 SVEXTERN int SVDECL(n_meshnabors_threads, 1), SVDECL(use_meshnabors_threads, 1);
 SVEXTERN threaderdata SVDECL(*meshnabors_threads, NULL);
-SVEXTERN int SVDECL(have_mesh_nabors, 0);
 
 //***checkfiles
 SVEXTERN int SVDECL(n_checkfiles_threads, 1), SVDECL(use_checkfiles_threads, 1);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -1990,8 +1990,6 @@ SVEXTERN texturedata SVDECL(*textureinfo,NULL), SVDECL(*terrain_textures,NULL);
 SVEXTERN int SVDECL(visSkysphere, 0), SVDECL(visSkybox, 1), SVDECL(visSkySpheretexture, 1);
 SVEXTERN float box_sky_corners[8][3];
 
-SVEXTERN texturedata SVDECL(*sky_texture, NULL);
-SVEXTERN int SVDECL(nsky_texture, 0);
 SVEXTERN float SVDECL(sky_diam, 4.0);
 SVEXTERN int SVDECL(visSkyboxoutline, 0);
 SVEXTERN int SVDECL(visSkyground, 1);

--- a/Source/smokeview/smokeviewvars.h
+++ b/Source/smokeview/smokeviewvars.h
@@ -1709,17 +1709,10 @@ SVEXTERN f_units SVDECL(*unitclasses,NULL),SVDECL(*unitclasses_default,NULL),SVD
 SVEXTERN int SVDECL(nunitclasses,0),SVDECL(nunitclasses_default,0),SVDECL(nunitclasses_ini,0);
 #ifdef INMAIN
 SVEXTERN smv_case global_scase = {0};
-parse_options parse_opts = {
-    .smoke3d_only = 0,
-    .setup_only = 0,
-    .fast_startup = 1,
-    .lookfor_compressed_files = 0,
-    .handle_slice_files = 1
-};
 #else
 SVEXTERN smv_case global_scase;
-SVEXTERN parse_options parse_opts;
 #endif
+extern CCC parse_options parse_opts;
 SVEXTERN meshdata SVDECL(*current_mesh,NULL), SVDECL(*mesh_save,NULL);
 SVEXTERN meshdata SVDECL(*mesh_last,NULL), SVDECL(*loaded_isomesh,NULL);
 SVEXTERN float SVDECL(devicenorm_length,0.1);


### PR DESCRIPTION
This PR does two things:

1. This adds `have_mesh_nabors` and `sky_texture` to shared/ so they can be used without GLUT.
2. Moves a few functions into shared/ and reorders a few lines so that parsing can be moved to shared/.

The only remaining task to be able to parse SMV files without GLUT is to split `readsmv.c` in two. This has been done [here](https://github.com/JakeOShannessy/smv/tree/create-readsmvfile) and I'll propose that as a separate PR.