### PR TITLE
smokeview source: only use 'glActiveTexture' when GPU is active, clam…

### DIFF
--- a/Source/smokeview/IOslice.c
+++ b/Source/smokeview/IOslice.c
@@ -30,7 +30,7 @@
     valmin + (valmax-valmin)*(float)sd->slicecomplevel[ IJK_SLICE((i), (j),  (k))]/255.0 \
     )
 
-#define SLICETEXTURE(val) ( (val-valmin)/(valmax-valmin) )
+#define SLICETEXTURE(val) ( CLAMP((val-valmin)/(valmax-valmin),0.001,0.999) )
 
 #define SLICECOLOR(cell_index) \
     (sd->compression_type==UNCOMPRESSED ? \

--- a/Source/smokeview/getdatacolors.c
+++ b/Source/smokeview/getdatacolors.c
@@ -924,11 +924,13 @@ void UpdateTexturebar(void){
   glTexImage1D(GL_TEXTURE_1D,0,GL_RGBA,256,0,GL_RGBA,GL_FLOAT,rgb_iso);
   SNIFF_ERRORS("UpdateTexturebar - glTexImage1D (rgb_iso) ");
 
-  glActiveTexture(GL_TEXTURE2);
-  glBindTexture(GL_TEXTURE_1D, slicesmoke_colormap_id);
-  glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, MAXSMOKERGB, 0, GL_RGBA, GL_FLOAT, rgb_slicesmokecolormap_01);
-  SNIFF_ERRORS("UpdateTexturebar - glTexImage1D (rgb_slicesmokecolormap_01)");
-  glActiveTexture(GL_TEXTURE0);
+  if(gpuactive == 1){
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_1D, slicesmoke_colormap_id);
+    glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA, MAXSMOKERGB, 0, GL_RGBA, GL_FLOAT, rgb_slicesmokecolormap_01);
+    SNIFF_ERRORS("UpdateTexturebar - glTexImage1D (rgb_slicesmokecolormap_01)");
+    glActiveTexture(GL_TEXTURE0);
+  }
 
   glBindTexture(GL_TEXTURE_1D,volsmoke_colormap_id);
   glTexImage1D(GL_TEXTURE_1D,0,GL_RGBA,MAXSMOKERGB,0,GL_RGBA,GL_FLOAT,rgb_volsmokecolormap);

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -363,18 +363,20 @@ void InitTextures0(void){
 #endif
   glTexImage1D(GL_TEXTURE_1D,0,GL_RGBA,MAXSMOKERGB,0,GL_RGBA,GL_FLOAT,rgb_volsmokecolormap);
 
-  glActiveTexture(GL_TEXTURE2);
-  glGenTextures(1, &slicesmoke_colormap_id);
-  glBindTexture(GL_TEXTURE_1D,slicesmoke_colormap_id);
-  glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  if(gpuactive == 1){
+    glActiveTexture(GL_TEXTURE2);
+    glGenTextures(1, &slicesmoke_colormap_id);
+    glBindTexture(GL_TEXTURE_1D,slicesmoke_colormap_id);
+    glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 #ifdef pp_GPU
-  glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 #else
-  glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+    glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_WRAP_S, GL_CLAMP);
 #endif
-  glTexImage1D(GL_TEXTURE_1D,0,GL_RGBA,MAXSMOKERGB,0,GL_RGBA,GL_FLOAT,rgb_slicesmokecolormap_01);
-  glActiveTexture(GL_TEXTURE0);
+    glTexImage1D(GL_TEXTURE_1D,0,GL_RGBA,MAXSMOKERGB,0,GL_RGBA,GL_FLOAT,rgb_slicesmokecolormap_01);
+    glActiveTexture(GL_TEXTURE0);
+  }
 
   PRINT_TIMER(texture_timer, "texture setup");
   CheckMemory;


### PR DESCRIPTION
…p slice texture values to 0.001 to 0.999 - addresses smokeview issue 2397