### PR TITLE
remove overflow and fixed bufffer in Writable()

### DIFF
--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -391,7 +391,7 @@ int Writable(char *dir){
     char tempfile[tempfile_length+1];
     RandStr(tempfile, tempfile_length);
     char *temp_path = CombinePaths(dir, tempfile);
-    FILE *stream = FOPEN(temp_path, "w");
+    FILE *stream = fopen(temp_path, "w");
     FREEMEMORY(temp_path);
     if(stream == NULL) {
       UNLINK(temp_path);


### PR DESCRIPTION
The `Writable()` function has a fixed length buffer of 100 which can cause a segfault on long directory names. This modifies `Writable()` to use the path functions (e.g. `CombinePaths()`) which don't have this length restriction.