### PR TITLE
use FOPEN et al instead of fopen et al

### DIFF
--- a/Source/background/main.c
+++ b/Source/background/main.c
@@ -223,7 +223,7 @@ int main(int argc, char **argv){
 #ifdef pp_LINUX
   nhostinfo=0;
   if(hostlistfile!=NULL){
-    stream=fopen(hostlistfile,"r");
+    stream=FOPEN(hostlistfile,"r");
   }
   if(hostlistfile!=NULL&&stream!=NULL){
     char buffer[255];
@@ -379,7 +379,7 @@ int getnprocs(char *command){
 
   system("tasklist > process.out");
 
-  stream = fopen("process.out","r");
+  stream = FOPEN("process.out","r");
   if(stream==NULL)return 0;
 
   strcpy(com_copy, command);
@@ -489,7 +489,7 @@ void get_sysctl(char *host, char *var, int *ivar, float *fvar){
   strcat(command,sysctl_file);
   system(command);
 
-  stream=fopen(sysctl_file,"r");
+  stream=FOPEN(sysctl_file,"r");
   if(stream!=NULL){
     char buffer[255];
 
@@ -553,7 +553,7 @@ int get_ncores(void){
   int ncores=0;
   char buffer[255];
 
-  stream=fopen("/proc/cpuinfo","r");
+  stream=FOPEN("/proc/cpuinfo","r");
   if(stream==NULL)return 1;
   while(!feof(stream)){
     if(fgets(buffer,255,stream)==NULL)break;
@@ -587,7 +587,7 @@ int get_host_ncores(char *hosta){
 
   system(command);
 
-  stream=fopen(localfile,"r");
+  stream=FOPEN(localfile,"r");
   if(stream==NULL){
     printf("unable to open %s\n",localfile);
     return 1;
@@ -628,7 +628,7 @@ float get_host_load(char *host_arg){
 
   system(command);
 
-  stream=fopen(localfile,"r");
+  stream=FOPEN(localfile,"r");
   if(stream==NULL)return 1.0;
   if(fgets(buffer,255,stream)==NULL){
     fclose(stream);
@@ -647,7 +647,7 @@ float get_load(void){
   char buffer[255];
   float load1;
 
-  stream=fopen("/proc/loadavg","r");
+  stream=FOPEN("/proc/loadavg","r");
   if(stream==NULL)return 1.0;
   if(fgets(buffer,255,stream)==NULL){
     fclose(stream);

--- a/Source/env2mod/env2mod.c
+++ b/Source/env2mod/env2mod.c
@@ -94,10 +94,10 @@ int CreateModule(char *left_file, char* right_file, char *module_file){
   if(right_file == NULL || strlen(right_file) == 0)return -1;
   if(module_file == NULL || strlen(module_file) == 0)return -1;
 
-  stream_left = fopen(left_file, "r");
+  stream_left = FOPEN(left_file, "r");
   if(stream_left == NULL)return -1;
 
-  stream_right = fopen(right_file, "r");
+  stream_right = FOPEN(right_file, "r");
   if(stream_right == NULL){
     fclose(stream_left);
     return -1;
@@ -107,7 +107,7 @@ int CreateModule(char *left_file, char* right_file, char *module_file){
     stream_module = stdout;
   }
   else{
-    stream_module = fopen(module_file, "w");
+    stream_module = FOPEN(module_file, "w");
   }
   if(stream_module==NULL){
     fclose(stream_left);
@@ -261,10 +261,10 @@ int CreateScript(char *left_file, char* right_file, char *module_file){
   if(right_file == NULL || strlen(right_file) == 0)return -1;
   if(module_file == NULL || strlen(module_file) == 0)return -1;
 
-  stream_left = fopen(left_file, "r");
+  stream_left = FOPEN(left_file, "r");
   if(stream_left == NULL)return -1;
 
-  stream_right = fopen(right_file, "r");
+  stream_right = FOPEN(right_file, "r");
   if(stream_right == NULL){
     fclose(stream_left);
     return -1;
@@ -274,7 +274,7 @@ int CreateScript(char *left_file, char* right_file, char *module_file){
     stream_module = stdout;
   }
   else{
-    stream_module = fopen(module_file, "w");
+    stream_module = FOPEN(module_file, "w");
   }
   if(stream_module==NULL){
     fclose(stream_left);

--- a/Source/fds2fed/fds2fed.c
+++ b/Source/fds2fed/fds2fed.c
@@ -16,7 +16,7 @@ int ReadSMV(char *smvfile){
 #define BUFFERSIZE 255
   char buffer[BUFFERSIZE];
 
-  stream=fopen(smvfile,"r");
+  stream=FOPEN(smvfile,"r");
   if(stream==NULL){
     PRINTF("The file: %s could not be opened\n",smvfile);
     return 1;
@@ -309,7 +309,7 @@ void MakeFEDSmv(char *file){
   FILE *stream;
 
   if(nfedinfo == 0||fedinfo==NULL)return;
-  stream = fopen(file, "w");
+  stream = FOPEN(file, "w");
   if(stream == NULL)return;
 
   nfedisos = 0;
@@ -373,8 +373,8 @@ void GetSliceInfo(slicedata *slicei){
   int ijk[6];
   int ip1, ip2, jp1, jp2, kp1, kp2;
   int nxsp, nysp, nzsp;
-  
-  stream = fopen(slicei->file, "rb");
+
+  stream = FOPEN(slicei->file, "rb");
   if(stream == NULL)return;
 
   headersize = 3*(4+30+4);
@@ -422,7 +422,7 @@ void ReadSlice(slicedata *slicei){
   FREEMEMORY(slicei->vals);
   FREEMEMORY(slicei->times);
   GetSliceInfo(slicei);
-  STREAM = fopen(slicei->file, "rb");
+  STREAM = FOPEN(slicei->file, "rb");
   if(STREAM == NULL)return;
   FSEEK(STREAM, slicei->headersize, SEEK_CUR);
   for(i = 0; i < slicei->nframes; i++){
@@ -452,7 +452,7 @@ void FreeFEDData(feddata *fedi){
 /* ------------------ OutputFEDSlice ------------------------ */
 
 void OutputFEDSlice(feddata *fedi){
-  writeslicedata(fedi->sf_file, 
+  writeslicedata(fedi->sf_file,
     fedi->fed->is1, fedi->fed->is2,
     fedi->fed->js1, fedi->fed->js2,
     fedi->fed->ks1, fedi->fed->ks2,
@@ -575,7 +575,7 @@ void MakeFEDSlice(feddata *fedi){
     }
     FILE *stream;
 
-    stream = fopen(fedi->bndfile, "w");
+    stream = FOPEN(fedi->bndfile, "w");
     fprintf(stream, "%f %f %f\n", 0.0, valmin, valmax);
     OutputFEDSlice(fedi);
   }

--- a/Source/set_path/main.c
+++ b/Source/set_path/main.c
@@ -45,12 +45,12 @@ void backup_path(char *path_type_local, char *pathbuffer){
     else{
       sprintf(file,"%s_%03i.txt",filebase,i);
     }
-    stream=fopen(file,"r");
+    stream=FOPEN(file,"r");
     if(stream==NULL)break;
     fclose(stream);
   }
 
-  stream=fopen(file,"w");
+  stream=FOPEN(file,"w");
   if(stream!=NULL){
     fprintf(stream,"%s Path\n",path_type_local);
     fprintf(stream,"%s\n",pathbuffer);

--- a/Source/sh2bat/sh2bat.c
+++ b/Source/sh2bat/sh2bat.c
@@ -76,8 +76,8 @@ int main(int argc, char **argv){
     Usage(HELP_ALL);
     exit(1);
   }
-  streamin=fopen(filein,"r");
-  streamout=fopen(fileout,"w");
+  streamin=FOPEN(filein,"r");
+  streamout=FOPEN(fileout,"w");
 
   if(streamin==NULL||streamout==NULL){
     if(streamin==NULL){

--- a/Source/shared/colorbars.c
+++ b/Source/shared/colorbars.c
@@ -496,7 +496,7 @@ int ReadCSVColorbar(colorbardata *colorbar, const char *filepath,
   int have_name = 0;
 
   // Open the file
-  FILE *stream = fopen(filepath, "r");
+  FILE *stream = FOPEN(filepath, "r");
   if(stream == NULL) return 1;
   if(fgets(buffer, 255, stream) == NULL){
     fclose(stream);

--- a/Source/shared/file_util.h
+++ b/Source/shared/file_util.h
@@ -68,12 +68,6 @@ typedef struct {
 // vvvvvvvvvvvvvvvvvvvvvvvv preprocessing directives
 // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 
-#ifdef WIN32
-#define UNLINK _unlink
-#else
-#define UNLINK unlink
-#endif
-
 #ifdef X64
 #define FSEEK(a, b, c) _fseeki64(a, b, c)
 #define FTELL(a) _ftelli64(a)
@@ -108,22 +102,28 @@ typedef struct {
 
 #define BFILE bufferstreamdata
 
+#ifdef X64
+  #ifdef WIN32
+    #define LINT __int64
+  #else
+    #define LINT long long int
+  #endif
+#else
+  #define LINT long int
+#endif
+
+#ifdef X64
+  #define STRUCTSTAT struct __stat64
+#else
+  #define STRUCTSTAT struct stat
+#endif
+
 #define FILE_EXISTS(a) FileExists(a, NULL, 0, NULL, 0)
 int FileExistsOrig(char *filename);
 
 #ifdef WIN32
-#define MKDIR(a) CreateDirectory(a, NULL)
-#else
-#define MKDIR(a)                                                               \
-  mkdir(a, S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
-#endif
-
-#ifdef WIN32
-#define ACCESS _access
 #define F_OK 0
 #define W_OK 2
-#else
-#define ACCESS access
 #endif
 
 #ifndef NO
@@ -135,11 +135,9 @@ int FileExistsOrig(char *filename);
 #endif
 
 #ifdef WIN32
-#define CHDIR _chdir
 #define GETCWD _getcwd
 #define SEP '\\'
 #else
-#define CHDIR chdir
 #define GETCWD getcwd
 #define SEP '/'
 #endif
@@ -154,6 +152,11 @@ EXTERNCPP bufferdata *File2Buffer(char *file, char *size_file, int *options, buf
 EXTERNCPP FILE_SIZE fread_p(char *file, unsigned char *buffer, FILE_SIZE offset, FILE_SIZE nchars, int nthreads);
 EXTERNCPP void FileErase(char *file);
 EXTERNCPP FILE *FOPEN(const char *file, const char *mode);
+EXTERNCPP int MKDIR(const char *file);
+EXTERNCPP int ACCESS(const char *file, int mode);
+EXTERNCPP int STAT(const char *file, STRUCTSTAT *buffer);
+EXTERNCPP int CHDIR(const char *file);
+EXTERNCPP int UNLINK(const char *file);
 EXTERNCPP FILE *fopen_indir(char *dir, char *file, char *mode);
 EXTERNCPP FILE *fopen_2dir_scratch(char *file, char *mode);
 EXTERNCPP FILE *fopen_2dir(char *file, char *mode, char *scratch_dir);

--- a/Source/shared/getdata.c
+++ b/Source/shared/getdata.c
@@ -32,20 +32,6 @@ _Static_assert(sizeof(float) == 4, "getdata.c assumes that float is 4 bytes");
 #endif
 #endif
 
-/* ------------------ FOPEN  ------------------------ */
-
-#ifdef WIN32
-FILE* FOPEN(const char* file, const char* mode){
-  FILE* stream;
-  stream = _fsopen(file, mode, _SH_DENYNO);
-  return stream;
-}
-#else
-FILE* FOPEN(const char* file, const char* mode){
-  return fopen(file, mode);
-}
-#endif
-
 //  ------------------ fortread ------------------------
 
 int fortread(void *ptr, size_t size, size_t count, FILE *file){

--- a/Source/shared/isobox.c
+++ b/Source/shared/isobox.c
@@ -15,6 +15,7 @@
 #define IN_ISOBOX
 #include "isobox.h"
 #include "datadefs.h"
+#include "file_util.h"
 
 #define GAS 1
 #define SOLID 0
@@ -1663,7 +1664,7 @@ void CCIsoHeader(char *isofile,
 
 
   *error=-1;
-  isostream=fopen(isofile,"wb");
+  isostream=FOPEN(isofile,"wb");
   if(isostream==NULL)return;
 
   len[0]=strlen(isolonglabel)+1;
@@ -1695,7 +1696,7 @@ void CCTIsoHeader(char *isofile,
 
 
   *error=-1;
-  isostream=fopen(isofile,"wb");
+  isostream=FOPEN(isofile,"wb");
   if(isostream==NULL)return;
 
   len[0]=strlen(isolonglabel)+1;
@@ -1789,7 +1790,7 @@ void CCIsoSurface2File(char *isofile, float *t, float *data, char *iblank,
   FILE *isostream=NULL;
 
   PrintMemoryInfo;
-  isostream = fopen(isofile, "ab");
+  isostream = FOPEN(isofile, "ab");
   *error=-1;
   if(isostream==NULL)return;
   *error = 0;
@@ -1846,7 +1847,7 @@ void CCIsoSurfaceT2File(char *isofile, float *t, float *data, int *data2flag, fl
 
 
   PrintMemoryInfo;
-  isostream = fopen(isofile, "ab");
+  isostream = FOPEN(isofile, "ab");
   *error=-1;
   if(isostream==NULL)return;
   *error = 0;

--- a/Source/shared/options_common.h
+++ b/Source/shared/options_common.h
@@ -95,22 +95,6 @@
 
 #define FILE_SIZE unsigned long long
 
-#ifdef X64
-  #define STRUCTSTAT struct __stat64
-  #define STAT _stat64
-
-  #ifdef WIN32
-    #define LINT __int64
-  #else
-    #define LINT long long int
-  #endif
-#else
-  #define STRUCTSTAT struct stat
-  #define STAT stat
-
-  #define LINT long int
-#endif
-
 #ifdef CPP
 #define CCC "C"
 #define EXTERNCPP extern "C"

--- a/Source/shared/readcad.c
+++ b/Source/shared/readcad.c
@@ -107,7 +107,7 @@ void ReadCAD2Geom(cadgeomdata *cd, GLfloat block_shininess) {
   int iquad;
   int have_textures = 0;
 
-  if((stream = fopen(cd->file, "r")) == NULL) {
+  if((stream = FOPEN(cd->file, "r")) == NULL) {
     return;
   }
 
@@ -320,7 +320,7 @@ int ReadCADGeom(cadgeomdata *cd, const char *file, GLfloat block_shininess) {
   if(NewMemory((void **)&cd->file, (unsigned int)(strlen(file) + 1)) == 0)
     return 2;
   STRCPY(cd->file, file);
-  stream = fopen(cd->file, "r");
+  stream = FOPEN(cd->file, "r");
   if(stream == NULL) return 1;
 
   if(fgets(buffer, 255, stream) == NULL) {

--- a/Source/shared/readgeom.c
+++ b/Source/shared/readgeom.c
@@ -588,7 +588,7 @@ void ReadGeomFile2(geomdata *geomi){
   int ntris, *tris;
 
   if(geomi->file2 == NULL) return;
-  stream = fopen(geomi->file2, "rb");
+  stream = FOPEN(geomi->file2, "rb");
   if(stream == NULL) return;
   FSEEK(stream, 4, SEEK_CUR);
   fread(&ntris, 4, 1, stream);
@@ -757,7 +757,7 @@ void ReadGeomHeader2(geomdata *geomi, int *ntimes_local){
   // surf_1, ..., surf_ntris
   // texture_1, ..., texture_ntris
 
-  stream = fopen(geomi->file, "rb");
+  stream = FOPEN(geomi->file, "rb");
   if(stream == NULL){
     *ntimes_local = -1;
     return;
@@ -853,7 +853,7 @@ void GetGeomDataHeader(char *file, int *ntimes_local, int *nvals){
   int nt, nv;
   int returncode = 0;
 
-  stream = fopen(file, "r");
+  stream = FOPEN(file, "r");
   if(stream == NULL){
     *ntimes_local = -1;
     return;

--- a/Source/shared/readhvac.c
+++ b/Source/shared/readhvac.c
@@ -595,7 +595,7 @@ int ReadHVACData0(hvacdatacollection *hvaccoll, int flag,
   hvaccoll->hvacnodevalsinfo->loaded = 0;
   if(flag == 1 /*TODO: should be 'UNLOAD'*/) return 2;
 
-  stream = fopen(hvaccoll->hvacductvalsinfo->file, "rb");
+  stream = FOPEN(hvaccoll->hvacductvalsinfo->file, "rb");
   if(stream == NULL) return 3;
 
   FSEEK(stream, 4, SEEK_CUR);

--- a/Source/shared/readimage.c
+++ b/Source/shared/readimage.c
@@ -19,7 +19,7 @@ unsigned char *ReadJPEG(const char *filename,int *width, int *height, int *is_tr
   unsigned int intrgb;
   int WIDTH, HEIGHT;
 
-  file = fopen(filename, "rb");
+  file = FOPEN(filename, "rb");
   if(file == NULL)return NULL;
   image = gdImageCreateFromJpeg(file);
   fclose(file);
@@ -64,7 +64,7 @@ unsigned char *ReadPNG(const char *filename,int *width, int *height, int *is_tra
   int i,j;
   unsigned int intrgb;
 
-  file = fopen(filename, "rb");
+  file = FOPEN(filename, "rb");
   if(file == NULL)return NULL;
   image = gdImageCreateFromPng(file);
   fclose(file);
@@ -127,7 +127,7 @@ unsigned char *ReadPicture(char *texturedir, char *filename, int *width, int *he
       strcpy(filebuffer,texturedir);
       strcat(filebuffer,dirseparator);
       strcat(filebuffer,filename);
-      stream=fopen(filebuffer,"rb");
+      stream=FOPEN(filebuffer,"rb");
       if(stream==NULL){
         if(printflag==1){
           fprintf(stderr,"*** Error: texture file: %s unavailable\n",filebuffer);

--- a/Source/shared/readobject.c
+++ b/Source/shared/readobject.c
@@ -1178,7 +1178,7 @@ int ReadObjectDefs(object_collection *objectscoll, const char *file){
   int ndevices = 0;
   int eof = 0;
 
-  stream = fopen(file, "r");
+  stream = FOPEN(file, "r");
   if(stream == NULL) return 0;
 
   firstdef = -1;
@@ -1688,7 +1688,7 @@ int GetNDevices(char *file){
   int buffer_len = BUFFER_LEN, nd = 0;
 
   if(file == NULL) return 0;
-  stream = fopen(file, "r");
+  stream = FOPEN(file, "r");
   if(stream == NULL) return 0;
   fgets(buffer, buffer_len, stream);
   comma = strchr(buffer, ',');

--- a/Source/shared/readslice.c
+++ b/Source/shared/readslice.c
@@ -17,7 +17,7 @@ void GetSliceFileHeader(char *file, int *ip1, int *ip2, int *jp1, int *jp2, int 
   FILE *stream = NULL;
   int vals[6];
 
-  stream = fopen(file, "rb");
+  stream = FOPEN(file, "rb");
   *error = 1;
   *ip1 = 0;
   *ip2 = 0;

--- a/Source/shared/readsmvfile.c
+++ b/Source/shared/readsmvfile.c
@@ -4360,7 +4360,7 @@ void ReadSMVOrig(smv_case *scase){
   FILE *stream=NULL;
 
   char *smv_orig_filename = CasePathSmvOrig(scase);
-  stream = fopen(smv_orig_filename, "r");
+  stream = FOPEN(smv_orig_filename, "r");
   if(stream == NULL) {
     FREEMEMORY(smv_orig_filename);
     return;

--- a/Source/shared/stdio_buffer.c
+++ b/Source/shared/stdio_buffer.c
@@ -216,7 +216,7 @@ FILE_SIZE freadptr_buffer(void **ptr, FILE_SIZE size, FILE_SIZE count, filedata 
 void ReadBufferi(readbufferdata *readbufferi){
   FILE *stream;
 
-  stream = fopen(readbufferi->filename, "rb");
+  stream = FOPEN(readbufferi->filename, "rb");
   if(stream==NULL){
     readbufferi->returnval = 0;
     return;

--- a/Source/shared/stdio_m.c
+++ b/Source/shared/stdio_m.c
@@ -11,7 +11,7 @@
 int GetFileBuffer(char *file, FILE_SIZE offset, unsigned char *buffer, size_t nbuffer){
   FILE *stream = NULL;
 
-  stream = fopen(file, "rb");
+  stream = FOPEN(file, "rb");
   if(stream==NULL)return 0;
   fseek(stream, offset, SEEK_SET);
   fread(buffer, (size_t)1, (size_t)nbuffer, stream);
@@ -46,7 +46,7 @@ FILE_m *fopen_mo(char *file, FILE_SIZE offset, FILE_SIZE size, char *mode){
   stream_m->stream = NULL;
 
   if(strcmp(mode, "rb")==0){    // not mode rbm so use regular IO
-    stream = fopen(file, "rb");
+    stream = FOPEN(file, "rb");
     if(stream==NULL)return NULL;
     stream_m->stream = stream;
     return stream_m;
@@ -56,7 +56,7 @@ FILE_m *fopen_mo(char *file, FILE_SIZE offset, FILE_SIZE size, char *mode){
     nbuffer = size;
   }
   else{
-    stream = fopen(file, "rb");
+    stream = FOPEN(file, "rb");
     if(stream==NULL)return NULL;
     fseek(stream, 0L, SEEK_END);
     nbuffer = FTELL(stream);
@@ -71,7 +71,7 @@ FILE_m *fopen_mo(char *file, FILE_SIZE offset, FILE_SIZE size, char *mode){
   }
 
   if(NewMemory((void **)&buffer, nbuffer)==0){ // allocation of memory buffer failed so revert to regular IO
-    stream = fopen(file, "rb");
+    stream = FOPEN(file, "rb");
     if(stream==NULL)return NULL;
     stream_m->stream = stream;
     return stream_m;
@@ -118,7 +118,7 @@ FILE_m *fopen_b(char *file, unsigned char *buffer, size_t nbuffer, char *mode){
   if(buffer != NULL)stream_m->buffer_end = buffer + nbuffer;
   stream_m->file       = m_file;
   if(buffer == NULL){
-    stream_m->stream = fopen(file, mode);
+    stream_m->stream = FOPEN(file, mode);
     if(stream_m->stream == NULL){
       FREEMEMORY(stream_m);
       FREEMEMORY(m_file);

--- a/Source/shared/string_util.c
+++ b/Source/shared/string_util.c
@@ -1003,7 +1003,7 @@ char *GetChid(char *file, char *buffer){
   int found1st, found2nd;
 
   if(file==NULL)return NULL;
-  stream=fopen(file,"r");
+  stream=FOPEN(file,"r");
   if(stream==NULL)return NULL;
 
   found1st=0;
@@ -1792,7 +1792,7 @@ unsigned char *GetHashSHA1(char *file){
   FILE *stream = NULL;
 
   if(file==NULL)return NULL;
-  stream = fopen(file, "rb");
+  stream = FOPEN(file, "rb");
   if(stream==NULL){
     char *pathentry, fullpath[1024];
 
@@ -1814,7 +1814,7 @@ unsigned char *GetHashSHA1(char *file){
     }
 #endif
 
-    stream = fopen(fullpath, "rb");
+    stream = FOPEN(fullpath, "rb");
     if(stream==NULL)return NULL;
   }
 
@@ -1855,7 +1855,7 @@ unsigned char *GetHashMD5(char *file){
   size_t len_data;
 
   if(file==NULL)return NULL;
-  stream = fopen(file, "rb");
+  stream = FOPEN(file, "rb");
   if(stream == NULL){
     char *pathentry, fullpath[1024];
 
@@ -1877,7 +1877,7 @@ unsigned char *GetHashMD5(char *file){
     }
 #endif
 
-    stream = fopen(fullpath, "rb");
+    stream = FOPEN(fullpath, "rb");
     if(stream == NULL)return NULL;
   }
 
@@ -1909,7 +1909,7 @@ unsigned char *GetHashSHA256(char *file){
   size_t len_data;
 
   if(file==NULL)return NULL;
-  stream = fopen(file, "rb");
+  stream = FOPEN(file, "rb");
   if(stream==NULL){
     char *pathentry, fullpath[1024];
 
@@ -1931,7 +1931,7 @@ unsigned char *GetHashSHA256(char *file){
     }
 #endif
 
-    stream = fopen(fullpath, "rb");
+    stream = FOPEN(fullpath, "rb");
     if(stream==NULL)return NULL;
   }
 

--- a/Source/shared/translate.c
+++ b/Source/shared/translate.c
@@ -50,7 +50,7 @@ int ParseLang(char *file, trdata **trinfoptr, int *ntrinfoptr){
 
   ntrinfo_local=0;
   if(file==NULL)return 0;
-  stream=fopen(file,"r");
+  stream=FOPEN(file,"r");
   if(stream==NULL)return 0;
 
   while(!feof(stream)){
@@ -157,7 +157,7 @@ void InitTranslate(char *bindir, char *tr_name){
     STRCAT(smokeview_lang,lang);
     STRCAT(smokeview_lang,".po");
 
-    stream=fopen(smokeview_lang,"r");
+    stream=FOPEN(smokeview_lang,"r");
     if(stream!=NULL){
       fclose(stream);
       tr_otherlang=1;

--- a/Source/smokediff/IOdboundary.c
+++ b/Source/smokediff/IOdboundary.c
@@ -173,17 +173,17 @@ void DiffBoundarYes(FILE *stream_out){
     NewMemory((void **)&p3k2,npatches3*sizeof(int));
     NewMemory((void **)&patchdir3,npatches3*sizeof(int));
 
-    stream=fopen(fullfile1,"r");
+    stream=FOPEN(fullfile1,"r");
     if(stream==NULL)continue;
     fclose(stream);
 
-    stream=fopen(fullfile2,"r");
+    stream=FOPEN(fullfile2,"r");
     if(stream==NULL)continue;
     fclose(stream);
 
     MakeOutFile(outfile,destdir,file1,".bf");
     if(strlen(outfile)==0)continue;
-    stream=fopen(outfile,"w");
+    stream=FOPEN(outfile,"w");
     if(stream==NULL)continue;
     fclose(stream);
     MakeOutFile(outfile2,NULL,boundary1->file,".bf");

--- a/Source/smokediff/IOdplot.c
+++ b/Source/smokediff/IOdplot.c
@@ -106,17 +106,17 @@ void DiffPlot3Ds(FILE *stream_out){
     FullFile(fullfile1,sourcedir1,file1);
     FullFile(fullfile2,sourcedir2,file2);
 
-    stream=fopen(fullfile1,"r");
+    stream=FOPEN(fullfile1,"r");
     if(stream==NULL)continue;
     fclose(stream);
 
-    stream=fopen(fullfile2,"r");
+    stream=FOPEN(fullfile2,"r");
     if(stream==NULL)continue;
     fclose(stream);
 
     MakeOutFile(outfile,destdir,file1,".q");
     if(strlen(outfile)==0)continue;
-    stream=fopen(outfile,"w");
+    stream=FOPEN(outfile,"w");
     if(stream==NULL)continue;
     fclose(stream);
 

--- a/Source/smokediff/IOdslice.c
+++ b/Source/smokediff/IOdslice.c
@@ -105,11 +105,11 @@ void DiffSlices(FILE *stream_out){
     FullFile(fullfile1,sourcedir1,file1);
     FullFile(fullfile2,sourcedir2,file2);
 
-    stream=fopen(fullfile1,"r");
+    stream=FOPEN(fullfile1,"r");
     if(stream==NULL)continue;
     fclose(stream);
 
-    stream=fopen(fullfile2,"r");
+    stream=FOPEN(fullfile2,"r");
     if(stream==NULL)continue;
     fclose(stream);
 
@@ -118,7 +118,7 @@ void DiffSlices(FILE *stream_out){
     strcpy(outfile_bnd, outfile);
     strcat(outfile_bnd, ".bnd");
 
-    stream=fopen(outfile,"w");
+    stream=FOPEN(outfile,"w");
     if(stream==NULL)continue;
     fclose(stream);
 
@@ -257,7 +257,7 @@ void DiffSlices(FILE *stream_out){
     {
       FILE *stream_bnd=NULL;
 
-      stream_bnd = fopen(outfile_bnd, "w");
+      stream_bnd = FOPEN(outfile_bnd, "w");
       if(stream_bnd!=NULL){
         fprintf(stream_bnd, "%f %f %f", 0.0, valmin, valmax);
         fclose(stream_bnd);

--- a/Source/smokediff/main.c
+++ b/Source/smokediff/main.c
@@ -232,7 +232,7 @@ int main(int argc, char **argv){
     if(destdir!=NULL)strcat(svdlogfile,destdir);
     if(smv1!=NULL)strcat(svdlogfile,smv1);
     strcat(svdlogfile,"_diff.svdlog");
-    LOG_FILENAME=fopen(svdlogfile,"w");
+    LOG_FILENAME=FOPEN(svdlogfile,"w");
     if(LOG_FILENAME!=NULL){
       SetStdOut(LOG_FILENAME);
     }
@@ -248,15 +248,15 @@ int main(int argc, char **argv){
   }
   MakeOutFile(smv_out,destdir,smv1_out,".smv");
 
-  stream_out=fopen(smv_out,"w");
+  stream_out=FOPEN(smv_out,"w");
   if(stream_out==NULL){
     fprintf(stderr,"*** Error The .smv file, %s, could not be opened for output.\n",smv_out);
   }
-  stream_in1=fopen(smoke1,"r");
+  stream_in1=FOPEN(smoke1,"r");
   if(stream_in1==NULL){
     fprintf(stderr,"*** Error The .smv file, %s, could not be opened for input\n",smoke1);
   }
-  stream_in2=fopen(smoke2,"r");
+  stream_in2=FOPEN(smoke2,"r");
   if(stream_in2==NULL){
     fprintf(stderr,"*** Error The .smv file, %s, could not be opened for input.\n",smoke2);
   }

--- a/Source/smokediff/svdiff.h
+++ b/Source/smokediff/svdiff.h
@@ -19,22 +19,6 @@
 #define STDCALLF extern void
 #endif
 
-#ifdef X64
-#ifndef STRUCTSTAT
-#define STRUCTSTAT struct __stat64
-#endif
-#ifndef STAT
-#define STAT _stat64
-#endif
-#else
-#ifndef STRUCTSTAT
-#define STRUCTSTAT struct stat
-#endif
-#ifndef STAT
-#define STAT stat
-#endif
-#endif
-
 #ifndef FILE_SIZE
 #define FILE_SIZE unsigned long long
 #endif

--- a/Source/smokeview/IOboundary.c
+++ b/Source/smokeview/IOboundary.c
@@ -633,7 +633,7 @@ void GetBoundaryHeader(char *file, int *npatches, float *ppatchmin, float *ppatc
   FILE *stream;
   float minmax[2];
 
-  stream = fopen(file, "rb");
+  stream = FOPEN(file, "rb");
 
   if(stream==NULL)return;
 
@@ -679,7 +679,7 @@ void GetBoundaryHeader2(char *file, patchfacedata *patchfaceinfo, int nmeshes_ar
   // compressed size of frame
   // compressed buffer
 
-  stream = fopen(file, "rb");
+  stream = FOPEN(file, "rb");
 
   if(stream==NULL)return;
 
@@ -748,7 +748,7 @@ void GetBoundarySizeInfo(patchdata *patchi, int *nframes, int *buffersize){
     strcpy(sizefile, patchi->size_file);
     strcat(sizefile, ".sz");
 
-    stream = fopen(patchi->file, "rb");
+    stream = FOPEN(patchi->file, "rb");
     if(stream==NULL){
       if(streamsize!=NULL)fclose(streamsize);
       return;
@@ -889,7 +889,7 @@ int GetPatchNTimes(char *file){
   FILE *stream;
 
   if(file == NULL) return 0;
-  stream = fopen(file, "r");
+  stream = FOPEN(file, "r");
   if(stream == NULL) return 0;
 
   int count = 0;
@@ -2005,7 +2005,7 @@ FILE_SIZE ReadBoundaryBndf(int ifile, int load_flag, int *errorcode){
             if(
               vi->imin >= pfi->ib[0] && vi->imax <= pfi->ib[1] &&
               vi->jmin >= pfi->ib[2] && vi->jmax <= pfi->ib[3] &&
-              vi->kmin >= pfi->ib[4] && vi->kmax <= pfi->ib[5] 
+              vi->kmin >= pfi->ib[4] && vi->kmax <= pfi->ib[5]
               ){
               vi->patch_index = n;
             }

--- a/Source/smokeview/IOgeometry.c
+++ b/Source/smokeview/IOgeometry.c
@@ -2019,7 +2019,7 @@ void UpdateTriangles(int flag,int update){
       geomi = geominfoptrs[j];
       if(geomi->geomtype!=GEOM_ISO||geomi->cache_defined==1)continue;
 
-      stream = fopen(geomi->topo_file, "wb");
+      stream = FOPEN(geomi->topo_file, "wb");
       if(stream==NULL)continue;
       for(ii = 0; ii<geomi->ntimes; ii++){
         geomlistdata *geomlisti;
@@ -3241,7 +3241,7 @@ FILE_SIZE ReadGeom2(geomdata *geomi, int load_flag, int type){
 
   ReadGeomHeader(geomi,NULL,&ntimes_local);
   if(ntimes_local<0)return 0;
-  stream = fopen(geomi->file,"rb");
+  stream = FOPEN(geomi->file,"rb");
   if(stream==NULL)return 0;
 
   FSEEK(stream,4,SEEK_CUR);fread(&one,4,1,stream);FSEEK(stream,4,SEEK_CUR);
@@ -4956,7 +4956,7 @@ void ShowHideSortGeometry(int sort_geom, float *mm){
           isurf = tri->geomsurf - global_scase.surfcoll.surfinfo - global_scase.surfcoll.nsurfinfo - 1;
           tri->geomlisti = geomlisti;
           if(
-            (geomi->geomtype==GEOM_ISO&&showlevels != NULL&&showlevels[isurf] == 0) || 
+            (geomi->geomtype==GEOM_ISO&&showlevels != NULL&&showlevels[isurf] == 0) ||
             (tri->geomsurf!=NULL&&tri->geomsurf->transparent_level <= 0.0)
             ){
             continue;

--- a/Source/smokeview/IOiso.c
+++ b/Source/smokeview/IOiso.c
@@ -21,7 +21,7 @@ void GetIsoLevels(const char *isofile, int dataflag, float **levelsptr, float **
   int i;
   float **colorlevels=NULL;
 
-  isostreamptr=fopen(isofile,"rb");
+  isostreamptr=FOPEN(isofile,"rb");
 
   fread(&one,4,1,isostreamptr);
   if(dataflag!=0){
@@ -62,7 +62,7 @@ void GetIsoSizes(const char *isofile, int dataflag, FILE **isostreamptr, int *nv
   int skip_local;
   float ttmin, ttmax;
 
-  *isostreamptr=fopen(isofile,"rb");
+  *isostreamptr=FOPEN(isofile,"rb");
 
   *tmin_local=1000000000.;
   *tmax_local=-1000000000.;
@@ -274,7 +274,7 @@ void OutputIsoBounds(isodata *isoi){
   geomi = isoi->geominfo;
   strcpy(file, geomi->file);
   strcat(file, ".csv");
-  stream = fopen(file, "w");
+  stream = FOPEN(file, "w");
   if(stream == NULL)return;
   if(geomi->ntimes <= 0){
     fclose(stream);

--- a/Source/smokeview/IOobjects.c
+++ b/Source/smokeview/IOobjects.c
@@ -5227,7 +5227,7 @@ void SetupZoneDevs(void){
     if(zonei->csv!=1)continue;
     file = zonei->file;
 
-    stream=fopen(file,"r");
+    stream=FOPEN(file,"r");
     if(stream==NULL)continue;
     buffer_len=GetRowCols(stream,&nrows,&ncols);
     buffer_len += ncols;
@@ -5356,7 +5356,7 @@ FILE_SIZE ReadDeviceData(char *file, int filetype, int loadstatus){
 
   // find number of rows and columns
 
-  stream=fopen(file,"r");
+  stream=FOPEN(file,"r");
   if(stream==NULL)return 0;
   RewindDeviceFile(stream);
   buffer_len=GetRowCols(stream,&nrows,&ncols);

--- a/Source/smokeview/IOpart.c
+++ b/Source/smokeview/IOpart.c
@@ -1050,7 +1050,7 @@ void CreatePartSizeFile(partdata *parti){
   LINT header_offset_local;
   char *smokeview_scratchdir = GetUserConfigDir();
 
-  if(parti->reg_file!=NULL)stream_local = fopen(parti->reg_file, "rb");
+  if(parti->reg_file!=NULL)stream_local = FOPEN(parti->reg_file, "rb");
   if(parti->reg_file==NULL||stream_local==NULL)return;
   fclose(stream_local);
   header_offset_local =GetPartHeaderOffset(parti);

--- a/Source/smokeview/IOscript.c
+++ b/Source/smokeview/IOscript.c
@@ -447,7 +447,7 @@ int CheckScript(char *file){
   int nparams = 0, return_val, reset;
   keyworddata *kw, *kw_last;
 
-  stream = fopen(file, "r");
+  stream = FOPEN(file, "r");
   if(stream == NULL){
     fprintf(stderr, "*** Error: scriptfile, %s, could not be opened for input\n", file);
     return 1;
@@ -728,7 +728,7 @@ int CompileScript(char *scriptfile){
    ************************************************************************
  */
 
-  stream = fopen(scriptfile, "r");
+  stream = FOPEN(scriptfile, "r");
   if(stream == NULL){
     fprintf(stderr, "*** Error: scriptfile, %s, could not be opened for input\n", scriptfile);
     return 1;
@@ -844,7 +844,7 @@ int CompileScript(char *scriptfile){
         SETival;
         scripti->ival = CLAMP(scripti->ival, 0, 5);
         break;
-        
+
 // SMOKEPROP
       case SCRIPT_SMOKEPROP:
         SETfval;
@@ -2374,7 +2374,7 @@ void SetSliceGlobalBounds(char *type){
       slicei = global_scase.slicecoll.sliceinfo+i;
       slice_type = slicei->label.shortlabel;
       if(strcmp(type, slice_type)!=0)continue;
-      stream = fopen(slicei->bound_file, "r");
+      stream = FOPEN(slicei->bound_file, "r");
       if(stream==NULL)continue;
       for(;;){
         char buffer[255];
@@ -3070,7 +3070,7 @@ void ScriptOutputSmokeSensors(void){
     NewMemory((void **)&file_smokesensors,strlen(global_scase.fdsprefix)+17+1);
     strcpy(file_smokesensors,global_scase.fdsprefix);
     strcat(file_smokesensors,"_ss.csv");
-    stream_smokesensors = fopen(file_smokesensors, "w");
+    stream_smokesensors = FOPEN(file_smokesensors, "w");
 
     fprintf(stream_smokesensors, "s,");
     for(i = 1;i < nsmokesensors-1;i++){
@@ -3096,7 +3096,7 @@ void ScriptOutputSmokeSensors(void){
     }
   }
   else{
-    stream_smokesensors = fopen(file_smokesensors, "a");
+    stream_smokesensors = FOPEN(file_smokesensors, "a");
   }
 
   if(global_times!=NULL&&itimes>=0&&itimes<nglobal_times){

--- a/Source/smokeview/IOslice.c
+++ b/Source/smokeview/IOslice.c
@@ -38,7 +38,7 @@
     4*CLAMP(sd->slicecomplevel[cell_index],0,255) \
     )
 
-#define FOPEN_SLICE(a,b)         fopen(a,b)
+#define FOPEN_SLICE(a,b)         FOPEN(a,b)
 #ifdef X64
 #define FSEEK_SLICE(a,b,c)       _fseeki64(a,b,c)
 #define FTELL_SLICE(a)           _ftelli64(a)
@@ -64,12 +64,6 @@ float gslice_valmin, gslice_valmax, *gslicedata;
 meshdata *gslice_valmesh;
 slicedata *gslice_u, *gslice_v, *gslice_w;
 slicedata *gslice;
-
-#ifdef WIN32
-#define FOPEN(file,mode) _fsopen(file,mode,_SH_DENYNO)
-#else
-#define FOPEN(file,mode) fopen(file,mode)
-#endif
 
 #define FORTRLESLICEREAD(var,size) FSEEK(RLESLICEFILE,4,SEEK_CUR);\
                            returncode=fread(var,4,size,RLESLICEFILE);\
@@ -2267,7 +2261,7 @@ void GetSliceParams(sliceparmdata *sp){
     }
     else if(sd->compression_type!=UNCOMPRESSED){
       int return_code;
-      
+
       is1 = 0;is2 = 0;js1 = 0;js2 = 0;ks1 = 0;ks2 = 0;
       error=0;
       return_code = GetSliceHeader0(sd->comp_file,sd->size_file,sd->compression_type,&is1,&is2,&js1,&js2,&ks1,&ks2, &sd->volslice);
@@ -3704,7 +3698,7 @@ int GetNSliceFrames(char *file, float *stime_min, float *stime_max){
   int nframes = (file_size-header_size)/frame_size;
 
   if(*stime_min > *stime_max&&nframes>0){
-    FILE *stream = fopen(file, "rb");
+    FILE *stream = FOPEN(file, "rb");
     if(stream!=NULL){
       fseek(stream, header_size, SEEK_SET);
       fseek(stream, 4, SEEK_CUR); fread(stime_min, sizeof(float), 1, stream); fseek(stream, 4, SEEK_CUR);
@@ -3767,7 +3761,7 @@ void GetSliceTimes(char *file, float *times, int ntimes){
   int i;
   char buffer[256];
 
-  stream = fopen(file, "r");
+  stream = FOPEN(file, "r");
   if(stream == NULL){
     for(i = 0; i<ntimes; i++){
       times[i] = (float)i;
@@ -8691,7 +8685,7 @@ void InitSliceData(void){
     strcat(datafile, "_sf_");
     strcat(datafile, flabel);
     strcat(datafile, ".csv");
-    fileout = fopen(datafile, "w");
+    fileout = FOPEN(datafile, "w");
     if(fileout == NULL)continue;
     fprintf(fileout, "%s\n", sd->label.longlabel);
     fprintf(fileout, "%s\n", sd->label.unit);
@@ -8850,7 +8844,7 @@ void GenerateSliceMenu(int option){
   if(option==1){
     int max1 = 0, max2 = 0, max3 = 0, max4 = 0;
 
-    stream = fopen(slicemenu_filename, "w");
+    stream = FOPEN(slicemenu_filename, "w");
     if(stream==NULL){
       FREEMEMORY(slicemenu_filename);
       return;

--- a/Source/smokeview/IOsmoke.c
+++ b/Source/smokeview/IOsmoke.c
@@ -2877,7 +2877,7 @@ FILE *GetSmokeFileSize(char *smokefile, int fortran_skip, int version){
     printf("          and was not able to create a new size file: %s\n", smoke_sizefilename);
     return NULL;  // can't write size file in temp directory so give up
   }
-  SMOKE3DFILE = fopen(smokefile, "rb");
+  SMOKE3DFILE = FOPEN(smokefile, "rb");
   if(SMOKE3DFILE == NULL){
     fclose(SMOKE_SIZE);
     return NULL;
@@ -3236,10 +3236,10 @@ int GetSmoke3DVersion2(smoke3ddata *smoke3di){
   if(smoke3di->filetype==FORTRAN_GENERATED&&smoke3di->is_zlib==0)fortran_skip = 4;
 
   file = smoke3di->comp_file;
-  if(file!=NULL)SMOKE3D_COMPFILE = fopen(file, "rb");
+  if(file!=NULL)SMOKE3D_COMPFILE = FOPEN(file, "rb");
   if(SMOKE3D_COMPFILE==NULL){
     file = smoke3di->reg_file;
-    SMOKE3D_REGFILE = fopen(file, "rb");
+    SMOKE3D_REGFILE = FOPEN(file, "rb");
   }
   if(SMOKE3D_REGFILE==NULL&&SMOKE3D_COMPFILE==NULL)return -1;
   if(SMOKE3D_COMPFILE!=NULL)SMOKE3DFILE = SMOKE3D_COMPFILE;
@@ -3622,7 +3622,7 @@ FILE_SIZE ReadSmoke3D(int time_frame,int ifile_arg,int load_flag, int first_time
   char *file;
   file = smoke3di->file;
   if(load_smoke_density == 1 && smoke3di->is_smoke_density == 1)file = smoke3di->smoke_density_file;
-  SMOKE3DFILE=fopen(file,"rb");
+  SMOKE3DFILE=FOPEN(file,"rb");
   if(SMOKE3DFILE==NULL){
     SetupSmoke3D(smoke3di,UNLOAD, time_frame, &error_local);
     *errorcode_arg =1;

--- a/Source/smokeview/IOvolsmoke.c
+++ b/Source/smokeview/IOvolsmoke.c
@@ -1259,7 +1259,7 @@ int GetVolsmokeNFrames(volrenderdata *vr){
 
   smokeslice = vr->smokeslice;
   if(load_volcompressed==1&&vr->smokeslice->vol_file!=NULL){
-    volstream = fopen(vr->smokeslice->vol_file, "rb");
+    volstream = FOPEN(vr->smokeslice->vol_file, "rb");
   }
   if(volstream==NULL){
     framesize = smokeslice->nslicei*smokeslice->nslicej*smokeslice->nslicek;
@@ -2612,7 +2612,7 @@ float GetVolsmokeFrameTime(volrenderdata *vr, int framenum){
   skip_local += framenum*(HEADER_SIZE +4        +TRAILER_SIZE); // framenum time's
   skip_local += (LINT)framenum*(LINT)(HEADER_SIZE +4*framesize+TRAILER_SIZE); // framenum slice data's
 
-  SLICEFILE=fopen(smokeslice->reg_file,"rb");
+  SLICEFILE=FOPEN(smokeslice->reg_file,"rb");
   if(SLICEFILE==NULL)return time_local;
 
   FSEEK(SLICEFILE,skip_local,SEEK_SET); // skip from beginning of file
@@ -2629,7 +2629,7 @@ void GetVolsmokeAllTimes(volrenderdata *vr){
   FILE *volstream=NULL;
 
   if(load_volcompressed==1&&vr->smokeslice->vol_file!=NULL){
-    volstream=fopen(vr->smokeslice->vol_file,"rb");
+    volstream=FOPEN(vr->smokeslice->vol_file,"rb");
   }
 
   if(volstream==NULL){
@@ -2662,7 +2662,7 @@ void GetVolsmokeAllTimes(volrenderdata *vr){
 // fire positions
 
     volstream=NULL;
-    if(vr->fireslice->vol_file!=NULL)volstream=fopen(vr->fireslice->vol_file,"rb");
+    if(vr->fireslice->vol_file!=NULL)volstream=FOPEN(vr->fireslice->vol_file,"rb");
     if(volstream!=NULL){
       FSEEK(volstream,12,SEEK_SET);
       for(ii=0;ii<vr->ntimes;ii++){
@@ -2751,7 +2751,7 @@ void ReadVolsmokeFrame(volrenderdata *vr, int framenum, int *first){
   }
 
   if(load_volcompressed==1&&vr->smokeslice->vol_file!=NULL){
-    volstream=fopen(vr->smokeslice->vol_file,"rb");
+    volstream=FOPEN(vr->smokeslice->vol_file,"rb");
   }
 
   skip_local = (HEADER_SIZE + 30 + TRAILER_SIZE); // long label
@@ -2761,7 +2761,7 @@ void ReadVolsmokeFrame(volrenderdata *vr, int framenum, int *first){
   skip_local += framenum * (HEADER_SIZE + 4 + TRAILER_SIZE); // framenum time's
   skip_local += ( LINT )framenum * ( LINT )(HEADER_SIZE + 4 * framesize + TRAILER_SIZE); // framenum slice data's
   if(volstream==NULL){
-    SLICEFILE=fopen(smokeslice->reg_file,"rb");
+    SLICEFILE=FOPEN(smokeslice->reg_file,"rb");
     if(SLICEFILE==NULL)return;
 
     FSEEK(SLICEFILE,skip_local,SEEK_SET); // skip from beginning of file
@@ -2823,10 +2823,10 @@ void ReadVolsmokeFrame(volrenderdata *vr, int framenum, int *first){
 
   if(fireslice!=NULL){
     if(load_volcompressed==1&&vr->fireslice->vol_file!=NULL){
-      volstream=fopen(vr->fireslice->vol_file,"rb");
+      volstream=FOPEN(vr->fireslice->vol_file,"rb");
     }
     if(volstream==NULL){
-      SLICEFILE=fopen(fireslice->reg_file,"rb");
+      SLICEFILE=FOPEN(fireslice->reg_file,"rb");
       if(SLICEFILE!=NULL){
         FSEEK(SLICEFILE,skip_local,SEEK_SET); // skip from beginning of file
 

--- a/Source/smokeview/IOwui.c
+++ b/Source/smokeview/IOwui.c
@@ -1191,7 +1191,7 @@ int GetTerrainData(char *file, terraindata *terri){
 #ifdef _DEBUG
   printf("reading terrain data mesh: %i\n", (int)(terri-global_scase.terraininfo));
 #endif
-  WUIFILE = fopen(file, "rb");
+  WUIFILE = FOPEN(file, "rb");
   if(WUIFILE==NULL)return 1;
 
 //    WRITE(LU_TERRAIN(NM)) REAL(M%ZS-1._EB, FB)
@@ -1804,7 +1804,7 @@ int GetTerrainSize(char *file, float *xmin, float *xmax, int *nx, float *ymin, f
   int nchanges;
   int nt = 0;
 
-  WUIFILE = fopen(file, "rb");
+  WUIFILE = FOPEN(file, "rb");
   if(WUIFILE == NULL)return 1;
 
   FSEEK(WUIFILE, 4, SEEK_CUR);fread(&one, 4, 1, WUIFILE);FSEEK(WUIFILE, 4, SEEK_CUR);

--- a/Source/smokeview/drawGeometry.c
+++ b/Source/smokeview/drawGeometry.c
@@ -5286,7 +5286,7 @@ void GetObstLabels(const char *filein){
   int i;
 
   if(filein==NULL)return;
-  stream_in = fopen(filein,"r");
+  stream_in = FOPEN(filein,"r");
   if(stream_in==NULL)return;
 
   while(!feof(stream_in)){

--- a/Source/smokeview/glui_colorbar.cpp
+++ b/Source/smokeview/glui_colorbar.cpp
@@ -341,7 +341,7 @@ void Colorbar2File(colorbardata *cbi, char *file, char *label){
 
   // values consistent with http://colormine.org/convert/rgb-to-lab
 
-  if(file != NULL && strlen(file) > 0 && label != NULL && strlen(label) > 0)stream = fopen(file, "w");
+  if(file != NULL && strlen(file) > 0 && label != NULL && strlen(label) > 0)stream = FOPEN(file, "w");
   if(stream == NULL)return;
   fprintf(stream, "name,%s\n", label);
   for(i = 0;i < 256;i++){

--- a/Source/smokeview/glui_motion.cpp
+++ b/Source/smokeview/glui_motion.cpp
@@ -225,7 +225,7 @@ void MakeMovieBashScript(void){
     return;
   }
 
-  stream = fopen(movie_bash_script, "w");
+  stream = FOPEN(movie_bash_script, "w");
   if(stream==NULL)return;
 
   fprintf(stream, "#/bin/bash\n");
@@ -285,7 +285,7 @@ void MakeMovieSMVScript(void){
   slicedata *slicei;
   slicemenudata *slicemi;
 
-  stream = fopen(movie_ssf_script, "w");
+  stream = FOPEN(movie_ssf_script, "w");
   if(stream==NULL)return;
   slicemi = slicemenu_sorted[movie_slice_index];
   slicei = slicemi->sliceinfo;

--- a/Source/smokeview/main.c
+++ b/Source/smokeview/main.c
@@ -462,7 +462,7 @@ char *ProcessCommandLine(CommandlineArgs *args){
     }
     if(args->redirect){
       char *log_filename = CasePathLogFile(&global_scase);
-      LOG_FILENAME = fopen(log_filename, "w");
+      LOG_FILENAME = FOPEN(log_filename, "w");
       FREEMEMORY(log_filename);
       if(LOG_FILENAME != NULL){
         redirect = 1;
@@ -591,7 +591,7 @@ int CheckSMVFile(char *file, char *subdir){
   else{
     casedirptr = subdir;
   }
-  stream = fopen(casename, "r");
+  stream = FOPEN(casename, "r");
   if(stream==NULL){
     stream = fopen_indir(casedirptr, casename, "r");
     if(stream==NULL){

--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -2861,7 +2861,7 @@ void ScriptMenu(int value){
       GLUIUpdateScriptStart();
       GetNewScriptFileName(newscriptfilename);
       script_recording = InsertScriptFile(newscriptfilename);
-      scriptoutstream=fopen(newscriptfilename,"w");
+      scriptoutstream=FOPEN(newscriptfilename,"w");
       if(scriptoutstream!=NULL){
         PRINTF("Script recorder on\n");
         script_recording->recording=1;
@@ -3018,7 +3018,7 @@ void MemoryTest(void){
 
     diskread = 0;
     diskwrite = 0;
-    stream = fopen("test.bin", "wb");
+    stream = FOPEN("test.bin", "wb");
     if(stream != NULL){
       diskwrite = 1;
       START_TIMER(diskwrite_timer);
@@ -3027,7 +3027,7 @@ void MemoryTest(void){
       }
       STOP_TIMER(diskwrite_timer);
       fclose(stream);
-      stream = fopen("test.bin", "rb");
+      stream = FOPEN("test.bin", "rb");
       if(stream != NULL){
         diskread = 1;
         START_TIMER(diskread_timer);
@@ -3047,7 +3047,7 @@ void MemoryTest(void){
     }
     if(stream!=NULL){
       fclose(stream);
-      stream = fopen("test.bin", "wb");
+      stream = FOPEN("test.bin", "wb");
       if(stream != NULL){
         fwrite(buffer1, 1, 1, stream);
         fclose(stream);
@@ -3616,7 +3616,7 @@ void LoadUnloadMenu(int value){
     }
     if(redirect==1){
       char *log_filename = CasePathLogFile(&global_scase);
-      LOG_FILENAME=fopen(log_filename,"w");
+      LOG_FILENAME=FOPEN(log_filename,"w");
       FREEMEMORY(log_filename);
       if(LOG_FILENAME==NULL)redirect=0;
     }

--- a/Source/smokeview/output.c
+++ b/Source/smokeview/output.c
@@ -362,7 +362,7 @@ void WriteLabels(labels_collection *labelscoll_arg){
 
   if(event_file_exists==0)return;
   char *event_filename = CasePathEvent(&global_scase);
-  stream = fopen(event_filename, "w");
+  stream = FOPEN(event_filename, "w");
   FREEMEMORY(event_filename);
   if(stream==NULL)return;
 

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -1987,7 +1987,7 @@ int GetViewpoints(char *inifile, char ***viewpointlist_ptr){
   char **viewpointlist;
 
   if(inifile==NULL||strlen(inifile)==0)return 0;
-  stream = fopen(inifile, "r");
+  stream = FOPEN(inifile, "r");
   if(stream==NULL)return 0;
 
   int nviewpoints = 0;
@@ -2096,7 +2096,7 @@ void GenerateViewpointMenu(void){
   if(nviewpoints==0)return;
 
   // if we can't write out to the viewpoint menu file then abort
-  stream = fopen(viewpiontemenu_filename, "w");
+  stream = FOPEN(viewpiontemenu_filename, "w");
   if(stream==NULL)return;
 
   int max1 = 5;
@@ -2129,7 +2129,7 @@ void UpdateEvents(void){
   int i;
 
   char *event_filename = CasePathEvent(&global_scase);
-  stream = fopen(event_filename, "r");
+  stream = FOPEN(event_filename, "r");
   FREEMEMORY(event_filename);
   if(stream==NULL)return;
 
@@ -3304,7 +3304,7 @@ int ReadIni2(const char *inifile, int localfile){
   updatemenu = 1;
   updatefacelists = 1;
 
-  if((stream = fopen(inifile, "r")) == NULL)return 1;
+  if((stream = FOPEN(inifile, "r")) == NULL)return 1;
   if(readini_output==1){
     if(verbose_output==1)PRINTF("reading %s ", inifile);
   }
@@ -3911,11 +3911,11 @@ int ReadIni2(const char *inifile, int localfile){
     }
     if(MatchINI(buffer, "SPHEREARRAY") == 1){
       fgets(buffer, 255, stream);
-      sscanf(buffer, "%f %f %f %f %f %f", 
+      sscanf(buffer, "%f %f %f %f %f %f",
         sphere_xyz0, sphere_xyz0+1, sphere_xyz0+2,
         sphere_dxyz, sphere_dxyz+1, sphere_dxyz+2);
       fgets(buffer, 255, stream);
-      sscanf(buffer, "%i %i %i %i %i %i", 
+      sscanf(buffer, "%i %i %i %i %i %i",
         sphere_nxyz, sphere_nxyz + 1, sphere_nxyz + 2,
         sphere_rgb,  sphere_rgb + 1,  sphere_rgb + 2
         );
@@ -7622,19 +7622,19 @@ void WriteIni(int flag,char *filename){
 
   switch(flag){
   case GLOBAL_INI:
-    if(smokeviewini_filename!=NULL)fileout=fopen(smokeviewini_filename,"w");
+    if(smokeviewini_filename!=NULL)fileout=FOPEN(smokeviewini_filename,"w");
     outfilename= smokeviewini_filename;
     break;
   case STDOUT_INI:
     fileout=stdout;
     break;
   case SCRIPT_INI:
-    fileout=fopen(filename,"w");
+    fileout=FOPEN(filename,"w");
     outfilename=filename;
     break;
   case LOCAL_INI:
   {
-    fileout=fopen(caseini_filename,"w");
+    fileout=FOPEN(caseini_filename,"w");
     if(fileout==NULL&&smokeview_scratchdir!=NULL){
       fileout = fopen_indir(smokeview_scratchdir, caseini_filename, "w");
       outfiledir = smokeview_scratchdir;

--- a/Source/smokeview/renderhtml.c
+++ b/Source/smokeview/renderhtml.c
@@ -1705,7 +1705,7 @@ void OutputFixedFrameData(char *html_file, webgeomdata *webgi ,float *colorbar){
   FILE *stream_out = NULL;
 
   if(webgi->nframes<=0||webgi->nverts<=0||webgi->framesize<=0||webgi->nindices<=0)return;
-  stream_out = fopen(html_file, "w");
+  stream_out = FOPEN(html_file, "w");
   if(stream_out==NULL)return;
 
   fprintf(stream_out, "{\n");
@@ -2025,7 +2025,7 @@ int Obst2Data(char *html_file){
     FREEMEMORY(facesObstLit);
     return 0;
   }
-  stream_out = fopen(html_file, "w");
+  stream_out = FOPEN(html_file, "w");
   if(stream_out==NULL)return 0;
 
   fprintf(stream_out,"{\n");
@@ -2084,7 +2084,7 @@ int Smv2Geom(char *html_file){
   FILE *stream_out;
   int i;
 
-  stream_out = fopen(html_file, "w");
+  stream_out = FOPEN(html_file, "w");
   if(stream_out != NULL){
     GeomLitTriangles2Geom(&vertsGeomLit, &normalsGeomLit, &colorsGeomLit, &nvertsGeomLit, &facesGeomLit, &nfacesGeomLit);
 
@@ -2175,7 +2175,7 @@ int Smv2Html(char *html_file, int option, int from_where){
   webgeomdata slice_node_web, slice_cell_web, slice_geom_web, bndf_node_web, part_node_web;
 
   template_file = GetSmokeviewHtmlPath();
-  stream_in = fopen(template_file, "r");
+  stream_in = FOPEN(template_file, "r");
   if(stream_in==NULL){
     printf("***error: smokeview html template file %s failed to open\n", template_file);
     return 1;
@@ -2194,7 +2194,7 @@ int Smv2Html(char *html_file, int option, int from_where){
       return 1;
     }
   }
-  stream_out = fopen(html_fullfile, "w");
+  stream_out = FOPEN(html_fullfile, "w");
   if(stream_out==NULL){
     printf("***error: html output file %s failed to open for output\n", html_fullfile);
     fclose(stream_in);

--- a/Source/smokeview/renderimage.c
+++ b/Source/smokeview/renderimage.c
@@ -145,7 +145,7 @@ void MakeMovie(void){
         FILE *stream_ffmpeg=NULL;
 
         char *ffmpeg_command_filename = CasePathFfmpegCommand(&global_scase);
-        stream_ffmpeg = fopen(ffmpeg_command_filename,"w");
+        stream_ffmpeg = FOPEN(ffmpeg_command_filename,"w");
         FREEMEMORY(ffmpeg_command_filename);
         if(stream_ffmpeg!=NULL){
 #ifdef WIN32
@@ -442,7 +442,7 @@ void OutputSliceData(void){
     strcat(datafile, "_sf_");
     strcat(datafile, flabel);
     strcat(datafile, ".csv");
-    fileout = fopen(datafile, "a");
+    fileout = FOPEN(datafile, "a");
     if(fileout == NULL)continue;
     if(global_times != NULL)fprintf(fileout, "%f\n", global_times[itimes]);
     switch(sd->idir){
@@ -569,7 +569,7 @@ int MergeRenderScreenBuffers(int nfactor, GLubyte **screenbuffers){
   }
   strcat(renderfullfile,renderfile);
 
-  RENDERfile = fopen(renderfullfile, "wb");
+  RENDERfile = FOPEN(renderfullfile, "wb");
   if(RENDERfile == NULL){
     fprintf(stderr, "*** Error: unable to render screen image to %s", renderfullfile);
     return 1;
@@ -1001,7 +1001,7 @@ int MergeRenderScreenBuffers360(void){
   }
   strcat(renderfullfile,renderfile);
 
-  RENDERfile = fopen(renderfullfile, "wb");
+  RENDERfile = FOPEN(renderfullfile, "wb");
   if(RENDERfile == NULL){
     fprintf(stderr, "*** Error: unable to render screen image to %s", renderfullfile);
     return 1;
@@ -1179,7 +1179,7 @@ int SmokeviewImage2File(char *directory, char *RENDERfilename, int rendertype, i
     fprintf(stderr,"*** Error: unable to render screen image to %s", RENDERfilename);
     return 1;
   }
-  RENDERfile = fopen(renderfile, "wb");
+  RENDERfile = FOPEN(renderfile, "wb");
   if(RENDERfile == NULL){
     fprintf(stderr,"*** Error: unable to render screen image to %s", renderfile);
     return 1;

--- a/Source/smokeview/smokeview.c
+++ b/Source/smokeview/smokeview.c
@@ -187,7 +187,7 @@ void InitVolrenderScript(char *prefix, char *tour_label, int startframe, int ski
 
   sfd = InsertScriptFile(volrender_scriptname);
   if(sfd!=NULL)default_script=sfd;
-  script_stream=fopen(volrender_scriptname,"w");
+  script_stream=FOPEN(volrender_scriptname,"w");
   if(script_stream!=NULL){
     fprintf(script_stream,"RENDERDIR\n");
     fprintf(script_stream," .\n");

--- a/Source/smokeview/startup.c
+++ b/Source/smokeview/startup.c
@@ -211,7 +211,7 @@ int SetupCase(char *filename){
     if(HaveSmoke3D(smv_streaminfo) == 0){
       FILE *stream_smoke3d = NULL;
       char *smoke3d_filename = CasePathSmoke3d(&global_scase);
-      stream_smoke3d = fopen(smoke3d_filename, "w");
+      stream_smoke3d = FOPEN(smoke3d_filename, "w");
       if(stream_smoke3d != NULL){
         fprintf(stream_smoke3d, "SMOKF3D 1 8700.0                                    \n");
         fprintf(stream_smoke3d, " dummy.xyz                                          \n");
@@ -339,7 +339,7 @@ int GetScreenHeight(void){
   FREEMEMORY(smokeview_scratchdir);
   strcat(command,full_height_file);
   system(command);
-  stream = fopen(full_height_file,"r");
+  stream = FOPEN(full_height_file,"r");
   if(stream!=NULL){
     fgets(buffer, 255, stream);
     sscanf(buffer, "%i", &screen_height);

--- a/Source/smokeview/update.c
+++ b/Source/smokeview/update.c
@@ -991,7 +991,7 @@ void ConvertSsf(void){
   char *template = "tempssf";
 
   if(ssf_from==NULL||ssf_to==NULL)return;
-  stream_from = fopen(ssf_from, "r");
+  stream_from = FOPEN(ssf_from, "r");
   if(stream_from==NULL)return;
 
   if(strcmp(ssf_from, ssf_to)==0){
@@ -1000,11 +1000,11 @@ void ConvertSsf(void){
       fclose(stream_from);
       return;
     }
-    stream_to = fopen(tempfile, "w");
+    stream_to = FOPEN(tempfile, "w");
     outeqin = 1;
   }
   else{
-    stream_to = fopen(ssf_to, "w");
+    stream_to = FOPEN(ssf_to, "w");
   }
   if(stream_to==NULL){
     fclose(stream_from);

--- a/Source/smokeview/viewports.c
+++ b/Source/smokeview/viewports.c
@@ -1022,7 +1022,7 @@ void OutputSlicePlot(char *file){
   FILE *stream = NULL;
 
   if(file == NULL||strlen(file)==0)return;
-  stream = fopen(file, "w");
+  stream = FOPEN(file, "w");
   if(stream == NULL){
     printf("***error: %s not able to be opened for writing\n", file);
     return;

--- a/Source/smokezip/CNV3dsmoke.c
+++ b/Source/smokezip/CNV3dsmoke.c
@@ -55,7 +55,7 @@ void Convert3DSmoke(smoke3d *smoke3di, int *thread_index){
     fprintf(stderr,"*** Warning:  %s does not exist\n",smoke3dfile);
     return;
   }
-  SMOKE3DFILE=fopen(smoke3dfile,"rb");
+  SMOKE3DFILE=FOPEN(smoke3dfile,"rb");
   if(SMOKE3DFILE==NULL){
     fprintf(stderr,"*** Warning:  %s could not be opened\n",smoke3dfile);
     return;
@@ -86,7 +86,7 @@ void Convert3DSmoke(smoke3d *smoke3di, int *thread_index){
   // remove files if clean option is set
 
   if(GLOBcleanfiles==1){
-    smoke3dstream=fopen(smoke3dfile_svz,"rb");
+    smoke3dstream=FOPEN(smoke3dfile_svz,"rb");
     if(smoke3dstream!=NULL){
       fclose(smoke3dstream);
       PRINTF("  Removing %s\n",smoke3dfile_svz);
@@ -95,7 +95,7 @@ void Convert3DSmoke(smoke3d *smoke3di, int *thread_index){
       GLOBfilesremoved++;
       UNLOCK_COMPRESS;
     }
-    smoke3dsizestream=fopen(smoke3dsizefile_svz,"r");
+    smoke3dsizestream=FOPEN(smoke3dsizefile_svz,"r");
     if(smoke3dsizestream!=NULL){
       fclose(smoke3dsizestream);
       PRINTF("  Removing %s\n",smoke3dsizefile_svz);
@@ -109,7 +109,7 @@ void Convert3DSmoke(smoke3d *smoke3di, int *thread_index){
   }
 
   if(GLOBoverwrite_s==0){
-    smoke3dstream=fopen(smoke3dfile_svz,"rb");
+    smoke3dstream=FOPEN(smoke3dfile_svz,"rb");
     if(smoke3dstream!=NULL){
       fclose(smoke3dstream);
       fprintf(stderr,"*** Warning:  %s exists.\n",smoke3dfile_svz);
@@ -119,8 +119,8 @@ void Convert3DSmoke(smoke3d *smoke3di, int *thread_index){
     }
   }
 
-  smoke3dsizestream=fopen(smoke3dsizefile_svz,"w");
-  smoke3dstream=fopen(smoke3dfile_svz,"wb");
+  smoke3dsizestream=FOPEN(smoke3dsizefile_svz,"w");
+  smoke3dstream=FOPEN(smoke3dfile_svz,"wb");
   if(smoke3dstream==NULL||smoke3dsizestream==NULL
     ){
     if(smoke3dstream==NULL){

--- a/Source/smokezip/CNVboundary.c
+++ b/Source/smokezip/CNVboundary.c
@@ -35,7 +35,7 @@ int CleanBoundary(patchdata *patchi){
   if(strlen(shortlabel)>0)strcat(filetype,shortlabel);
   TrimBack(filetype);
 
-  BOUNDARYFILE=fopen(boundary_file,"rb");
+  BOUNDARYFILE=FOPEN(boundary_file,"rb");
   if(BOUNDARYFILE==NULL){
     return 0;
   }
@@ -61,7 +61,7 @@ int CleanBoundary(patchdata *patchi){
   }
   strcat(boundarysizefile_svz,".szz");
 
-  boundarystream=fopen(boundaryfile_svz,"rb");
+  boundarystream=FOPEN(boundaryfile_svz,"rb");
   if(boundarystream!=NULL){
     fclose(boundarystream);
     PRINTF("  Removing %s\n",boundaryfile_svz);
@@ -70,7 +70,7 @@ int CleanBoundary(patchdata *patchi){
     GLOBfilesremoved++;
     UNLOCK_COMPRESS;
   }
-  boundarysizestream=fopen(boundarysizefile_svz,"rb");
+  boundarysizestream=FOPEN(boundarysizefile_svz,"rb");
   if(boundarysizestream!=NULL){
     fclose(boundarysizestream);
     PRINTF("  Removing %s\n",boundarysizefile_svz);
@@ -119,7 +119,7 @@ int ConvertBoundaryGEOM(patchdata *patchi, int *thread_index){
     return 0;
   }
 
-  BOUNDARYFILE = fopen(boundary_file, "rb");
+  BOUNDARYFILE = FOPEN(boundary_file, "rb");
   if(BOUNDARYFILE == NULL){
     fprintf(stderr, "*** Warning: The file %s could not be opened\n", boundary_file);
     return 0;
@@ -146,7 +146,7 @@ int ConvertBoundaryGEOM(patchdata *patchi, int *thread_index){
   strcat(boundarysizefile_svz, ".szz");
 
   if(GLOBoverwrite_b == 0){
-    boundarystream = fopen(boundaryfile_svz, "rb");
+    boundarystream = FOPEN(boundaryfile_svz, "rb");
     if(boundarystream != NULL){
       if(boundarystream != NULL){
         fclose(boundarystream);
@@ -158,8 +158,8 @@ int ConvertBoundaryGEOM(patchdata *patchi, int *thread_index){
     }
   }
 
-  boundarystream = fopen(boundaryfile_svz, "wb");
-  boundarysizestream = fopen(boundarysizefile_svz, "w");
+  boundarystream = FOPEN(boundaryfile_svz, "wb");
+  boundarysizestream = FOPEN(boundarysizefile_svz, "w");
   if(boundarystream == NULL || boundarysizestream == NULL){
     if(boundarystream == NULL){
       fprintf(stderr, "*** Warning: The file %s could not be opened for writing\n", boundaryfile_svz);
@@ -250,7 +250,7 @@ int ConvertBoundaryGEOM(patchdata *patchi, int *thread_index){
     PRINTF(" ");
 #endif
     int MAXVALS = 0;
-    int MAXCOMPRESSEDVALS;    
+    int MAXCOMPRESSEDVALS;
     while(feof(BOUNDARYFILE) == 0){
       int nvals[4], offset[4];
 
@@ -415,7 +415,7 @@ int ConvertBoundaryBNDF(patchdata *patchi, int *thread_index){
     return 0;
   }
 
-  BOUNDARYFILE=fopen(boundary_file,"rb");
+  BOUNDARYFILE=FOPEN(boundary_file,"rb");
   if(BOUNDARYFILE==NULL){
     fprintf(stderr,"*** Warning: The file %s could not be opened\n",boundary_file);
     return 0;
@@ -442,8 +442,8 @@ int ConvertBoundaryBNDF(patchdata *patchi, int *thread_index){
   strcat(boundarysizefile_svz,".szz");
 
   if(GLOBoverwrite_b==0){
-    boundarystream=fopen(boundaryfile_svz,"rb");
-    boundarysizestream=fopen(boundarysizefile_svz,"r");
+    boundarystream=FOPEN(boundaryfile_svz,"rb");
+    boundarysizestream=FOPEN(boundarysizefile_svz,"r");
     if(boundarystream!=NULL||boundarysizestream!=NULL){
       if(boundarystream!=NULL){
         fclose(boundarystream);
@@ -455,8 +455,8 @@ int ConvertBoundaryBNDF(patchdata *patchi, int *thread_index){
     }
   }
 
-  boundarystream=fopen(boundaryfile_svz,"wb");
-  boundarysizestream=fopen(boundarysizefile_svz,"w");
+  boundarystream=FOPEN(boundaryfile_svz,"wb");
+  boundarysizestream=FOPEN(boundarysizefile_svz,"w");
   if(boundarystream==NULL||boundarysizestream==NULL){
     if(boundarystream==NULL){
       fprintf(stderr,"*** Warning: The file %s could not be opened for writing\n",boundaryfile_svz);

--- a/Source/smokezip/CNVpart.c
+++ b/Source/smokezip/CNVpart.c
@@ -59,7 +59,7 @@ void *ConvertParts2Iso(void *arg){
       FILE *stream;
       int j;
 
-      stream=fopen(GLOBsmvisofile,"rb");
+      stream=FOPEN(GLOBsmvisofile,"rb");
       if(stream!=NULL){
         fclose(stream);
         PRINTF("  Removing %s\n",GLOBsmvisofile);
@@ -85,7 +85,7 @@ void *ConvertParts2Iso(void *arg){
           strcat(isofilename,labels->shortlabel);
           strcat(isofilename,".tiso");
 
-          stream=fopen(isofilename,"rb");
+          stream=FOPEN(isofilename,"rb");
           if(stream!=NULL){
             fclose(stream);
             PRINTF("  Removing %s\n",isofilename);
@@ -260,10 +260,10 @@ void Part2Iso(part *parti, int *thread_index){
   LOCK_PART2ISO;
   if(GLOBfirst_part2iso_smvopen==1){
     GLOBfirst_part2iso_smvopen=0;
-    SMVISOFILE=fopen(GLOBsmvisofile,"w");
+    SMVISOFILE=FOPEN(GLOBsmvisofile,"w");
   }
   else{
-    SMVISOFILE=fopen(GLOBsmvisofile,"a");
+    SMVISOFILE=FOPEN(GLOBsmvisofile,"a");
   }
 
   fprintf(SMVISOFILE,"ISOF %i\n",blocknumber);
@@ -614,10 +614,10 @@ void Part2Object(part *parti, int *thread_index){
   LOCK_PART2ISO;
   if(GLOBfirst_part2iso_smvopen==1){
     GLOBfirst_part2iso_smvopen=0;
-    SMVISOFILE=fopen(GLOBsmvisofile,"w");
+    SMVISOFILE=FOPEN(GLOBsmvisofile,"w");
   }
   else{
-    SMVISOFILE=fopen(GLOBsmvisofile,"a");
+    SMVISOFILE=FOPEN(GLOBsmvisofile,"a");
   }
 
   fprintf(SMVISOFILE,"ISOF %i\n",blocknumber);

--- a/Source/smokezip/CNVslice.c
+++ b/Source/smokezip/CNVslice.c
@@ -137,7 +137,7 @@ int ConvertVolSlice(slicedata *slicei, int *thread_index){
     return 0;
   }
 
-  SLICEFILE=fopen(slice_file,"rb");
+  SLICEFILE=FOPEN(slice_file,"rb");
   if(SLICEFILE==NULL){
     fprintf(stderr,"*** Warning: The file %s could not be opened\n",slice_file);
     return 0;
@@ -156,7 +156,7 @@ int ConvertVolSlice(slicedata *slicei, int *thread_index){
   if(strlen(slicefile_svz)>4)strcat(slicefile_svz,".svv");
 
   if(GLOBcleanfiles==1){
-    slicestream=fopen(slicefile_svz,"rb");
+    slicestream=FOPEN(slicefile_svz,"rb");
     if(slicestream!=NULL){
       fclose(slicestream);
       PRINTF("  Removing %s\n",slicefile_svz);
@@ -170,7 +170,7 @@ int ConvertVolSlice(slicedata *slicei, int *thread_index){
   }
 
   if(GLOBoverwrite_slice==0){
-    slicestream=fopen(slicefile_svz,"rb");
+    slicestream=FOPEN(slicefile_svz,"rb");
     if(slicestream!=NULL){
       fclose(slicestream);
       fprintf(stderr,"*** Warning: The file %s exists.\n",slicefile_svz);
@@ -180,7 +180,7 @@ int ConvertVolSlice(slicedata *slicei, int *thread_index){
     }
   }
 
-  slicestream=fopen(slicefile_svz,"wb");
+  slicestream=FOPEN(slicefile_svz,"wb");
   if(slicestream==NULL){
     fprintf(stderr,"*** Warning: The file %s could not be opened for writing\n",slicefile_svz);
     fclose(SLICEFILE);
@@ -417,7 +417,7 @@ int ConvertSlice(slicedata *slicei, int *thread_index){
     return 0;
   }
 
-  SLICEFILE=fopen(slice_file,"rb");
+  SLICEFILE=FOPEN(slice_file,"rb");
   if(SLICEFILE==NULL){
     fprintf(stderr,"*** Warning: The file %s could not be opened\n",slice_file);
     return 0;
@@ -430,7 +430,7 @@ int ConvertSlice(slicedata *slicei, int *thread_index){
   MakeSliceFile(slicesizefile_svz, slicei, ".sz");
 
   if(GLOBcleanfiles==1){
-    slicestream=fopen(slicefile_svz,"rb");
+    slicestream=FOPEN(slicefile_svz,"rb");
     if(slicestream!=NULL){
       fclose(slicestream);
       PRINTF("  Removing %s\n",slicefile_svz);
@@ -439,7 +439,7 @@ int ConvertSlice(slicedata *slicei, int *thread_index){
       GLOBfilesremoved++;
       UNLOCK_COMPRESS;
     }
-    slicestream=fopen(slicefile_svv,"rb");
+    slicestream=FOPEN(slicefile_svv,"rb");
     if(slicestream!=NULL){
       fclose(slicestream);
       PRINTF("  Removing %s\n",slicefile_svv);
@@ -448,7 +448,7 @@ int ConvertSlice(slicedata *slicei, int *thread_index){
       GLOBfilesremoved++;
       UNLOCK_COMPRESS;
     }
-    slicesizestream=fopen(slicesizefile_svz,"rb");
+    slicesizestream=FOPEN(slicesizefile_svz,"rb");
     if(slicesizestream!=NULL){
       fclose(slicesizestream);
       PRINTF("  Removing %s\n",slicesizefile_svz);
@@ -462,7 +462,7 @@ int ConvertSlice(slicedata *slicei, int *thread_index){
   }
 
   if(GLOBoverwrite_slice==0){
-    slicestream=fopen(slicefile_svz,"rb");
+    slicestream=FOPEN(slicefile_svz,"rb");
     if(slicestream!=NULL){
       fclose(slicestream);
       fprintf(stderr,"*** Warning:  %s exists.\n",slicefile_svz);
@@ -472,8 +472,8 @@ int ConvertSlice(slicedata *slicei, int *thread_index){
     }
   }
 
-  slicestream=fopen(slicefile_svz,"wb");
-  slicesizestream=fopen(slicesizefile_svz,"w");
+  slicestream=FOPEN(slicefile_svz,"wb");
+  slicesizestream=FOPEN(slicesizefile_svz,"w");
   if(slicestream==NULL||slicesizestream==NULL){
     if(slicestream==NULL){
       fprintf(stderr,"*** Warning: The file %s could not be opened for writing\n",slicefile_svz);
@@ -819,7 +819,7 @@ void GetGlobalSliceBounds(char *label){
 
     slicej = sliceinfo+j;
     if(strcmp(label, slicej->label.shortlabel)!=0)continue;
-    stream = fopen(slicej->boundfile, "r");
+    stream = FOPEN(slicej->boundfile, "r");
     if(stream==NULL)continue;
     while(!feof(stream)){
       char buffer[255];
@@ -927,7 +927,7 @@ void GetSliceParmsC(char *file, int *ni, int *nj, int *nk){
     *nj=0;
     *nk=0;
 
-    stream=fopen(file,"rb");
+    stream=FOPEN(file,"rb");
     if(stream==NULL)return;
 
     skip = 3*(4+30+4);  // skip over 3 records each containing a 30 byte FORTRAN character string

--- a/Source/smokezip/main.c
+++ b/Source/smokezip/main.c
@@ -316,7 +316,7 @@ int main(int argc, char **argv){
       strcat(smzlogfile,filebase);
     }
     strcat(smzlogfile,".smzlog");
-    SMZLOG_STREAM=fopen(smzlogfile,"w");
+    SMZLOG_STREAM=FOPEN(smzlogfile,"w");
     if(SMZLOG_STREAM!=NULL){
       SetStdOut(SMZLOG_STREAM);
     }
@@ -357,7 +357,7 @@ int main(int argc, char **argv){
   else{
     FILE *stream;
 
-    stream = fopen(smvzip_filename, "w");
+    stream = FOPEN(smvzip_filename, "w");
     if(stream!=NULL){
       fprintf(stream, "1\n");
       fclose(stream);

--- a/Source/smokezip/readfiles.c
+++ b/Source/smokezip/readfiles.c
@@ -84,7 +84,7 @@ int ReadSMV(char *smvfile){
   char buffer[BUFFERSIZE];
 
   ipdim=0;
-  stream=fopen(smvfile,"r");
+  stream=FOPEN(smvfile,"r");
   if(stream==NULL){
     PRINTF("The file: %s could not be opened\n",smvfile);
     return 1;
@@ -809,7 +809,7 @@ void ReadINI2(char *inifile){
   char *type_buffer;
   FILE *stream;
 
-  stream=fopen(inifile,"r");
+  stream=FOPEN(inifile,"r");
   if(stream==NULL)return;
 
   while(!feof(stream)){
@@ -901,7 +901,7 @@ void ReadINI2(char *inifile){
       partpropdata *partpropi;
       int type=1;
 
-      
+
       if(Match(buffer,"V2_PARTICLES")==1)type = 1;
       fgets(buffer,BUFFERSIZE,stream);
       strcpy(buffer2,"");

--- a/Source/smokezip/svzip.h
+++ b/Source/smokezip/svzip.h
@@ -38,23 +38,6 @@
 #define GETINDEX(xval,xmin,dx,nx) CLAMP(((xval)-(xmin))/(dx),0,(nx)-1)
 #endif
 
-
-#ifdef X64
-#ifndef STRUCTSTAT
-#define STRUCTSTAT struct __stat64
-#endif
-#ifndef STAT
-#define STAT _stat64
-#endif
-#else
-#ifndef STRUCTSTAT
-#define STRUCTSTAT struct stat
-#endif
-#ifndef STAT
-#define STAT stat
-#endif
-#endif
-
 #ifndef C_FILE
 #define C_FILE 0
 #endif

--- a/Source/smokezip/utilities.c
+++ b/Source/smokezip/utilities.c
@@ -11,7 +11,7 @@ int GetFileBounds(char *file, float *valmin, float *valmax){
   char buffer[255];
   float t, vmin, vmax;
 
-  stream = fopen(file, "r");
+  stream = FOPEN(file, "r");
   if(stream == NULL || fgets(buffer, 255, stream) == NULL){
     *valmin = 1.0;
     *valmax = 0.0;

--- a/Source/wind2fds/main.c
+++ b/Source/wind2fds/main.c
@@ -217,7 +217,7 @@ int main(int argc, char **argv){
   }
   else{
     strcpy(in_file,argin);
-    stream_in=fopen(in_file,"r");
+    stream_in=FOPEN(in_file,"r");
   }
   if(stream_in==NULL){
     fprintf(stderr,"*** Error: The file %s could not be opened for input\n",in_file);
@@ -240,7 +240,7 @@ int main(int argc, char **argv){
     strcpy(out_file, argout);
   }
 
-  stream_out=fopen(out_file,"w");
+  stream_out=FOPEN(out_file,"w");
   if(stream_out==NULL){
     fprintf(stderr,"*** Error: The file %s could not be opened for output\n",out_file);
     if(stream_in!=NULL&&stream_in!=stdin)fclose(stream_in);

--- a/Tests/parse_simple_bndf.c
+++ b/Tests/parse_simple_bndf.c
@@ -5,6 +5,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
 int main(int argc, char **argv) {
   initMALLOC();
   if (argc < 3) return 2;

--- a/Tests/parse_simple_part.c
+++ b/Tests/parse_simple_part.c
@@ -5,6 +5,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
 int main(int argc, char **argv) {
   initMALLOC();
   if (argc < 3) return 2;

--- a/Tests/parse_simple_pl3d.c
+++ b/Tests/parse_simple_pl3d.c
@@ -5,6 +5,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
 // TODO: This is an additional function to aid in testing. This should be
 // replaced by a better file IO API.
 int get_pl3d_spec(const char *filename, int npts[3]) {

--- a/Tests/parse_simple_slice.c
+++ b/Tests/parse_simple_slice.c
@@ -4,6 +4,11 @@
 #include "dmalloc.h"
 #include <stdlib.h>
 
+int show_help;
+int hash_option;
+int show_version;
+char append_string[1024];
+
 int main(int argc, char **argv) {
   initMALLOC();
   FILE *file;


### PR DESCRIPTION
The following are used throughout for consistency:

- `MKDIR`
- `ACCESS`
- `STAT`
- `CHDIR`
- `UNLINK`

These have always been defined but are not used throughout. By using them throughout, the Smokeview's file access can be controlled through `file_util.c`.

This moves the definition of these to `file_util.c` and makes them functions rather than macros, however, their definitions are otherwise the same.