### PR TITLE
Make append_string static

### DIFF
--- a/Source/shared/string_util.c
+++ b/Source/shared/string_util.c
@@ -142,7 +142,9 @@ char *GetCharPtr(char *label) {
 
 /* ----------------------- AppendString ----------------------------- */
 
-char *AppendString(char *S1, char *S2){
+char *AppendString(const char *S1, const char *S2){
+#define APPEND_BUFFER_SIZE 1024
+  static char append_string[APPEND_BUFFER_SIZE];
   strcpy(append_string, S1);
   strcat(append_string, S2);
   return append_string;

--- a/Source/shared/string_util.h
+++ b/Source/shared/string_util.h
@@ -94,7 +94,7 @@ EXTERNCPP char          *GetStringPtr(char *buffer);
 EXTERNCPP char          *GetStringPtr(char *buffer);
 EXTERNCPP char          *GetFloatLabel(float val, char *label);
 EXTERNCPP char          *GetIntLabel(int val, char *label);
-EXTERNCPP char          *AppendString(char *S1, char *S2);
+EXTERNCPP char          *AppendString(const char *S1, const char *S2);
 EXTERNCPP void           UsageCommon(int option);
 EXTERNCPP int            ParseCommonOptions(int argc, char **argv);
 EXTERNCPP void           InitRandAB(int size);
@@ -175,7 +175,6 @@ EXTERNCPP void           PRINTversion(char *progname);
 SVEXTERN int SVDECL(hash_option, HASH_SHA1);
 #endif
 SVEXTERN int SVDECL(show_version, 0), SVDECL(show_help, 0);
-SVEXTERN char append_string[1024];
 
 #ifdef WIN32
 STREXTERN char STRDECL(dirseparator[],"\\");

--- a/Tests/parse_cad.c
+++ b/Tests/parse_cad.c
@@ -9,7 +9,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   if(argc < 2) {

--- a/Tests/parse_colorbar.c
+++ b/Tests/parse_colorbar.c
@@ -12,7 +12,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   initMALLOC();

--- a/Tests/parse_hvac_vals.c
+++ b/Tests/parse_hvac_vals.c
@@ -27,7 +27,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 void init_vals(hvacdatacollection *hvaccoll, const char *file) {
   NewMemory((void **)&(hvaccoll->hvacductvalsinfo), sizeof(hvacvalsdata));

--- a/Tests/parse_objects.c
+++ b/Tests/parse_objects.c
@@ -12,7 +12,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   initMALLOC();

--- a/Tests/parse_simple_bndf.c
+++ b/Tests/parse_simple_bndf.c
@@ -8,7 +8,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   initMALLOC();

--- a/Tests/parse_simple_part.c
+++ b/Tests/parse_simple_part.c
@@ -8,7 +8,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   initMALLOC();

--- a/Tests/parse_simple_pl3d.c
+++ b/Tests/parse_simple_pl3d.c
@@ -9,12 +9,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
-
-int show_help;
-int hash_option;
-int show_version;
-char append_string[1024];
 
 // TODO: This is an additional function to aid in testing. This should be
 // replaced by a better file IO API.

--- a/Tests/parse_simple_slice.c
+++ b/Tests/parse_simple_slice.c
@@ -7,7 +7,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   initMALLOC();

--- a/Tests/sort_surfs.c
+++ b/Tests/sort_surfs.c
@@ -11,7 +11,7 @@ void InitSurface(surfdata *surf, float *color);
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
+
 #define N_SURFS 3
 int main(int argc, char **argv) {
   initMALLOC();

--- a/Tests/test_iter_dir.c
+++ b/Tests/test_iter_dir.c
@@ -13,7 +13,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   int mode = FILE_MODE;

--- a/Tests/test_labels.c
+++ b/Tests/test_labels.c
@@ -14,7 +14,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   initMALLOC();

--- a/Tests/test_objects.c
+++ b/Tests/test_objects.c
@@ -12,7 +12,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   initMALLOC();

--- a/Tests/test_root_dir.c
+++ b/Tests/test_root_dir.c
@@ -13,7 +13,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 int main(int argc, char **argv) {
   initMALLOC();

--- a/Tests/unicode_paths.c
+++ b/Tests/unicode_paths.c
@@ -13,7 +13,6 @@
 int show_help;
 int hash_option;
 int show_version;
-char append_string[1024];
 
 static char *test_file_name_unicode = "test_файл_O’S.txt";
 static char *test_file_name_unicode_new = "test_файл_O’S_new.txt";


### PR DESCRIPTION
`append_string` is currently a global, however, it is only used within the function `AppendString`. Making this static within the function has the same outcome but simplifies some code, particularly with tests.