### PR TITLE
Move path definitions to functions

### DIFF
--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -53,7 +53,7 @@ csrc = callbacks.c camera.c color2rgb.c readimage.c readgeom.c readobject.c read
        IOwui.c IOzone.c IOframe.c isobox.c main.c md5.c menus.c output.c readsmvfile.c readsmv.c renderhtml.c \
        renderimage.c scontour2d.c sha1.c sha256.c shaders.c showscene.c skybox.c smokestream.c         \
        smokeview.c smv_geometry.c startup.c stdio_buffer.c stdio_m.c string_util.c threader.c  \
-       translate.c unit.c update.c viewports.c colortable.c command_args.c
+       translate.c unit.c update.c viewports.c colortable.c command_args.c paths.c
 
 cppsrc = glui_bounds.cpp  glui_clip.cpp glui_colorbar.cpp glui_display.cpp glui_geometry.cpp glui_motion.cpp \
          glui_objects.cpp glui_shooter.cpp glui_smoke.cpp glui_stereo.cpp glui_tour.cpp glui_trainer.cpp

--- a/Source/shared/CMakeLists.txt
+++ b/Source/shared/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(libsmv STATIC
     readtour.c
     scontour2d.c
     readsmvfile.c
+    "paths.c"
 )
 target_include_directories(libsmv PUBLIC
     .

--- a/Source/shared/colorbars.c
+++ b/Source/shared/colorbars.c
@@ -614,29 +614,28 @@ colorbardata *NewColorbar(colorbar_collection *colorbars){
   return cb;
 }
 
+/* ------------------ GetColorbarsSubDir ------------------------ */
+
 /**
  * @brief Get a path for a colorbar subdir. This is generally in the form
  * ${SMV_ROOT_DIR}/colorbars/${subdir}.
  *
  * @param subdir The name of the subdir
- * @return Path to directory (allocated via NEWMEMORY) or NULL if subidr is NULL
+ * @return Path to directory (allocated via NEWMEMORY) or NULL if subdir is NULL
  * or if GetSmvRootDir returns NULL.
  */
-
-/* ------------------ GetColorbarsSubDir ------------------------ */
-
-char *GetColorbarsSubDir(const char *subdir){
+char *GetColorbarsSubDir(const char *subdir) {
   char *return_path = NULL;
   char *smv_bindir = GetSmvRootDir();
   if(smv_bindir == NULL || subdir == NULL) return return_path;
-
-  NewMemory((void **)&return_path, strlen(smv_bindir) + strlen("colorbars") +
-                                       strlen(dirseparator) + strlen(subdir) +
-                                       2);
-  strcpy(return_path, smv_bindir);
-  strcat(return_path, "colorbars");
-  strcat(return_path, dirseparator);
-  if(strlen(subdir) > 0) strcat(return_path, subdir);
+  char *colorbar_dir = CombinePaths(smv_bindir, "colorbars");
+  if(strlen(subdir) > 0) {
+    return_path = CombinePaths(colorbar_dir, subdir);
+    FREEMEMORY(colorbar_dir);
+  }
+  else {
+    return_path = colorbar_dir;
+  }
   FREEMEMORY(smv_bindir);
   return return_path;
 }
@@ -653,7 +652,7 @@ void ReadColorbarDir(colorbar_collection *colorbars, const char *dir_path,
 
     if(filelist[i].file == NULL || strlen(filelist[i].file) == 0) return;
     if(dir_path == NULL || strlen(dir_path) == 0) return;
-    char *filepath = JoinPath(dir_path, filelist[i].file);
+    char *filepath = CombinePaths(dir_path, filelist[i].file);
     ReadCSVColorbar(cbi, filepath, label, type);
     colorbars->ncolorbars++;
     cbi->can_adjust = 1;

--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -1138,37 +1138,6 @@ char *GetFloatFileSizeLabel(float size, char *sizelabel){
   return sizelabel;
 }
 
-// Only allows something from NEWMEMORY
-char *JoinPath(const char *path, const char *segment) {
-  // TODO: replace with platform-specific functions
-  char *new_path;
-  if (path == NULL) {
-    if (segment == NULL) return NULL;
-    NEWMEMORY(new_path, (strlen(segment) + 1) * sizeof(char));
-    STRCPY(new_path, segment);
-    return new_path;
-  };
-  if (segment == NULL) {
-    NEWMEMORY(new_path, (strlen(path) + 1) * sizeof(char));
-    STRCPY(new_path, path);
-    return new_path;
-  };
-  int path_len = strlen(path);
-  int newlen = path_len + strlen(dirseparator) + strlen(segment) + 1;
-  NEWMEMORY(new_path, (newlen + 1) * sizeof(char));
-  strcpy(new_path, path);
-  int new_path_len;
-  new_path_len = strlen(new_path);
-  if(strcmp(new_path + new_path_len - 1, dirseparator) == 0){
-    strcat(new_path, segment);
-  }
-  else{
-    strcat(new_path, dirseparator);
-    strcat(new_path, segment);
-  }
-  return new_path;
-}
-
 #ifdef _WIN32
 
 /* ------------------ GetBinPath - windows ------------------------ */
@@ -1206,6 +1175,17 @@ char *GetBinDir(){
   PathAddBackslashA(buffer);
   return buffer;
 }
+
+char *CombinePaths(const char *path_a, const char *path_b){
+  char *path_out;
+  NEWMEMORY(path_out, sizeof(char) * MAX_PATH);
+  // NB: This uses on older function in order to support "char *".
+  // PathAllocCombine would be better but requires switching to "wchar *".
+  char *result = PathCombineA(path_out, path_a, path_b);
+  if(result == NULL) FREEMEMORY(path_out);
+  return result;
+}
+
 #elif __linux__
 
 /* ------------------ GetBinPath - linux ------------------------ */
@@ -1244,6 +1224,21 @@ char *GetBinDir(){
   buffer[pathlen + 1] = '\0';
   return buffer;
 }
+
+char *CombinePaths(const char *path_a, const char *path_b) {
+  char *path_out;
+  size_t path_a_len = strlen(path_a);
+  size_t path_b_len = strlen(path_b);
+  size_t new_len = path_a_len + 1 + path_b_len;
+  NEWMEMORY(path_out, sizeof(char) * (new_len + 1));
+  STRCPY(path_out, path_a);
+  path_out[path_a_len] = '/';
+  path_out[path_a_len+1] = '\0';
+  STRCAT(path_out, path_b);
+  path_out[new_len] = '\0';
+  return path_out;
+}
+
 #else
 
 /* ------------------ GetBinPath - osx ------------------------ */
@@ -1283,6 +1278,20 @@ char *GetBinDir(){
   buffer[pathlen] = '/';
   buffer[pathlen + 1] = '\0';
   return buffer;
+}
+
+char *CombinePaths(const char *path_a, const char *path_b) {
+  char *path_out;
+  size_t path_a_len = strlen(path_a);
+  size_t path_b_len = strlen(path_b);
+  size_t new_len = path_a_len + 1 + path_b_len;
+  NEWMEMORY(path_out, sizeof(char) * (new_len + 1));
+  STRCPY(path_out, path_a);
+  path_out[path_a_len] = '/';
+  path_out[path_a_len+1] = '\0';
+  STRCAT(path_out, path_b);
+  path_out[new_len] = '\0';
+  return path_out;
 }
 #endif
 
@@ -1387,18 +1396,21 @@ char *GetSmvRootDir(){
 char *GetSmvRootSubPath(const char *subdir) {
   char *root_dir = GetSmvRootDir();
   if (root_dir == NULL || subdir == NULL) return NULL;
-  return JoinPath(root_dir,subdir);
+  return CombinePaths(root_dir,subdir);
 }
 
 /* ------------------ GetHomeDir ------------------------ */
 
 char *GetHomeDir() {
 #ifdef WIN32
-  char *homedir = getenv("userprofile");
+  char *homedir_env = getenv("userprofile");
 #else
-  char *homedir = getenv("HOME");
+  char *homedir_env = getenv("HOME");
 #endif
-  if (homedir == NULL) return ".";
+  if(homedir_env == NULL) homedir_env = ".";
+  char *homedir;
+  NEWMEMORY(homedir, sizeof(char) * (strlen(homedir_env) + 1));
+  STRCPY(homedir, ".");
   return homedir;
 }
 
@@ -1422,7 +1434,7 @@ char *GetUserConfigDir() {
 char *GetUserConfigSubPath(const char *subdir) {
   char *config_dir = GetUserConfigDir();
   if (config_dir == NULL || subdir == NULL) return NULL;
-  return JoinPath(config_dir,subdir);
+  return CombinePaths(config_dir,subdir);
 }
 
 /* ------------------ GetSystemIniPath ------------------------ */
@@ -1462,6 +1474,36 @@ char *GetSmokeviewHtmlVrPath() {
 char *GetSmvScreenIni() {
   return GetSmvRootSubPath("smv_screen.ini");
 }
+
+
+
+/* ------------------ GetSmvRootFile ----------------------- */
+
+char *GetSmvRootFile(const char *path) {
+  char *root_path = GetSmvRootDir();
+  char *result = CombinePaths(root_path, path);
+  FREEMEMORY(root_path);
+  return result;
+}
+
+/* ------------------ GetSmvUserDir ------------------------ */
+
+char *GetSmvUserDir() {
+  char *home_path = GetHomeDir();
+  char *result = CombinePaths(home_path, ".smokeview");
+  FREEMEMORY(home_path);
+  return result;
+}
+
+/* ------------------ GetSmvUserFile ----------------------- */
+
+char *GetSmvUserFile(const char *path) {
+  char *user_path = GetSmvUserDir();
+  char *result = CombinePaths(user_path, path);
+  FREEMEMORY(user_path);
+  return result;
+}
+
 
 /* ------------------ IsSootFile ------------------------ */
 

--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -1383,9 +1383,10 @@ char *GetHomeDir() {
   char *homedir_env = getenv("HOME");
 #endif
   if(homedir_env == NULL) homedir_env = ".";
+  // For consistency allocate path using NEWMEMORY
   char *homedir;
   NEWMEMORY(homedir, sizeof(char) * (strlen(homedir_env) + 1));
-  STRCPY(homedir, ".");
+  STRCPY(homedir, homedir_env);
   return homedir;
 }
 
@@ -1393,14 +1394,9 @@ char *GetHomeDir() {
 
 char *GetUserConfigDir() {
   char *homedir = GetHomeDir();
-  if (homedir == NULL) return NULL;
-
-  char *config_path;
-  NEWMEMORY(config_path,
-            strlen(homedir) + strlen(dirseparator) + strlen(".smokeview") + 1);
-  strcpy(config_path, homedir);
-  strcat(config_path, dirseparator);
-  strcat(config_path, ".smokeview");
+  if(homedir == NULL) return NULL;
+  char *config_path = CombinePaths(homedir, ".smokeview");
+  FREEMEMORY(homedir);
   return config_path;
 }
 

--- a/Source/shared/file_util.h
+++ b/Source/shared/file_util.h
@@ -234,6 +234,24 @@ EXTERNCPP char *GetSmvRootSubPath(const char *subdir);
  */
 EXTERNCPP void SetSmvRootOverride(const char *path);
 /**
+ * @brief Combine to paths, allocating a new path.
+ * @param path_a The first path (optional). Maximum length MAX_PATH
+ * @param path_b The second path. Maximum length MAX_PATH
+ * @return A new path allocated with NEWMEMORY or NULL if the path could not be
+ * constructed.
+ */
+EXTERNCPP char *CombinePaths(const char *path_a, const char *path_b);
+/**
+ * @brief Get the path of a file relative to the root directory.
+ * @param path The filename or path relative to the smv root directory (as
+ * defined by GetSmvRooDir).
+ * @return A new path allocated with NEWMEMORY or NULL if the path could not be
+ * constructed.
+ */
+EXTERNCPP char *GetSmvRootFile(const char *path);
+EXTERNCPP char *GetSmvUserDir();
+EXTERNCPP char *GetSmvUserFile(const char *path);
+/**
  * @brief Get the path of the smokeview config directory. This is generally in a
  * directory called ".smokeview" within the users home directory. E.g.,
  * $HOME/.smokeview.
@@ -242,6 +260,7 @@ EXTERNCPP void SetSmvRootOverride(const char *path);
  * (including hitting the maximum buffer size).
  */
 EXTERNCPP char *GetUserConfigDir();
+EXTERNCPP char *GetHomeDir(void);
 /**
  * @brief Get the path of a subdirectory of the smokeview config directory. This
  * is generally in the form $HOME/.smokeview/${subdir}.
@@ -273,8 +292,6 @@ EXTERNCPP void PrintTime(const char *tag, int line, float *timer,
 EXTERNCPP int IsSootFile(char *shortlabel, char *longlabel);
 
 EXTERNCPP char *LastName(char *argi);
-
-EXTERNCPP char *JoinPath(const char *path, const char *segment);
 
 // vvvvvvvvvvvvvvvvvvvvvvvv variables vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 

--- a/Source/shared/paths.c
+++ b/Source/shared/paths.c
@@ -1,0 +1,168 @@
+#include <string.h>
+
+#include "dmalloc.h"
+#include "options_common.h"
+
+#include "file_util.h"
+#include "shared_structures.h"
+
+/// @brief Create (and allocate) a path to be used by smokeview. Each of the
+/// arguments are optional. All NULL paramaters returns an empty string.
+/// @param dirpath  A correctly formatted directory path with no trailing path
+/// separator. If NULL, no directory is added.
+/// @param basename The name of the file, usually the CHID. Ignored if NULL.
+/// @param suffix A suffix to be appended to the file path, usually a constant
+/// and usually a constant. Ignored if NULL.
+/// @return An allocated path combining each of the components. If all elements
+/// are NULL it returns an empty (but still allocated) string. Returns NULL if
+/// the path could not be constructed.
+char *SetupPath(const char *dirpath, const char *basename, const char *suffix) {
+  char *path = NULL;
+  char *filename;
+  size_t baselen = basename == NULL ? 0 : strlen(basename);
+  size_t suffixlen = suffix == NULL ? 0 : strlen(suffix);
+  NEWMEMORY(filename, sizeof(char) * (baselen + suffixlen + 1));
+  filename[0] = '\0';
+  if(basename != NULL) strcat(filename, basename);
+  if(suffix != NULL) strcat(filename, suffix);
+  if(dirpath != NULL) {
+    path = CombinePaths(dirpath, filename);
+    FREEMEMORY(filename);
+  }
+  else {
+    path = filename;
+  }
+  return path;
+}
+
+char *GetCSVFilename(smv_case *scase, const char *csv_suffix) {
+  const char *ext = ".csv";
+  char *suffix_ext;
+  NEWMEMORY(suffix_ext,
+            sizeof(char) * (strlen(csv_suffix) + strlen(ext) + 1));
+  strcpy(suffix_ext, csv_suffix);
+  strcpy(suffix_ext, ext);
+  char *p = SetupPath(NULL, scase->fdsprefix, suffix_ext);
+  FREEMEMORY(suffix_ext);
+  return p;
+}
+
+// char *fds_filein;
+char *CasePathFdsFileIn(smv_case *scase) {
+  return SetupPath(NULL, scase->fds_filein, NULL);
+}
+
+// char *chidfilebase;
+char *CasePathChidFileBase(smv_case *scase) {
+  return SetupPath(NULL, scase->chidfilebase, NULL);
+}
+
+// char *hrr_csv_filename;
+char *CasePathHrrCsv(smv_case *scase) {
+  return SetupPath(NULL, scase->chidfilebase, "_hrr.csv");
+}
+// char *devc_csv_filename;
+char *CasePathDevcCsv(smv_case *scase) {
+  return SetupPath(NULL, scase->chidfilebase, "_devc.csv");
+}
+// char *exp_csv_filename;
+char *CasePathExpCsv(smv_case *scase) {
+  return SetupPath(NULL, scase->chidfilebase, "_exp.csv");
+}
+// char *stepcsv_filename;
+char *CasePathStepCsv(smv_case *scase) {
+  return SetupPath(NULL, scase->chidfilebase, "_steps.csv");
+}
+
+// char *log_filename;
+char *CasePathLogFile(smv_case *scase) {
+  return SetupPath(NULL, scase->chidfilebase, ".smvlog");
+}
+
+// char *caseini_filename;
+char *CasePathCaseIni(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".ini");
+}
+// char *fedsmv_filename;
+char *CasePathFed(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".fedsmv");
+}
+#ifdef pp_FRAME
+// char *frametest_filename;
+char *CasePathFrameTest(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".tst");
+}
+#endif
+// char *dEcsv_filename;
+char *CasePathDeCsv(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, "_dE.csv");
+}
+// char *html_filename;
+char *CasePathHtml(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".html");
+}
+// char *smv_orig_filename;
+char *CasePathSmvOrig(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".smo");
+}
+// char *htmlvr_filename;
+char *CasePathHtmlVr(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, "_vr.html");
+}
+// char *htmlobst_filename;
+char *CasePathHtmlObst(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, "_obst.json");
+}
+// char *htmlslicenode_filename;
+char *CasePathHtmlSliceNode(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, "_slicenode.json");
+}
+// char *htmlslicecell_filename;
+char *CasePathHtmlSliceCell(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, "_slicecell.json");
+}
+// char *event_filename;
+char *CasePathEvent(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, "_events.csv");
+}
+// char *ffmpeg_command_filename;
+char *CasePathFfmpegCommand(smv_case *scase) {
+#ifdef WIN32
+  return SetupPath(NULL, scase->fdsprefix, "_ffmpeg.bat");
+#else
+  return SetupPath(NULL, scase->fdsprefix, "_ffmpeg.sh");
+#endif
+}
+// char *smvzip_filename;
+char *CasePathSmvZip(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".smvzip");
+}
+// char *sliceinfo_filename;
+char *CasePathSliceInfo(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".sinfo");
+}
+// char *deviceinfo_filename;
+char *CasePathDeviceInfo(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, "_device.info");
+}
+#ifdef pp_SMOKE3D_FORCE
+// char *smoke3d_filename;
+char *CasePathSmoke3d(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".s3d_dummy");
+}
+#endif
+// char *iso_filename;
+// if smokezip created part2iso files then concatenate .smv entries found in the
+// .isosmv file to the end of the .smv file creating a new .smv file.  Then read
+// in that .smv file.
+char *CasePathIso(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".isosmv");
+}
+// char *trainer_filename;
+char *CasePathTrainer(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".svd");
+}
+// char *test_filename;
+char *CasePathTest(smv_case *scase) {
+  return SetupPath(NULL, scase->fdsprefix, ".smt");
+}

--- a/Source/shared/paths.h
+++ b/Source/shared/paths.h
@@ -1,0 +1,66 @@
+#ifndef PATHS_H_DEFINED
+#define PATHS_H_DEFINED
+
+#include "shared_structures.h"
+
+EXTERNCPP char *GetCSVFilename(smv_case *scase, const char *csv_suffix);
+
+// char *fds_filein;
+EXTERNCPP char *CasePathFdsFileIn(smv_case *scase);
+
+// char *chidfilebase;
+EXTERNCPP char *CasePathChidFileBase(smv_case *scase);
+// char *hrr_csv_filename;
+EXTERNCPP char *CasePathHrrCsv(smv_case *scase);
+// char *devc_csv_filename;
+EXTERNCPP char *CasePathDevcCsv(smv_case *scase);
+// char *exp_csv_filename;
+EXTERNCPP char *CasePathExpCsv(smv_case *scase);
+// char *stepcsv_filename;
+EXTERNCPP char *CasePathStepCsv(smv_case *scase);
+
+// char *log_filename;
+EXTERNCPP char *CasePathLogFile(smv_case *scase);
+// char *caseini_filename;
+EXTERNCPP char *CasePathCaseIni(smv_case *scase);
+// char *fedsmv_filename;
+EXTERNCPP char *CasePathFed(smv_case *scase);
+#ifdef pp_FRAME
+// char *frametest_filename;
+EXTERNCPP char *CasePathFrameTest(smv_case *scase);
+#endif
+// char *dEcsv_filename;
+EXTERNCPP char *CasePathDeCsv(smv_case *scase);
+// char *html_filename;
+EXTERNCPP char *CasePathHtml(smv_case *scase);
+// char *smv_orig_filename;
+EXTERNCPP char *CasePathSmvOrig(smv_case *scase);
+// char *htmlvr_filename;
+EXTERNCPP char *CasePathHtmlVr(smv_case *scase);
+// char *htmlobst_filename;
+EXTERNCPP char *CasePathHtmlObst(smv_case *scase);
+// char *htmlslicenode_filename;
+EXTERNCPP char *CasePathHtmlSliceNode(smv_case *scase);
+// char *htmlslicecell_filename;
+EXTERNCPP char *CasePathHtmlSliceCell(smv_case *scase);
+// char *event_filename;
+EXTERNCPP char *CasePathEvent(smv_case *scase);
+// char *ffmpeg_command_filename;
+EXTERNCPP char *CasePathFfmpegCommand(smv_case *scase);
+// char *smvzip_filename;
+EXTERNCPP char *CasePathSmvZip(smv_case *scase);
+// char *sliceinfo_filename;
+EXTERNCPP char *CasePathSliceInfo(smv_case *scase);
+// char *deviceinfo_filename;
+EXTERNCPP char *CasePathDeviceInfo(smv_case *scase);
+#ifdef pp_SMOKE3D_FORCE
+// char *smoke3d_filename;
+EXTERNCPP char *CasePathSmoke3d(smv_case *scase);
+#endif
+// char *iso_filename;
+EXTERNCPP char *CasePathIso(smv_case *scase);
+// char *trainer_filename;
+EXTERNCPP char *CasePathTrainer(smv_case *scase);
+// char *test_filename;
+EXTERNCPP char *CasePathTest(smv_case *scase);
+#endif

--- a/Source/shared/readobject.c
+++ b/Source/shared/readobject.c
@@ -1486,7 +1486,6 @@ void LoadDefaultObjectDefs(object_collection *objectscoll){
 void ReadDefaultObjectCollection(object_collection *objectscoll,
                                  const char *fdsprefix,
                                  int isZoneFireModel){
-  char objectfile[1024];
 
   // There are 5 places to retrieve object definitions from:
   //
@@ -1499,23 +1498,24 @@ void ReadDefaultObjectCollection(object_collection *objectscoll,
   // Last definition wins.
 
   // Read "objects.svo" from bin dir
-  char *smv_bindir = GetSmvRootDir();
-  if(smv_bindir != NULL){
-    strcpy(objectfile, smv_bindir);
-    strcat(objectfile, "objects.svo");
-    ReadObjectDefs(objectscoll, objectfile);
+  char *path = GetSmvRootFile("objects.svo");
+  if(path != NULL){
+    ReadObjectDefs(objectscoll, path);
+    FREEMEMORY(path);
   }
-  FREEMEMORY(smv_bindir);
 
   // Read "objects.svo" from the current directory.
-  strcpy(objectfile, "objects.svo");
-  ReadObjectDefs(objectscoll, objectfile);
+  ReadObjectDefs(objectscoll, "objects.svo");
 
   // Read "${fdsprefix}.svo" from the current directory
   if(fdsprefix != NULL){
+    char *objectfile;
+    char *ext = ".svo";
+    NEWMEMORY(objectfile, sizeof(char) * (strlen(fdsprefix) + strlen(ext) + 1));
     strcpy(objectfile, fdsprefix);
-    strcat(objectfile, ".svo");
+    strcat(objectfile, ext);
     ReadObjectDefs(objectscoll, objectfile);
+    FREEMEMORY(objectfile);
   }
 
 #ifdef SMOKEVIEW_OBJECT_DEFS_PATH

--- a/Source/shared/shared_structures.h
+++ b/Source/shared/shared_structures.h
@@ -1065,49 +1065,6 @@ typedef struct {
 
 } surf_collection;
 
-/* --------------------------  casepaths ------------------------------------ */
-
-typedef struct {
-  char *fds_filein;
-  char *chidfilebase;
-  char *hrr_csv_filename;
-  char *devc_csv_filename;
-  char *exp_csv_filename;
-  char *stepcsv_filename;
-
-  // The base names are properties of the GUI
-  // char *movie_name;
-  // char *render_file_base;
-  // char *html_file_base;
-  char *log_filename;
-  char *caseini_filename;
-  char *fedsmv_filename;
-#ifdef pp_FRAME
-  char *frametest_filename;
-#endif
-  char *expcsv_filename;
-  char *dEcsv_filename;
-  char *html_filename;
-  char *smv_orig_filename;
-  char *hrr_filename;
-  char *htmlvr_filename;
-  char *htmlobst_filename;
-  char *htmlslicenode_filename;
-  char *htmlslicecell_filename;
-  char *event_filename;
-  char *ffmpeg_command_filename;
-  char *fed_filename;
-  char *smvzip_filename;
-  char *sliceinfo_filename;
-  char *deviceinfo_filename;
-#ifdef pp_SMOKE3D_FORCE
-  char *smoke3d_filename;
-#endif
-  char *iso_filename;
-  char *trainer_filename;
-  char *test_filename;
-} casepaths;
-
 /* --------------------------  csvdata ------------------------------------ */
 
 typedef struct _csvdata {
@@ -1773,9 +1730,23 @@ struct color_defaults {
 /* --------------------------  smv_case ------------------------------------ */
 
 typedef struct {
+  /// @brief This is the filename passed to smokeview without the extension.
   char *fdsprefix;
+  /// @brief This can be one of the two things, the &HEAD CHID={CHID} value
+  /// found in the input file (defined by INPF) or the CHID value found in
+  /// *.smv. The value defined by CHID takes precedence and the value defined in
+  /// INPF is discarded if the CHID entry exists.
+  char *chidfilebase;
+
+  /// @brief The value of INPF in the *.smv file, represents the input file for
+  /// the simulation.
+  char *fds_filein;
+  /// @brief The value of the TITLE in the *.smv file.
   char *fds_title;
+  /// @brief The value of FDSVERSION in the *.smv file.
   char *fds_version;
+  /// @brief The value of FDSVERSION in the *.smv file. Currently this is simply
+  /// a copy of fds_version.
   char *fds_githash;
   char *results_dir;
 
@@ -1799,8 +1770,6 @@ typedef struct {
   terrain_texture_collection     terrain_texture_coll;
   texture_collection             texture_coll;
   tour_collection                tourcoll;
-
-  casepaths paths;
 
   int nplot3dinfo;
   plot3ddata *plot3dinfo;

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -5846,7 +5846,7 @@ void SetupDeviceData(void){
         fprintf(stderr," %s,",devi->deviceID);
       }
     }
-    fprintf(stderr," found in %s\n",global_scase.paths.fds_filein);
+    fprintf(stderr," found in %s\n",global_scase.fds_filein);
   }
   for(i=0;i<global_scase.devicecoll.nvdeviceinfo;i++){
     vdevicedata *vdevi;

--- a/Source/smokeview/command_args.h
+++ b/Source/smokeview/command_args.h
@@ -1,6 +1,6 @@
 /// @file command_args.h
-#ifndef PATHS_H_DEFINED
-#define PATHS_H_DEFINED
+#ifndef COMMAND_ARGS_H_DEFINED
+#define COMMAND_ARGS_H_DEFINED
 
 #include <stdbool.h>
 #include "options.h"

--- a/Source/smokeview/glui_bounds.cpp
+++ b/Source/smokeview/glui_bounds.cpp
@@ -17,6 +17,7 @@
 #include "histogram.h"
 
 #include "colorbars.h"
+#include "paths.h"
 
 void SetResearchMode(int flag);
 int GetCacheFlag(int type);
@@ -4719,13 +4720,17 @@ void ScriptCB(int var){
     id = LIST_ini_list->get_int_val();
     ini_filename = GetIniFileName(id);
     if(ini_filename == NULL)break;
-    if(strcmp(ini_filename, global_scase.paths.caseini_filename) == 0){
+    char *caseini_filename = CasePathCaseIni(&global_scase);
+    if(strcmp(ini_filename, caseini_filename) == 0){
       ReadIni(NULL);
     }
     else if(id >= 0){
       char *script_filename2;
 
-      if(strlen(ini_filename) == 0)break;
+      if(strlen(ini_filename) == 0) {
+        FREEMEMORY(caseini_filename);
+        break;
+      }
       script_filename2 = script_filename;
       strcpy(script_filename, ini_filename);
       windowresized = 0;
@@ -4735,6 +4740,7 @@ void ScriptCB(int var){
       fprintf(scriptoutstream, "LOADINIFILE\n");
       fprintf(scriptoutstream, " %s\n", ini_filename);
     }
+    FREEMEMORY(caseini_filename);
   }
   break;
   case SCRIPT_STEP:
@@ -4919,7 +4925,7 @@ void AddMeshCheckbox(int icol,int nm, GLUI_Panel *PANEL, GLUI_Checkbox **CHECKBO
     for(i=icol-1;i<nm;i+=8){
       meshdata *meshi;
       char label[340];
-      
+
       meshi = global_scase.meshescoll.meshinfo + i;
       sprintf(label, "%i", i + 1);
       if(option == 1){
@@ -4929,7 +4935,7 @@ void AddMeshCheckbox(int icol,int nm, GLUI_Panel *PANEL, GLUI_Checkbox **CHECKBO
         CHECKBOX[i] = glui_bounds->add_checkbox_to_panel(PANEL, label, &meshi->datavis);
       }
     }
-    if(icol!=MIN(8,nm)){     
+    if(icol!=MIN(8,nm)){
       glui_bounds->add_column_to_panel(PANEL, false);
     }
   }
@@ -5802,12 +5808,12 @@ extern "C" void GLUIBoundsSetup(int main_window){
   for(i = 1;i < 9;i++){
     AddMeshCheckbox(i, nn, PANEL_geom_vis2, CHECKBOX_show_mesh_geom, 1);
   }
-  
+
   PANEL_geom_vis3 = glui_bounds->add_panel_to_panel(ROLLOUT_vismesh_blockages, "", GLUI_PANEL_NONE);
   glui_bounds->add_button_to_panel(PANEL_geom_vis3, _("Show all"),     SHOW_ALL_MESH_GEOM, GLUIShowHideGeomDataCB);
-  glui_bounds->add_column_to_panel(PANEL_geom_vis3, false);  
+  glui_bounds->add_column_to_panel(PANEL_geom_vis3, false);
   glui_bounds->add_button_to_panel(PANEL_geom_vis3, _("Hide all"),     HIDE_ALL_MESH_GEOM, GLUIShowHideGeomDataCB);
-  
+
   ROLLOUT_vismesh_data = glui_bounds->add_rollout_to_panel(ROLLOUT_view_options, "View data by mesh", false, MESHDATA_ROLLOUT, ViewRolloutCB);
   TOGGLE_ROLLOUT(viewprocinfo, nviewprocinfo, ROLLOUT_vismesh_data, MESHDATA_ROLLOUT, glui_bounds);
   PANEL_data_vis2 = glui_bounds->add_panel_to_panel(ROLLOUT_vismesh_data, "", GLUI_PANEL_NONE);
@@ -5816,9 +5822,9 @@ extern "C" void GLUIBoundsSetup(int main_window){
   }
   PANEL_data_vis3 = glui_bounds->add_panel_to_panel(ROLLOUT_vismesh_data, "", GLUI_PANEL_NONE);
   glui_bounds->add_button_to_panel(PANEL_data_vis3, _("Show all"),     SHOW_ALL_MESH_DATA, GLUIShowHideGeomDataCB);
-  glui_bounds->add_column_to_panel(PANEL_data_vis3, false);  
+  glui_bounds->add_column_to_panel(PANEL_data_vis3, false);
   glui_bounds->add_button_to_panel(PANEL_data_vis3, _("Hide all"),     HIDE_ALL_MESH_DATA, GLUIShowHideGeomDataCB);
-  
+
   // -------------- Data coloring -------------------
 
   ROLLOUT_coloring = glui_bounds->add_rollout("Coloring", false, COLORING_ROLLOUT, FileRolloutCB);
@@ -7038,7 +7044,7 @@ extern "C" void GLUISliceBoundCB(int var){
       slice_fileupdate--;
       break;
     }
-  last_slice = -1; 
+  last_slice = -1;
     for(ii = nslice_loaded - 1; ii >= 0; ii--){
       i = slice_loaded_list[ii];
       sd = global_scase.slicecoll.sliceinfo + i;

--- a/Source/smokeview/glui_motion.cpp
+++ b/Source/smokeview/glui_motion.cpp
@@ -14,6 +14,7 @@
 #include "IOvolsmoke.h"
 #include "glui_motion.h"
 #include "readgeom.h"
+#include "paths.h"
 
 #define ROTATE_TRANSLATE
 #ifdef pp_OSX_HIGHRES
@@ -2656,9 +2657,11 @@ void RenderCB(int var){
     case RENDER_LABEL:
     case RENDER_TYPE:
       break;
-    case RENDER_HTML:
-      Smv2Html(global_scase.paths.html_filename, HTML_CURRENT_TIME, FROM_SMOKEVIEW);
-      break;
+    case RENDER_HTML: {
+      char *html_filename = CasePathHtml(&global_scase);
+      Smv2Html(html_filename, HTML_CURRENT_TIME, FROM_SMOKEVIEW);
+      FREEMEMORY(html_filename);
+    } break;
 #ifdef pp_RENDER360_DEBUG
     case RENDER_DEBUG_360:
       if(debug_360_skip_x<2){

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -11,6 +11,7 @@
 #include "string_util.h"
 #include "smokeviewvars.h"
 #include "command_args.h"
+#include "paths.h"
 #include "readsmvfile.h"
 #include "IOscript.h"
 #include "IOvolsmoke.h"
@@ -20,6 +21,8 @@
 #endif
 
 #include <assert.h>
+
+
 
 /* ------------------ Usage ------------------------ */
 
@@ -256,8 +259,6 @@ char *ProcessCommandLine(CommandlineArgs *args){
   strcpy(html_file_base, global_scase.fdsprefix);
   smv_ext = strstr(html_file_base, ".smv");
   if(smv_ext!=NULL)*smv_ext = 0;
-  FREEMEMORY(global_scase.paths.trainer_filename);
-  FREEMEMORY(global_scase.paths.test_filename);
 
   strcpy(input_filename_ext, "");
 
@@ -278,100 +279,10 @@ char *ProcessCommandLine(CommandlineArgs *args){
         STRCPY(global_scase.fdsprefix, argi);
         strcpy(movie_name, global_scase.fdsprefix);
         strcpy(render_file_base, global_scase.fdsprefix);
-        FREEMEMORY(global_scase.paths.trainer_filename);
-        NewMemory((void **)&global_scase.paths.trainer_filename, (unsigned int)(len_casename + 7));
-        STRCPY(global_scase.paths.trainer_filename, argi);
-        STRCAT(global_scase.paths.trainer_filename, ".svd");
-        FREEMEMORY(global_scase.paths.test_filename);
-        NewMemory((void **)&global_scase.paths.test_filename, (unsigned int)(len_casename + 7));
-        STRCPY(global_scase.paths.test_filename, argi);
-        STRCAT(global_scase.paths.test_filename, ".smt");
       }
     }
   }
 
-  FREEMEMORY(global_scase.paths.log_filename);
-  NewMemory((void **)&global_scase.paths.log_filename, len_casename + strlen(".smvlog") + 1);
-  STRCPY(global_scase.paths.log_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.log_filename, ".smvlog");
-
-  FREEMEMORY(global_scase.paths.caseini_filename);
-  NewMemory((void **)&global_scase.paths.caseini_filename, len_casename + strlen(".ini") + 1);
-  STRCPY(global_scase.paths.caseini_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.caseini_filename, ".ini");
-
-#ifdef pp_FRAME
-  FREEMEMORY(global_scase.paths.frametest_filename);
-  NewMemory((void **)&global_scase.paths.frametest_filename, len_casename + strlen(".tst") + 1);
-  STRCPY(global_scase.paths.frametest_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.frametest_filename, ".tst");
-#endif
-
-  FREEMEMORY(global_scase.paths.fedsmv_filename);
-  NewMemory((void **)&global_scase.paths.fedsmv_filename, len_casename + strlen(".fedsmv") + 1);
-  STRCPY(global_scase.paths.fedsmv_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.fedsmv_filename, ".fedsmv");
-
-  FREEMEMORY(global_scase.paths.expcsv_filename);
-  NewMemory((void **)&global_scase.paths.expcsv_filename, len_casename + strlen("_exp.csv") + 1);
-  STRCPY(global_scase.paths.expcsv_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.expcsv_filename, "_exp.csv");
-
-  FREEMEMORY(global_scase.paths.stepcsv_filename);
-  NewMemory((void **)&global_scase.paths.stepcsv_filename, len_casename + strlen("_steps.csv") + 1);
-  STRCPY(global_scase.paths.stepcsv_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.stepcsv_filename, "_steps.csv");
-
-  FREEMEMORY(global_scase.paths.dEcsv_filename);
-  NewMemory((void **)&global_scase.paths.dEcsv_filename, len_casename + strlen("_dE.csv") + 1);
-  STRCPY(global_scase.paths.dEcsv_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.dEcsv_filename, "_dE.csv");
-
-  FREEMEMORY(global_scase.paths.html_filename);
-  NewMemory((void **)&global_scase.paths.html_filename, len_casename+strlen(".html")+1);
-  STRCPY(global_scase.paths.html_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.html_filename, ".html");
-
-  FREEMEMORY(global_scase.paths.smv_orig_filename);
-  NewMemory((void **)&global_scase.paths.smv_orig_filename, len_casename+strlen(".smo")+1);
-  STRCPY(global_scase.paths.smv_orig_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.smv_orig_filename, ".smo");
-
-  FREEMEMORY(global_scase.paths.hrr_filename);
-  NewMemory((void **)&global_scase.paths.hrr_filename, len_casename+strlen("_hrr.csv")+1);
-  STRCPY(global_scase.paths.hrr_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.hrr_filename, "_hrr.csv");
-
-  FREEMEMORY(global_scase.paths.htmlvr_filename);
-  NewMemory((void **)&global_scase.paths.htmlvr_filename, len_casename+strlen("_vr.html")+1);
-  STRCPY(global_scase.paths.htmlvr_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.htmlvr_filename, "_vr.html");
-
-  FREEMEMORY(global_scase.paths.htmlobst_filename);
-  NewMemory((void **)&global_scase.paths.htmlobst_filename, len_casename+strlen("_obst.json")+1);
-  STRCPY(global_scase.paths.htmlobst_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.htmlobst_filename, "_obst.json");
-
-  FREEMEMORY(global_scase.paths.htmlslicenode_filename);
-  NewMemory((void **)&global_scase.paths.htmlslicenode_filename, len_casename+strlen("_slicenode.json")+1);
-  STRCPY(global_scase.paths.htmlslicenode_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.htmlslicenode_filename, "_slicenode.json");
-
-  FREEMEMORY(global_scase.paths.htmlslicecell_filename);
-  NewMemory((void **)&global_scase.paths.htmlslicecell_filename, len_casename+strlen("_slicecell.json")+1);
-  STRCPY(global_scase.paths.htmlslicecell_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.htmlslicecell_filename, "_slicecell.json");
-
-  FREEMEMORY(global_scase.paths.event_filename);
-  NewMemory((void **)&global_scase.paths.event_filename, len_casename+strlen("_events.csv")+1);
-  STRCPY(global_scase.paths.event_filename, global_scase.fdsprefix);
-  STRCAT(global_scase.paths.event_filename, "_events.csv");
-
-  if(filename_local==NULL){
-    NewMemory((void **)&filename_local, (unsigned int)(len_casename+6));
-    STRCPY(filename_local, global_scase.fdsprefix);
-    STRCAT(filename_local, ".smv");
-  }
   {
     char scriptbuffer[1024];
 
@@ -380,80 +291,6 @@ char *ProcessCommandLine(CommandlineArgs *args){
     if(default_script == NULL&&FILE_EXISTS(scriptbuffer) == YES){
       default_script = InsertScriptFile(scriptbuffer);
     }
-  }
-  if(filename_local!= NULL){
-    FREEMEMORY(global_scase.paths.fds_filein);
-    NewMemory((void **)&global_scase.paths.fds_filein, strlen(global_scase.fdsprefix) + 6);
-    STRCPY(global_scase.paths.fds_filein, global_scase.fdsprefix);
-    STRCAT(global_scase.paths.fds_filein, ".fds");
-    if(FILE_EXISTS(global_scase.paths.fds_filein) == NO){
-      FREEMEMORY(global_scase.paths.fds_filein);
-    }
-  }
-  if(global_scase.paths.ffmpeg_command_filename == NULL){
-    NewMemory((void **)&global_scase.paths.ffmpeg_command_filename, (unsigned int)(len_casename + 12));
-    STRCPY(global_scase.paths.ffmpeg_command_filename, global_scase.fdsprefix);
-    STRCAT(global_scase.paths.ffmpeg_command_filename, "_ffmpeg");
-#ifdef WIN32
-    STRCAT(global_scase.paths.ffmpeg_command_filename,".bat");
-#else
-    STRCAT(global_scase.paths.ffmpeg_command_filename,".sh");
-#endif
-  }
-  if(global_scase.paths.smvzip_filename == NULL){
-    NewMemory((void **)&global_scase.paths.smvzip_filename, (unsigned int)(len_casename + strlen(".smvzip") + 1));
-    STRCPY(global_scase.paths.smvzip_filename, global_scase.fdsprefix);
-    STRCAT(global_scase.paths.smvzip_filename, ".smvzip");
-  }
-  if(global_scase.paths.sliceinfo_filename == NULL){
-    NewMemory((void **)&global_scase.paths.sliceinfo_filename, strlen(global_scase.fdsprefix) + strlen(".sinfo") + 1);
-    STRCPY(global_scase.paths.sliceinfo_filename, global_scase.fdsprefix);
-    STRCAT(global_scase.paths.sliceinfo_filename, ".sinfo");
-  }
-  if(global_scase.paths.deviceinfo_filename==NULL){
-    NewMemory((void **)&global_scase.paths.deviceinfo_filename, strlen(global_scase.fdsprefix)+strlen("_device.info")+1);
-    STRCPY(global_scase.paths.deviceinfo_filename, global_scase.fdsprefix);
-    STRCAT(global_scase.paths.deviceinfo_filename, "_device.info");
-  }
-
-  // if smokezip created part2iso files then concatenate .smv entries found in the .isosmv file
-  // to the end of the .smv file creating a new .smv file.  Then read in that .smv file.
-
-  {
-    FILE *stream_iso = NULL;
-
-    NewMemory((void **)&global_scase.paths.iso_filename, len_casename + strlen(".isosmv") + 1);
-    STRCPY(global_scase.paths.iso_filename, global_scase.fdsprefix);
-    STRCAT(global_scase.paths.iso_filename, ".isosmv");
-    stream_iso = fopen(global_scase.paths.iso_filename, "r");
-    if(stream_iso != NULL){
-      fclose(stream_iso);
-    }
-    else{
-      FREEMEMORY(global_scase.paths.iso_filename);
-    }
-  }
-
-  if(global_scase.paths.trainer_filename == NULL){
-    NewMemory((void **)&global_scase.paths.trainer_filename, (unsigned int)(len_casename + 6));
-    STRCPY(global_scase.paths.trainer_filename, global_scase.fdsprefix);
-    STRCAT(global_scase.paths.trainer_filename, ".svd");
-  }
-#ifdef pp_SMOKE3D_FORCE
-  if(global_scase.paths.smoke3d_filename == NULL){
-    char *smoke3d_filename;
-
-    NewMemory(( void ** )&smoke3d_filename, ( unsigned int )(len_casename + 11));
-    STRCPY(smoke3d_filename, global_scase.fdsprefix);
-    STRCAT(smoke3d_filename, ".s3d_dummy");
-    global_scase.paths.smoke3d_filename = GetScratchFilename(smoke3d_filename);
-    FREEMEMORY(smoke3d_filename);
-  }
-#endif
-  if(global_scase.paths.test_filename == NULL){
-    NewMemory((void **)&global_scase.paths.test_filename, (unsigned int)(len_casename + 6));
-    STRCPY(global_scase.paths.test_filename, global_scase.fdsprefix);
-    STRCAT(global_scase.paths.test_filename, ".svd");
   }
 
 #ifdef pp_OSX_HIGHRES
@@ -624,7 +461,9 @@ char *ProcessCommandLine(CommandlineArgs *args){
       vis_title_gversion = 1;
     }
     if(args->redirect){
-      LOG_FILENAME = fopen(global_scase.paths.log_filename, "w");
+      char *log_filename = CasePathLogFile(&global_scase);
+      LOG_FILENAME = fopen(log_filename, "w");
+      FREEMEMORY(log_filename);
       if(LOG_FILENAME != NULL){
         redirect = 1;
         SetStdOut(LOG_FILENAME);

--- a/Source/smokeview/output.c
+++ b/Source/smokeview/output.c
@@ -13,6 +13,7 @@
 
 #include "smokeviewvars.h"
 #include "glutbitmap.h"
+#include "paths.h"
 
 
 #define DENORMAL(x,i, n, min,max) ((min) + (i)*((max)-(min))/(n))
@@ -360,7 +361,9 @@ void WriteLabels(labels_collection *labelscoll_arg){
   char quote[2];
 
   if(event_file_exists==0)return;
-  stream = fopen(global_scase.paths.event_filename, "w");
+  char *event_filename = CasePathEvent(&global_scase);
+  stream = fopen(event_filename, "w");
+  FREEMEMORY(event_filename);
   if(stream==NULL)return;
 
   first_label = labelscoll_arg->label_first_ptr;

--- a/Source/smokeview/renderimage.c
+++ b/Source/smokeview/renderimage.c
@@ -12,6 +12,7 @@
 #include GLUT_H
 #include "gd.h"
 #include "IOscript.h"
+#include "paths.h"
 
 /* ------------------ PlayMovie ------------------------ */
 
@@ -141,10 +142,11 @@ void MakeMovie(void){
 
 // make movie
     if(output_ffmpeg_command==1){
-      if(global_scase.paths.ffmpeg_command_filename!=NULL){
         FILE *stream_ffmpeg=NULL;
 
-        stream_ffmpeg = fopen(global_scase.paths.ffmpeg_command_filename,"w");
+        char *ffmpeg_command_filename = CasePathFfmpegCommand(&global_scase);
+        stream_ffmpeg = fopen(ffmpeg_command_filename,"w");
+        FREEMEMORY(ffmpeg_command_filename);
         if(stream_ffmpeg!=NULL){
 #ifdef WIN32
           fprintf(stream_ffmpeg,"@echo off\n");
@@ -154,7 +156,6 @@ void MakeMovie(void){
           fprintf(stream_ffmpeg,"%s\n",command_line);
           fclose(stream_ffmpeg);
         }
-      }
       printf("%s\n", command_line);
       output_ffmpeg_command=0;
     }

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -840,7 +840,6 @@ EXTERNCPP int  OnMeshBoundary(float *xyz);
 //*** startup.c headers
 
 EXTERNCPP void FreeVars(void);
-EXTERNCPP char *GetHomeDir(void);
 EXTERNCPP void GetStartupVSlice(int seq_id);
 EXTERNCPP void GetStartupSlice(int seq_id);
 EXTERNCPP void GetStartupPart(int seq_id);
@@ -850,7 +849,6 @@ EXTERNCPP void GetStartupISO(int seq_id);
 EXTERNCPP void GetStartupBoundary(int seq_id);
 EXTERNCPP int GLUTGetScreenWidth(void);
 EXTERNCPP int GLUTGetScreenHeight(void);
-EXTERNCPP void InitColorbarsDir(void);
 EXTERNCPP void InitOpenGL(int option);
 EXTERNCPP void InitScriptErrorFiles(void);
 EXTERNCPP void InitStartupDirs(void);

--- a/Source/smokeview/smokeview.c
+++ b/Source/smokeview/smokeview.c
@@ -239,17 +239,14 @@ void DisplayVersionInfo(char *progname){
   }
   FREEMEMORY(user_ini_path);
 
-  char objectfile[1024];
-  if(smv_bindir != NULL){
-    strcpy(objectfile, smv_bindir);
-    strcat(objectfile, "objects.svo");
-  }
-  if(smv_bindir != NULL && FileExistsOrig(objectfile) == 1){
+  char *objectfile = GetSmvRootFile("objects.svo");
+  if(objectfile != NULL && FileExistsOrig(objectfile) == 1){
     PRINTF("objects.svo      : %s\n", objectfile);
   }
   else{
     PRINTF("objects.svo      : not found\n");
   }
+  FREEMEMORY(objectfile);
 
   char fullini_filename[256];
   strcpy(fullini_filename, "");

--- a/Source/smokeview/smokeview.c
+++ b/Source/smokeview/smokeview.c
@@ -10,6 +10,7 @@
 #include "smokeviewvars.h"
 #include "glui_motion.h"
 #include "IOscript.h"
+#include "paths.h"
 
 #ifdef WIN32
 #include <direct.h>
@@ -253,20 +254,22 @@ void DisplayVersionInfo(char *progname){
   char fullini_filename[256];
   strcpy(fullini_filename, "");
   char *smokeview_scratchdir = GetUserConfigDir();
-  if(global_scase.paths.caseini_filename != NULL){
-    if(FileExistsOrig(global_scase.paths.caseini_filename) == 1){
+  char *caseini_filename = CasePathCaseIni(&global_scase);
+  if(caseini_filename != NULL){
+    if(FileExistsOrig(caseini_filename) == 1){
       char cwdpath[1000];
       GETCWD(cwdpath, 1000);
       strcpy(fullini_filename, cwdpath);
       strcat(fullini_filename, dirseparator);
-      strcat(fullini_filename, global_scase.paths.caseini_filename);
+      strcat(fullini_filename, caseini_filename);
     }
     else if(smokeview_scratchdir!=NULL){
       strcpy(fullini_filename, smokeview_scratchdir);
-      strcat(fullini_filename, global_scase.paths.caseini_filename);
+      strcat(fullini_filename, caseini_filename);
       if(FileExistsOrig(fullini_filename)==0)strcpy(fullini_filename, "");
     }
   }
+  FREEMEMORY(caseini_filename);
   FREEMEMORY(smokeview_scratchdir);
   if(smv_filename != NULL || show_version == 0){
     if(strlen(fullini_filename) > 0){
@@ -285,7 +288,9 @@ void DisplayVersionInfo(char *progname){
 int IsFDSRunning(FILE_SIZE *last_size){
   FILE_SIZE file_size;
 
-  file_size = GetFileSizeSMV(global_scase.paths.stepcsv_filename);
+  char *stepcsv_filename = CasePathStepCsv(&global_scase);
+  file_size = GetFileSizeSMV(stepcsv_filename);
+  FREEMEMORY(stepcsv_filename);
   if(file_size != *last_size){
     *last_size = file_size;
     return 1;
@@ -296,23 +301,25 @@ int IsFDSRunning(FILE_SIZE *last_size){
 /* ------------------ BuildGbndFile ------------------------ */
 
 int BuildGbndFile(int file_type){
+  char *stepcsv_filename = CasePathStepCsv(&global_scase);
   switch(file_type){
     case BOUND_SLICE:
       if(FileExistsOrig(slice_gbnd_filename)==0)return 1;
-      if(IsFileNewer(global_scase.paths.stepcsv_filename, slice_gbnd_filename)==1)return 1;
+      if(IsFileNewer(stepcsv_filename, slice_gbnd_filename)==1)return 1;
       break;
     case BOUND_PATCH:
       if(FileExistsOrig(patch_gbnd_filename)==0)return 1;
-      if(IsFileNewer(global_scase.paths.stepcsv_filename, patch_gbnd_filename)==1)return 1;
+      if(IsFileNewer(stepcsv_filename, patch_gbnd_filename)==1)return 1;
       break;
     case BOUND_PLOT3D:
       if(FileExistsOrig(plot3d_gbnd_filename)==0)return 1;
-      if(IsFileNewer(global_scase.paths.stepcsv_filename, plot3d_gbnd_filename)==1)return 1;
+      if(IsFileNewer(stepcsv_filename, plot3d_gbnd_filename)==1)return 1;
       break;
     default:
       assert(FFALSE);
       break;
   }
+  FREEMEMORY(stepcsv_filename);
   return 0;
 }
 

--- a/Source/smvq/smvq.c
+++ b/Source/smvq/smvq.c
@@ -13,11 +13,11 @@
 #include "dmalloc.h"
 #include "shared_structures.h"
 
+#include "readlabel.h"
+#include "readsmvfile.h"
 #include "smokeviewdefs.h"
 #include "string_util.h"
 #include <math.h>
-#include "readlabel.h"
-#include "readsmvfile.h"
 
 #include <json-c/json_object.h>
 
@@ -29,19 +29,19 @@ int ReadSMV_Init(smv_case *scase);
 int ReadSMV_Parse(smv_case *scase, bufferstreamdata *stream);
 void ReadSMVDynamic(smv_case *scase, char *file);
 void ReadSMVOrig(smv_case *scase);
-smv_case * CreateScase();
+smv_case *CreateScase();
 
 /// @brief Given a file path, get the filename excluding the final extension.
 /// This allocates a new copy which can be deallocated with free().
 /// @param input_file a file path
 /// @return an allocated string containing the basename or NULL on failure.
 char *GetBaseName(const char *input_file) {
-  if (input_file == NULL) return NULL;
+  if(input_file == NULL) return NULL;
 #ifdef _WIN32
   char *result = malloc(_MAX_FNAME + 1);
   errno_t err =
       _splitpath_s(input_file, NULL, 0, NULL, 0, result, _MAX_FNAME, NULL, 0);
-  if (err) return NULL;
+  if(err) return NULL;
 #else
   // POSIX basename can modify it's contents, so we'll make some copies.
   char *input_file_temp = strdup(input_file);
@@ -49,157 +49,29 @@ char *GetBaseName(const char *input_file) {
   char *bname = basename(input_file_temp);
   // If a '.' exists, set it to '\0' to trim the extension.
   char *dot = strrchr(bname, '.');
-  if (dot) *dot = '\0';
+  if(dot) *dot = '\0';
   char *result = strdup(bname);
   free(input_file_temp);
 #endif
   return result;
 }
 
-int SetGlobalFilenames(smv_case *scase) {
-  int len_casename = strlen(scase->fdsprefix);
-
-  FREEMEMORY(scase->paths.log_filename);
-  NewMemory((void **)&scase->paths.log_filename, len_casename + strlen(".smvlog") + 1);
-  STRCPY(scase->paths.log_filename, scase->fdsprefix);
-  STRCAT(scase->paths.log_filename, ".smvlog");
-
-  FREEMEMORY(scase->paths.caseini_filename);
-  NewMemory((void **)&scase->paths.caseini_filename, len_casename + strlen(".ini") + 1);
-  STRCPY(scase->paths.caseini_filename, scase->fdsprefix);
-  STRCAT(scase->paths.caseini_filename, ".ini");
-
-  FREEMEMORY(scase->paths.expcsv_filename);
-  NewMemory((void **)&scase->paths.expcsv_filename, len_casename + strlen("_exp.csv") + 1);
-  STRCPY(scase->paths.expcsv_filename, scase->fdsprefix);
-  STRCAT(scase->paths.expcsv_filename, "_exp.csv");
-
-  FREEMEMORY(scase->paths.dEcsv_filename);
-  NewMemory((void **)&scase->paths.dEcsv_filename, len_casename + strlen("_dE.csv") + 1);
-  STRCPY(scase->paths.dEcsv_filename, scase->fdsprefix);
-  STRCAT(scase->paths.dEcsv_filename, "_dE.csv");
-
-  FREEMEMORY(scase->paths.html_filename);
-  NewMemory((void **)&scase->paths.html_filename, len_casename + strlen(".html") + 1);
-  STRCPY(scase->paths.html_filename, scase->fdsprefix);
-  STRCAT(scase->paths.html_filename, ".html");
-
-  FREEMEMORY(scase->paths.smv_orig_filename);
-  NewMemory((void **)&scase->paths.smv_orig_filename, len_casename + strlen(".smo") + 1);
-  STRCPY(scase->paths.smv_orig_filename, scase->fdsprefix);
-  STRCAT(scase->paths.smv_orig_filename, ".smo");
-
-  FREEMEMORY(scase->paths.hrr_filename);
-  NewMemory((void **)&scase->paths.hrr_filename, len_casename + strlen("_hrr.csv") + 1);
-  STRCPY(scase->paths.hrr_filename, scase->fdsprefix);
-  STRCAT(scase->paths.hrr_filename, "_hrr.csv");
-
-  FREEMEMORY(scase->paths.htmlvr_filename);
-  NewMemory((void **)&scase->paths.htmlvr_filename, len_casename + strlen("_vr.html") + 1);
-  STRCPY(scase->paths.htmlvr_filename, scase->fdsprefix);
-  STRCAT(scase->paths.htmlvr_filename, "_vr.html");
-
-  FREEMEMORY(scase->paths.htmlobst_filename);
-  NewMemory((void **)&scase->paths.htmlobst_filename,
-            len_casename + strlen("_obst.json") + 1);
-  STRCPY(scase->paths.htmlobst_filename, scase->fdsprefix);
-  STRCAT(scase->paths.htmlobst_filename, "_obst.json");
-
-  FREEMEMORY(scase->paths.htmlslicenode_filename);
-  NewMemory((void **)&scase->paths.htmlslicenode_filename,
-            len_casename + strlen("_slicenode.json") + 1);
-  STRCPY(scase->paths.htmlslicenode_filename, scase->fdsprefix);
-  STRCAT(scase->paths.htmlslicenode_filename, "_slicenode.json");
-
-  FREEMEMORY(scase->paths.htmlslicecell_filename);
-  NewMemory((void **)&scase->paths.htmlslicecell_filename,
-            len_casename + strlen("_slicecell.json") + 1);
-  STRCPY(scase->paths.htmlslicecell_filename, scase->fdsprefix);
-  STRCAT(scase->paths.htmlslicecell_filename, "_slicecell.json");
-
-  FREEMEMORY(scase->paths.event_filename);
-  NewMemory((void **)&scase->paths.event_filename, len_casename + strlen("_events.csv") + 1);
-  STRCPY(scase->paths.event_filename, scase->fdsprefix);
-  STRCAT(scase->paths.event_filename, "_events.csv");
-
-  if (scase->paths.ffmpeg_command_filename == NULL) {
-    NewMemory((void **)&scase->paths.ffmpeg_command_filename,
-              (unsigned int)(len_casename + 12));
-    STRCPY(scase->paths.ffmpeg_command_filename, scase->fdsprefix);
-    STRCAT(scase->paths.ffmpeg_command_filename, "_ffmpeg");
-#ifdef WIN32
-    STRCAT(scase->paths.ffmpeg_command_filename, ".bat");
-#else
-    STRCAT(scase->paths.ffmpeg_command_filename, ".sh");
-#endif
-  }
-  if (scase->paths.smvzip_filename == NULL) {
-    NewMemory((void **)&scase->paths.smvzip_filename,
-              (unsigned int)(len_casename + strlen(".smvzip") + 1));
-    STRCPY(scase->paths.smvzip_filename, scase->fdsprefix);
-    STRCAT(scase->paths.smvzip_filename, ".smvzip");
-  }
-  if (scase->paths.sliceinfo_filename == NULL) {
-    NewMemory((void **)&scase->paths.sliceinfo_filename,
-              strlen(scase->fdsprefix) + strlen(".sinfo") + 1);
-    STRCPY(scase->paths.sliceinfo_filename, scase->fdsprefix);
-    STRCAT(scase->paths.sliceinfo_filename, ".sinfo");
-  }
-  if (scase->paths.deviceinfo_filename == NULL) {
-    NewMemory((void **)&scase->paths.deviceinfo_filename,
-              strlen(scase->fdsprefix) + strlen("_device.info") + 1);
-    STRCPY(scase->paths.deviceinfo_filename, scase->fdsprefix);
-    STRCAT(scase->paths.deviceinfo_filename, "_device.info");
-  }
-
-  // if smokezip created part2iso files then concatenate .smv entries found in
-  // the .isosmv file to the end of the .smv file creating a new .smv file. Then
-  // read in that .smv file.
-
-  {
-    FILE *stream_iso = NULL;
-
-    NewMemory((void **)&scase->paths.iso_filename, len_casename + strlen(".isosmv") + 1);
-    STRCPY(scase->paths.iso_filename, scase->fdsprefix);
-    STRCAT(scase->paths.iso_filename, ".isosmv");
-    stream_iso = fopen(scase->paths.iso_filename, "r");
-    if (stream_iso != NULL) {
-      fclose(stream_iso);
-    }
-    else {
-      FREEMEMORY(scase->paths.iso_filename);
-    }
-  }
-
-  if (scase->paths.trainer_filename == NULL) {
-    NewMemory((void **)&scase->paths.trainer_filename, (unsigned int)(len_casename + 6));
-    STRCPY(scase->paths.trainer_filename, scase->fdsprefix);
-    STRCAT(scase->paths.trainer_filename, ".svd");
-  }
-  if (scase->paths.test_filename == NULL) {
-    NewMemory((void **)&scase->paths.test_filename, (unsigned int)(len_casename + 6));
-    STRCPY(scase->paths.test_filename, scase->fdsprefix);
-    STRCAT(scase->paths.test_filename, ".svd");
-  }
-  return 0;
-}
-
 int PrintJson(smv_case *scase) {
   struct json_object *jobj = json_object_new_object();
   json_object_object_add(jobj, "version", json_object_new_int(1));
   json_object_object_add(jobj, "chid",
-                         json_object_new_string(scase->paths.chidfilebase));
-  if(scase->paths.fds_filein != NULL) {
+                         json_object_new_string(scase->chidfilebase));
+  if(scase->fds_filein != NULL) {
     json_object_object_add(jobj, "input_file",
-                           json_object_new_string(scase->paths.fds_filein));
+                           json_object_new_string(scase->fds_filein));
   }
   if(scase->fds_title != NULL) {
     json_object_object_add(jobj, "title",
                            json_object_new_string(scase->fds_title));
   }
   if(scase->fds_version != NULL) {
-  json_object_object_add(jobj, "fds_version",
-                         json_object_new_string(scase->fds_version));
+    json_object_object_add(jobj, "fds_version",
+                           json_object_new_string(scase->fds_version));
   }
   struct json_object *mesh_array = json_object_new_array();
   for(int i = 0; i < scase->meshescoll.nmeshes; i++) {
@@ -307,7 +179,7 @@ int PrintJson(smv_case *scase) {
                            json_object_new_string(device->labelptr));
     json_object_object_add(device_obj, "quantity",
                            json_object_new_string(device->quantity));
-    if (device->have_xyz) {
+    if(device->have_xyz) {
       struct json_object *device_position = json_object_new_object();
       json_object_object_add(device_position, "x",
                              json_object_new_double(device->xyz[0]));
@@ -317,9 +189,9 @@ int PrintJson(smv_case *scase) {
                              json_object_new_double(device->xyz[2]));
       json_object_object_add(device_obj, "position", device_position);
     }
-    if (device->act_times != NULL) {
+    if(device->act_times != NULL) {
       struct json_object *state_changes = json_object_new_array();
-      for (int j = 0; j < device->nstate_changes; j++) {
+      for(int j = 0; j < device->nstate_changes; j++) {
         struct json_object *state_change = json_object_new_object();
         json_object_object_add(state_change, "time",
                                json_object_new_double(device->act_times[j]));
@@ -341,19 +213,19 @@ int PrintJson(smv_case *scase) {
     json_object_object_add(slice_obj, "index", json_object_new_int(i + 1));
     json_object_object_add(slice_obj, "mesh",
                            json_object_new_int(slice->blocknumber));
-    if (slice->label.longlabel != NULL) {
+    if(slice->label.longlabel != NULL) {
       json_object_object_add(slice_obj, "longlabel",
                              json_object_new_string(slice->label.longlabel));
     }
-    if (slice->label.shortlabel) {
+    if(slice->label.shortlabel) {
       json_object_object_add(slice_obj, "shortlabel",
                              json_object_new_string(slice->label.shortlabel));
     }
-    if (slice->slicelabel) {
+    if(slice->slicelabel) {
       json_object_object_add(slice_obj, "id",
                              json_object_new_string(slice->slicelabel));
     }
-    if (slice->label.unit) {
+    if(slice->label.unit) {
       json_object_object_add(slice_obj, "unit",
                              json_object_new_string(slice->label.unit));
     }
@@ -412,7 +284,6 @@ int RunSmvq(char *input_file, const char *fdsprefix) {
   smv_case *scase = CreateScase();
   NEWMEMORY(scase->fdsprefix, (strlen(fdsprefix) + 1) * sizeof(char));
   STRCPY(scase->fdsprefix, fdsprefix);
-  SetGlobalFilenames(scase);
 
   INIT_PRINT_TIMER(parse_time);
   fprintf(stderr, "reading:\t%s\n", input_file);
@@ -456,8 +327,8 @@ int main(int argc, char **argv) {
 
   opterr = 0;
 
-  while ((c = getopt(argc, argv, "hV")) != -1)
-    switch (c) {
+  while((c = getopt(argc, argv, "hV")) != -1)
+    switch(c) {
     case 'h':
       print_help = true;
       break;
@@ -465,7 +336,7 @@ int main(int argc, char **argv) {
       print_version = true;
       break;
     case '?':
-      if (isprint(optopt))
+      if(isprint(optopt))
         fprintf(stderr, "Unknown option `-%c'.\n", optopt);
       else
         fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
@@ -473,7 +344,7 @@ int main(int argc, char **argv) {
     default:
       abort();
     }
-  if (print_help) {
+  if(print_help) {
     printf("smvq-%s\n", PROGVERSION);
     printf("\nUsage:  smvq [OPTIONS] <FILE>\n");
     printf("\nOptions:\n");
@@ -481,7 +352,7 @@ int main(int argc, char **argv) {
     printf("  -V Print version\n");
     return 0;
   }
-  if (print_version) {
+  if(print_version) {
     printf("smvq - smv query processor (v%s)\n", PROGVERSION);
     return 0;
   }
@@ -493,5 +364,6 @@ int main(int argc, char **argv) {
   }
   char *fdsprefix = GetBaseName(input_file);
   int result = RunSmvq(input_file, fdsprefix);
+  free(fdsprefix);
   return result;
 }

--- a/Tests/test_root_dir.c
+++ b/Tests/test_root_dir.c
@@ -23,5 +23,23 @@ int main(int argc, char **argv) {
     assert(root_len > 0);
     assert(root[root_len - 1] == dirseparator[0]);
   }
+  {
+    char *path = CombinePaths("1234/abc/efg", "hij/klm");
+#ifdef _WIN32
+    assert(strcmp(path, "1234/abc/efg\\hij/klm") == 0);
+#else
+    assert(strcmp(path, "1234/abc/efg/hij/klm") == 0);
+#endif
+  }
+  {
+    char *filename = "objects.svo";
+    char *path = GetSmvRootFile(filename);
+    assert(strcmp(LastName(path), filename) == 0);
+  }
+  {
+    char *filename = "smokeview.ini";
+    char *path = GetSmvRootFile(filename);
+    assert(strcmp(LastName(path), filename) == 0);
+  }
   return 0;
 }

--- a/Tests/test_root_dir.c
+++ b/Tests/test_root_dir.c
@@ -41,5 +41,15 @@ int main(int argc, char **argv) {
     char *path = GetSmvRootFile(filename);
     assert(strcmp(LastName(path), filename) == 0);
   }
+  {
+    char *path = GetHomeDir();
+    assert(path != NULL);
+    assert(strlen(path) > 1);
+  }
+  {
+    char *path = GetSmvRootFile("objects.svo");
+    assert(path != NULL);
+    assert(strlen(path) > 0);
+  }
   return 0;
 }


### PR DESCRIPTION
Previously, all paths (including config paths and paths of data files) were initialised into global variables or into a struct. This occurred at various points in the code and did not always use the same logic. If not initialised correctly, smokeview would crash.

This commit places all of this logic into paths.c and uses functions to create paths on demand. This should make the use of paths more consistent. This will also help support things such as different working directories. In many cases a lot of these paths are not used. Whether `fdsprefix` or `chidfilebase` is used is preserved in this commit, but it may be something worth revising as they can be different values.

This also abstracts away much of the buffer and directory separator logic and defers to the underlying OS for that information. 
