### PR TITLE
abort on script errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ option(STRICT_CHECKS "Run additional strict checks" OFF)
 option(VENDORED_UI_LIBS "Use the vendored GLUT" ON)
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 option(UNICODE "Enable Unicode on Windows" ON)
+option(DISPLAY_TESTS "Enable tests which require a display to run" OFF)
 
 # Ensure all files are in the right place to run the tests
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")

--- a/Source/smokeview/IOscript.c
+++ b/Source/smokeview/IOscript.c
@@ -3992,6 +3992,7 @@ int RunScriptCommand(scriptdata *script_command){
         if(Writable(script_dir_path)==NO){
           fprintf(stderr,"*** Error: Cannot write to the RENDERDIR directory: %s\n",script_dir_path);
           if(stderr2!=NULL)fprintf(stderr2, "*** Error: Cannot write to the RENDERDIR directory: %s\n", script_dir_path);
+          SMV_EXIT(2);
         }
         PRINTF("script: setting render path to %s\n",script_dir_path);
       }
@@ -4005,6 +4006,7 @@ int RunScriptCommand(scriptdata *script_command){
         if(Writable(script_htmldir_path)==NO){
           fprintf(stderr, "*** Error: Cannot write to the RENDERHTMLDIR directory: %s\n", script_htmldir_path);
           if(stderr2!=NULL)fprintf(stderr2, "*** Error: Cannot write to the RENDERHTMLDIR directory: %s\n", script_htmldir_path);
+          SMV_EXIT(2);
         }
         PRINTF("script: setting html render path to %s\n", script_htmldir_path);
       }
@@ -4181,6 +4183,7 @@ int RunScriptCommand(scriptdata *script_command){
         dev_index = GetDeviceIndexFromLabel(scripti->cval);
         if(dev_index<0){
           printf("***error: device %s does not exist\n", scripti->cval);
+          SMV_EXIT(2);
           break;
         }
         dev_index += global_scase.devicecoll.ndeviceinfo;                                       // show device

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -18,6 +18,12 @@ add_test(NAME "Execute smokezip" COMMAND smokezip)
 add_test(NAME "Execute smokeview sizes" COMMAND smokeview -sizes ${TEST_SMALL_SMV})
 add_test(NAME "Execute smokeview info" COMMAND smokeview -info ${TEST_SMALL_SMV})
 
+if (DISPLAY_TESTS)
+    add_test(NAME "Execute smokeview good-script" COMMAND smokeview -script good-script.ssf ${CMAKE_SOURCE_DIR}/Tests/test_model_small/test_model_small.smv)
+    add_test(NAME "Execute smokeview bad-script" COMMAND smokeview -script bad-script.ssf ${CMAKE_SOURCE_DIR}/Tests/test_model_small/test_model_small.smv)
+    set_tests_properties("Execute smokeview bad-script" PROPERTIES WILL_FAIL TRUE)
+endif()
+
 # parse_simple_slice
 add_executable(parse_simple_slice parse_simple_slice.c)
 target_link_libraries(parse_simple_slice PRIVATE libsmv)

--- a/Tests/test_model_small/bad-script.ssf
+++ b/Tests/test_model_small/bad-script.ssf
@@ -1,0 +1,3 @@
+
+RENDERDIR
+ non-existent

--- a/Tests/test_model_small/good-script.ssf
+++ b/Tests/test_model_small/good-script.ssf
@@ -1,0 +1,3 @@
+
+RENDERDIR
+ ../test_model_large


### PR DESCRIPTION
When an error occurs during RENDERDIR, immediately abort and return a non-zero exit code.

This also adds tests to ensure this works correctly, however, they only run when a display is attached.