### PR TITLE
define default colors in shared

### DIFF
--- a/Source/shared/colorbars.c
+++ b/Source/shared/colorbars.c
@@ -20,6 +20,13 @@ int STRCMP(const char *s1, const char *s2);
 void Rgb2Lab(unsigned char *rgb_arg, float *lab);
 void Rgbf2Lab(float *rgbf_arg, float *lab);
 
+// Defines a number of readonly color defaults.
+float mat_ambient_orig[4] = {0.5f, 0.5f, 0.2f, 1.0f};
+float mat_specular_orig[4] = {0.5f, 0.5f, 0.2f, 1.0f};
+float ventcolor_orig[4] = {1.0, 0.0, 1.0, 1.0};
+float block_ambient_orig[4] = {1.0, 0.8, 0.4, 1.0};
+float block_specular_orig[4] = {0.0, 0.0, 0.0, 1.0};
+
 /* ------------------ GetColorbar ------------------------ */
 
 colorbardata *GetColorbar(colorbar_collection *colorbars, const char *menu_label){

--- a/Source/shared/colorbars.h
+++ b/Source/shared/colorbars.h
@@ -21,20 +21,12 @@
 #define INTERP_RGB 0
 #define INTERP_LAB 1
 
-// Define a number of readonly color defaults.
-#ifdef INMAIN
-SVEXTERN float mat_ambient_orig[4] = {0.5f, 0.5f, 0.2f, 1.0f};
-SVEXTERN float mat_specular_orig[4] = {0.5f, 0.5f, 0.2f, 1.0f};
-SVEXTERN float ventcolor_orig[4] = {1.0, 0.0, 1.0, 1.0};
-SVEXTERN float block_ambient_orig[4] = {1.0, 0.8, 0.4, 1.0};
-SVEXTERN float block_specular_orig[4] = {0.0, 0.0, 0.0, 1.0};
-#else
-SVEXTERN float mat_ambient_orig[4];
-SVEXTERN float mat_specular_orig[4];
-SVEXTERN float ventcolor_orig[4];
-SVEXTERN float block_ambient_orig[4];
-SVEXTERN float block_specular_orig[4];
-#endif
+// Declares a number of readonly color defaults.
+extern CCC float mat_ambient_orig[4];
+extern CCC float mat_specular_orig[4];
+extern CCC float ventcolor_orig[4];
+extern CCC float block_ambient_orig[4];
+extern CCC float block_specular_orig[4];
 
 /* --------------------------  colordata ------------------------------------ */
 

--- a/Source/smokeview/IOiso.c
+++ b/Source/smokeview/IOiso.c
@@ -9,6 +9,7 @@
 #include "smokeviewvars.h"
 #include "glui_bounds.h"
 #include "getdata.h"
+#include "readsmvfile.h"
 
 /* ------------------ GetIsoLevels ------------------------ */
 

--- a/Source/smokeview/drawGeometry.c
+++ b/Source/smokeview/drawGeometry.c
@@ -11,6 +11,7 @@
 #include "readimage.h"
 #include "readcad.h"
 #include "readobject.h"
+#include "readsmvfile.h"
 
 #define DRAW_OBSTS_AND_VENTS 0
 #define DRAW_OBSTS           1

--- a/Source/smokeview/getdatacolors.c
+++ b/Source/smokeview/getdatacolors.c
@@ -7,6 +7,7 @@
 
 #include "smokeviewvars.h"
 #include "glui_bounds.h"
+#include "readsmvfile.h"
 
 #define EXPMIN -1
 #define EXPMAX 3

--- a/Source/smokeview/glui_display.cpp
+++ b/Source/smokeview/glui_display.cpp
@@ -11,6 +11,7 @@
 #include "glui_motion.h"
 #include "colorbars.h"
 #include "readlabel.h"
+#include "readsmvfile.h"
 
 GLUI *glui_labels=NULL;
 

--- a/Source/smokeview/smokeheaders.h
+++ b/Source/smokeview/smokeheaders.h
@@ -318,7 +318,6 @@ EXTERNCPP void GetBoundaryLabels(
               char **labels, float *boundaryvaluespatch, float *tvals256, int nlevel);
 EXTERNCPP void GetColorbarLabels(float tmin, float tmax, int nlevel,
               char labels[12][11],float *tlevels256);
-EXTERNCPP float *GetColorPtr(smv_case *scase, float *color);
 EXTERNCPP float *GetColorTranPtr(float *color, float transparency);
 EXTERNCPP void GetPartColors(partdata *parti, int nlevels, int flag);
 EXTERNCPP void GetPlot3DColors(int iplot, float *ttmin, float *ttmax,


### PR DESCRIPTION
Smokeview defines a number of colors (nominally) as constants. Previously, the `INMAIN` macro was used to copy the definition across for each executable.

This change places the definition of these colors within shared/ (and can therefore be built in to a library).

It does not mark them as constant as that's not the way Smokeview uses them, but they could be.

This (effectively) removes the need to use the `INMAIN` macro in shared/ which makes code reuse much easier.