### PR TITLE
ci: pin macos version to macos-14 (arm64)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04
-    #      - macos-latest
+          - macos-14
     # Set the platform to build on
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Previously the macos version was set to macos-latest and was therefore unpinned. This pins the version to macos-14.