### PR TITLE
Add some support for Unicode paths on Windows

### DIFF
--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -36,6 +36,75 @@
 
 FILE *alt_stdout=NULL;
 
+#ifdef WIN32
+/// @brief Given a UTF-8 (or ASCII) string, convert it to Windows UTF-16.
+/// @param path a UTF-8 (or ASCII) string
+/// @return a UTF-16 string or NULL on error
+wchar_t *convert_utf8_to_utf16(const char *path) {
+  int r;
+  r = MultiByteToWideChar(CP_UTF8, 0, path, -1, NULL, 0);
+  if(r == 0) goto err;
+  LPWSTR out;
+  NEWMEMORY(out, r * sizeof(WCHAR));
+  r = MultiByteToWideChar(CP_UTF8, 0, path, -1, out, r);
+  if(r == 0) goto err;
+  return out;
+err:
+  // There was an error converting this string to utf-16. Produce a suitable
+  // error message and return NULL.
+  DWORD dw = GetLastError();
+  switch(dw) {
+  case ERROR_INSUFFICIENT_BUFFER:
+    fprintf(stderr, "A supplied buffer size was not large enough, or it was "
+                    "incorrectly set to NULL.\n");
+    break;
+  case ERROR_INVALID_FLAGS:
+    fprintf(stderr, "The values supplied for flags were not valid.\n");
+    break;
+  case ERROR_INVALID_PARAMETER:
+    fprintf(stderr, "Any of the parameter values was invalid.\n");
+    break;
+  case ERROR_NO_UNICODE_TRANSLATION:
+    fprintf(stderr, "Invalid Unicode was found in a string.\n");
+    break;
+  default:
+    break;
+  }
+  return NULL;
+}
+
+/* ------------------ FOPEN  ------------------------ */
+
+FILE *FOPEN(const char *file, const char *mode) {
+  wchar_t *path = convert_utf8_to_utf16(file);
+  wchar_t *wmode = convert_utf8_to_utf16(mode);
+  FILE *stream = _wfsopen(path, wmode, _SH_DENYNO);
+  FREEMEMORY(path);
+  FREEMEMORY(wmode);
+  return stream;
+}
+
+/* ------------------ MKDIR  ------------------------ */
+
+int MKDIR(const char *file) {
+  wchar_t *path = convert_utf8_to_utf16(file);
+  int r = CreateDirectoryW(path, NULL);
+  FREEMEMORY(path);
+  return r;
+}
+
+/* ------------------ UNLINK  ----------------------- */
+
+int UNLINK(const char *file) {
+  wchar_t *path = convert_utf8_to_utf16(file);
+  int r = _wunlink(path);
+  FREEMEMORY(path);
+  return r;
+}
+#else
+FILE *FOPEN(const char *file, const char *mode) { return fopen(file, mode); }
+#endif
+
 /* ------------------ TestWrite ------------------------ */
 
 void TestWrite(char *scratchdir, char **fileptr){
@@ -394,7 +463,7 @@ int Writable(char *dir){
     strcat(tempfullfile,dirseparator);
     RandStr(tempfile,35);
     strcat(tempfullfile,tempfile);
-    stream = fopen(tempfullfile,"w");
+    stream = FOPEN(tempfullfile,"w");
     if(stream==NULL){
       UNLINK(tempfullfile);
       return NO;

--- a/Source/shared/file_util.h
+++ b/Source/shared/file_util.h
@@ -69,7 +69,7 @@ typedef struct {
 // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 
 #ifdef WIN32
-#define UNLINK _unlink
+int UNLINK(const char *file);
 #else
 #define UNLINK unlink
 #endif
@@ -112,7 +112,7 @@ typedef struct {
 int FileExistsOrig(char *filename);
 
 #ifdef WIN32
-#define MKDIR(a) CreateDirectory(a, NULL)
+int MKDIR(const char *file);
 #else
 #define MKDIR(a)                                                               \
   mkdir(a, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
@@ -154,6 +154,9 @@ EXTERNCPP bufferdata *File2Buffer(char *file, char *size_file, int *options, buf
 EXTERNCPP FILE_SIZE fread_p(char *file, unsigned char *buffer, FILE_SIZE offset, FILE_SIZE nchars, int nthreads);
 EXTERNCPP void FileErase(char *file);
 EXTERNCPP FILE *FOPEN(const char *file, const char *mode);
+#ifdef WIN32
+EXTERNCPP wchar_t *convert_utf8_to_utf16(const char *path);
+#endif
 EXTERNCPP FILE *fopen_indir(char *dir, char *file, char *mode);
 EXTERNCPP FILE *fopen_2dir_scratch(char *file, char *mode);
 EXTERNCPP FILE *fopen_2dir(char *file, char *mode, char *scratch_dir);

--- a/Source/shared/getdata.c
+++ b/Source/shared/getdata.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #ifdef WIN32
 #include <share.h>
+// #include <windows.h>
 #endif
 #include "dmalloc.h"
 #include "datadefs.h"
@@ -30,20 +31,6 @@
 _Static_assert(CHAR_BIT == 8, "getdata.c assumes that CHAR_BIT == 8");
 _Static_assert(sizeof(float) == 4, "getdata.c assumes that float is 4 bytes");
 #endif
-#endif
-
-/* ------------------ FOPEN  ------------------------ */
-
-#ifdef WIN32
-FILE* FOPEN(const char* file, const char* mode){
-  FILE* stream;
-  stream = _fsopen(file, mode, _SH_DENYNO);
-  return stream;
-}
-#else
-FILE* FOPEN(const char* file, const char* mode){
-  return fopen(file, mode);
-}
 #endif
 
 //  ------------------ fortread ------------------------

--- a/Source/smokeview/renderimage.c
+++ b/Source/smokeview/renderimage.c
@@ -1179,7 +1179,7 @@ int SmokeviewImage2File(char *directory, char *RENDERfilename, int rendertype, i
     fprintf(stderr,"*** Error: unable to render screen image to %s", RENDERfilename);
     return 1;
   }
-  RENDERfile = fopen(renderfile, "wb");
+  RENDERfile = FOPEN(renderfile, "wb");
   if(RENDERfile == NULL){
     fprintf(stderr,"*** Error: unable to render screen image to %s", renderfile);
     return 1;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -63,6 +63,10 @@ target_link_libraries(mem_test PRIVATE libsmv)
 add_executable(test_root_dir test_root_dir.c)
 target_link_libraries(test_root_dir PRIVATE libsmv)
 
+# test_unicode_paths
+add_executable(test_unicode_paths unicode_paths.c)
+target_link_libraries(test_unicode_paths PRIVATE libsmv)
+
 # sort_surfs
 add_executable(sort_surfs sort_surfs.c)
 target_link_libraries(sort_surfs PRIVATE libsmv)
@@ -122,6 +126,9 @@ add_test(NAME "Mem Test"
 
 add_test(NAME "Test Root Dir"
     COMMAND test_root_dir)
+
+add_test(NAME "Test Unicode Paths"
+    COMMAND test_unicode_paths ${CMAKE_SOURCE_DIR}/Tests/unicode_test_files)
 
 add_test(NAME "Sort Surfs"
     COMMAND sort_surfs)

--- a/Tests/parse_simple_bndf.c
+++ b/Tests/parse_simple_bndf.c
@@ -5,6 +5,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
 int main(int argc, char **argv) {
   initMALLOC();
   if (argc < 3) return 2;

--- a/Tests/parse_simple_part.c
+++ b/Tests/parse_simple_part.c
@@ -5,6 +5,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
 int main(int argc, char **argv) {
   initMALLOC();
   if (argc < 3) return 2;

--- a/Tests/parse_simple_pl3d.c
+++ b/Tests/parse_simple_pl3d.c
@@ -5,6 +5,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
 // TODO: This is an additional function to aid in testing. This should be
 // replaced by a better file IO API.
 int get_pl3d_spec(const char *filename, int npts[3]) {

--- a/Tests/parse_simple_slice.c
+++ b/Tests/parse_simple_slice.c
@@ -4,6 +4,11 @@
 #include "dmalloc.h"
 #include <stdlib.h>
 
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
 int main(int argc, char **argv) {
   initMALLOC();
   FILE *file;

--- a/Tests/unicode_paths.c
+++ b/Tests/unicode_paths.c
@@ -1,0 +1,92 @@
+#include "options.h"
+
+#include "getdata.h"
+
+#include "dmalloc.h"
+
+#include "file_util.h"
+#include "string_util.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
+static char *test_file_name_unicode = "test_файл_O’S.txt";
+static char *test_file_name_unicode_new = "test_файл_O’S_new.txt";
+static char *test_file_content_unicode = "test_file_content_unicode";
+
+static char *test_file_name_ascii = "test_ascii.txt";
+static char *test_file_content_ascii = "test_file_content_ascii";
+
+int WriteTo(const char *path, const char *content) {
+  FILE *stream = FOPEN(path, "wb");
+  if(stream == NULL) {
+    fprintf(stderr, "failed to open file\n");
+    return 1;
+  }
+  int l = strlen(content);
+  int n_written = fwrite(content, 1, l, stream);
+  if(l != n_written) {
+    perror("Error writing file");
+    fprintf(stderr, "failed to write file\n");
+    return 2;
+  }
+  return fclose(stream);
+}
+
+int ReadFrom(const char *path, const char *expected) {
+  FILE *stream = FOPEN(path, "rb");
+  if(stream == NULL) {
+    fprintf(stderr, "failed to open file\n");
+    return 1;
+  }
+  char buf[256];
+  char *b = fgets(buf, 256, stream);
+  if(b == NULL) {
+    perror("Error reading file");
+    fprintf(stderr, "failed to read file\n");
+    return 2;
+  }
+  TrimBack(b);
+  if(strcmp(b, expected) != 0) {
+    fprintf(stderr,
+            "file content doesn't match\n   found: \"%s\"\nexpected: \"%s\"\n",
+            b, expected);
+    return 3;
+  }
+  return fclose(stream);
+}
+
+int main(int argc, char **argv) {
+  int err = 0;
+  initMALLOC();
+  char *test_file_dir = argv[1];
+  {
+    // Test reading of existing unicode file
+    char *path = CombinePaths(test_file_dir, test_file_name_unicode);
+    err = ReadFrom(path, test_file_content_unicode);
+    if(err) return err;
+  }
+  {
+    char *path = CombinePaths(".", test_file_name_unicode_new);
+    // Test creation of new unicode file
+    err = WriteTo(path, test_file_content_unicode);
+    if(err) return err;
+    // Test reading of new unicode file
+    err = ReadFrom(path, test_file_content_unicode);
+    if(err) return err;
+    err = UNLINK(path);
+    if(err) return err;
+  }
+  {
+    // Test reading of existing ascii file
+    char *path = CombinePaths(test_file_dir, test_file_name_ascii);
+    err = ReadFrom(path, test_file_content_ascii);
+    if(err) return err;
+  }
+  return err;
+}

--- a/Tests/unicode_test_files/test_ascii.txt
+++ b/Tests/unicode_test_files/test_ascii.txt
@@ -1,0 +1,1 @@
+test_file_content_ascii

--- a/Tests/unicode_test_files/test_файл_O’S.txt
+++ b/Tests/unicode_test_files/test_файл_O’S.txt
@@ -1,0 +1,1 @@
+test_file_content_unicode


### PR DESCRIPTION
On linux paths are bytestrings and UTF-8 is supported transparently. On Windows, Unicode paths are a superset of UTF-16. This means that Smokeview can have issues opening files and directories with non-ASCII characters in their path.

This adds a conversion function from UTF-8 to UTF-16 and includes it in the FOPEN, UNLINK, and MKDIR functions. It also uses the functions in a few extra places.

This also adds tests to verify that this works correctly.