### PR TITLE
change a mesh structure element name (append _smv) to make code clearer (make clear that contents contain smokeview not fds coordinates)

### DIFF
--- a/Source/shared/shared_structures.h
+++ b/Source/shared/shared_structures.h
@@ -226,7 +226,7 @@ typedef struct _meshdata {
   float verts[24], eyedist;
   float slice_min[3], slice_max[3];
   float xyz_bar0[3], xyz_bar[3];
-  float face_centers[18];
+  float face_centers_smv[18];
   float offset[3];
   float xyzmaxdiff;
   float boxoffset;

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -1538,14 +1538,14 @@ void UpdateMeshCoords(void){
     dplane_max[2] = MAX(dx, dz);
     dplane_max[3] = MAX(dx, dy);
 
-    face_centers = meshi->face_centers;
+    face_centers = meshi->face_centers_smv;
     for(j=0;j<6;j++){
       face_centers[0]=meshi->xcen_smv;
       face_centers[1]=meshi->ycen_smv;
       face_centers[2]=meshi->zcen_smv;
       face_centers+=3;
     }
-    face_centers = meshi->face_centers;
+    face_centers = meshi->face_centers_smv;
     face_centers[0]=meshi->boxmin_smv[0];
     face_centers[3]=meshi->boxmax_smv[0];
     face_centers[7]=meshi->boxmin_smv[1];

--- a/Source/smokeview/viewports.c
+++ b/Source/smokeview/viewports.c
@@ -1696,7 +1696,7 @@ void GetVolSmokeDir(float *mm){
       if(drawsides[j + 3] == 0)continue;
       vi->facemesh = meshi;
       vi->iwall = j;
-      xyz = meshi->face_centers + facemap[j + 3];
+      xyz = meshi->face_centers_smv + facemap[j + 3];
 
       dx = xyz[0] - eye_position_smv[0];
       dy = xyz[1] - eye_position_smv[1];


### PR DESCRIPTION
…ue2361""

This reverts commit 3f54d9af9fc67ebddd935608b518f7eb9fae0ced.