### PR TITLE
fix some checks and update .clang-tidy to ignore some checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: "clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,readability-identifier-naming"
+Checks: "clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-unix.Errno,-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,-clang-analyzer-optin.performance.Padding,-readability-identifier-naming,-clang-analyzer-unix.Stream,-clang-analyzer-core.uninitialized.Assign,-clang-analyzer-optin.taint.TaintedDiv,-clang-analyzer-unix.StdCLibraryFunctions"
 WarningsAsErrors: ""
 HeaderFilterRegex: ""
 CheckOptions:

--- a/Source/shared/colorbar_defs.h
+++ b/Source/shared/colorbar_defs.h
@@ -2,6 +2,8 @@
 #ifndef COLORBAR_DEFS_H_DEFINED
 #define COLORBAR_DEFS_H_DEFINED
 
+#include "colorbars.h"
+
 void CreateColorbarRainbow(colorbardata *cbi);
 void CreateColorbarOriginalRainbow(colorbardata *cbi);
 void CreateColorbarRainbow2(colorbardata *cbi);

--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -892,7 +892,7 @@ FILE *fopen_2dir_scratch(char *file, char *mode) {
 /* ------------------ fopen_3dir ------------------------ */
 
 FILE *fopen_3dir(char *file, char *mode, char *dir1, char *dir2, char *dir3){
-  FILE *stream;
+  FILE *stream = NULL;
   char buffer[4096];
   // try opening file in the current directory, dir1 then in dir2 then in dir3
   // (currently results direcrory defined by fds, current directory, scratch directory)

--- a/Source/shared/file_util.h
+++ b/Source/shared/file_util.h
@@ -8,7 +8,9 @@ extern int show_timings;
 #endif
 
 // vvvvvvvvvvvvvvvvvvvvvvvv header files vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-
+#include <stddef.h>
+#include <stdio.h>
+#include "options_common.h"
 #include <time.h>
 #ifdef __MINGW32__
 #include "options.h"

--- a/Source/shared/getdata.c
+++ b/Source/shared/getdata.c
@@ -875,7 +875,11 @@ void outboundaryheader(const char *boundaryfilename, FILE **file, int npatches,
 
   *error = 0;
   *file = FOPEN(boundaryfilename, "wb");
-
+  if(*file == NULL) {
+    fprintf(stderr, " Could not open %s\n", boundaryfilename);
+    *error = 1;
+    return;
+  }
   strncpy(blank, "                              ", 31);
   *error = fortwrite(blank, 30, 1, *file);
   *error = fortwrite(blank, 30, 1, *file);

--- a/Source/shared/stdio_buffer.h
+++ b/Source/shared/stdio_buffer.h
@@ -2,6 +2,8 @@
 #define STDIO_BUFFER_H_DEFINED
 
 #include <stdio.h>
+#include "options_common.h"
+
 /* --------------------------  _filedata ------------------------------------ */
 
 #define FILEBUFFER               FILE

--- a/Source/shared/stdio_m.h
+++ b/Source/shared/stdio_m.h
@@ -1,6 +1,10 @@
 #ifndef STDIO_M_H_DEFINED
 #define STDIO_M_H_DEFINED
 
+#include <stddef.h>
+#include <stdio.h>
+#include "options_common.h"
+
 typedef struct {
   char *file;
   FILE *stream;

--- a/Source/shared/translate.h
+++ b/Source/shared/translate.h
@@ -1,6 +1,8 @@
 #ifndef TRANSLATE_H_DEFINED
 #define TRANSLATE_H_DEFINED
 
+#include "options_common.h"
+
 #ifdef IN_TRANSLATE
 #define TREXTERN
 #define TRDECL(var,val)  var=val
@@ -35,4 +37,3 @@ TREXTERN char TRDECL(*smokeview_lang,NULL);
 TREXTERN trdata TRDECL(*trinfo,NULL);
 TREXTERN int TRDECL(ntrinfo,0);
 #endif
-


### PR DESCRIPTION
clang-tidy 20 triggers many warnings. Some of have been addressed in previous commits, however, some warnings (such as `clang-analyzer-unix.Stream`) are pervasive but have been part of the codebase for some time. This commit turns off those checks are they better addressed at another time.

As of this PR clang-tidy is showing no warnings for Source/shared although is showing some warnings in Source/smokeview.