### PR TITLE
add missing includes on Windows

### DIFF
--- a/Source/shared/file_util.h
+++ b/Source/shared/file_util.h
@@ -27,6 +27,8 @@ extern int show_timings;
 
 #ifdef WIN32
 #define PATH_MAX MAX_PATH
+#include <sys/types.h>
+#include <sys/stat.h>
 #elif defined(__linux__)
 #include <linux/limits.h>
 #elif defined(__APPLE__) && defined(__MACH__)


### PR DESCRIPTION
Add definition of __stat64 etc. via

#include <sys/types.h>
#include <sys/stat.h>