### PR TITLE
replace X64 with _WIN64

### DIFF
--- a/Build/background/Makefile
+++ b/Build/background/Makefile
@@ -76,7 +76,7 @@ linux_osx_check : $(linux_osx_chk)
 
 # ------------- win_check ----------------
 
-win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB
+win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB
 win_check : INC_DIR += -I $(SOURCE_DIR)/pthreads
 win_check : $(win_chk)
 	$(CLANGWINSUMMARY) background.summary
@@ -85,7 +85,7 @@ win_check : $(win_chk)
 
 # ------------- intel Win 64 ----------------
 
-intel_win_64 : CFLAGS    = -O1 /nologo -D X64 -I $(SOURCE_DIR)/pthreads -I $(SOURCE_DIR)/shared $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -O1 /nologo -I $(SOURCE_DIR)/pthreads -I $(SOURCE_DIR)/shared $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = background_win_64.exe
 

--- a/Build/convert/Makefile
+++ b/Build/convert/Makefile
@@ -42,7 +42,7 @@ no_target:
 
 # ------------- intel winx 64 db ----------------
 
-intel_win_64_db : CFLAGS    = /Od /Wall /debug:full /W4 /ZI -I $(SOURCE_DIR)/pthreads -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64_db : CFLAGS    = /Od /Wall /debug:full /W4 /ZI -I $(SOURCE_DIR)/pthreads -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64_db : CC        = $(I_CC)
 intel_win_64_db : CPP       = $(I_CC)
 intel_win_64_db : exe       = convert_win_64_db.exe
@@ -52,7 +52,7 @@ intel_win_64_db : $(objwin)
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = /O2 /nologo -I $(SOURCE_DIR)/pthreads -D X64 $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = /O2 /nologo -I $(SOURCE_DIR)/pthreads $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : CPP       = $(I_CC)
 intel_win_64 : exe       = convert_win_64.exe

--- a/Build/env2mod/Makefile
+++ b/Build/env2mod/Makefile
@@ -44,7 +44,7 @@ no_target:
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = -Od -I $(SOURCE_DIR)/pthreads -D X64 /nologo $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -Od -I $(SOURCE_DIR)/pthreads /nologo $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = env2mod_win_64.exe
 

--- a/Build/fds2fed/Makefile
+++ b/Build/fds2fed/Makefile
@@ -78,14 +78,14 @@ linux_osx_check : $(linux_osx_chk)
 
 # ------------- win_check ----------------
 
-win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB
+win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB
 win_check : INC_DIR += -I $(SOURCE_DIR)/pthreads
 win_check : $(win_chk)
 	$(CLANGWINSUMMARY) fds2fed.summary
 
 # ------------- intel winx 64 db ----------------
 
-intel_win_64_db : CFLAGS    = /Od /Wall /debug:full /W4 /ZI -I $(SOURCE_DIR)/pthreads -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64_db : CFLAGS    = /Od /Wall /debug:full /W4 /ZI -I $(SOURCE_DIR)/pthreads -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64_db : CC        = $(I_CC)
 intel_win_64_db : exe       = fds2fed_win_64_db.exe
 
@@ -94,7 +94,7 @@ intel_win_64_db : $(objwin)
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = /O2 /nologo -I $(SOURCE_DIR)/pthreads -D X64 $(GITINFO) $(SMV_TESTFLAG) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = /O2 /nologo -I $(SOURCE_DIR)/pthreads $(GITINFO) $(SMV_TESTFLAG) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = fds2fed_win_64.exe
 

--- a/Build/flush/Makefile
+++ b/Build/flush/Makefile
@@ -50,7 +50,7 @@ no_target:
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = -Od -I $(SOURCE_DIR)/pthreads -D X64 /nologo $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -Od -I $(SOURCE_DIR)/pthreads /nologo $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = flush_win_64.exe
 

--- a/Build/get_time/Makefile
+++ b/Build/get_time/Makefile
@@ -34,7 +34,7 @@ no_target:
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = -Od /nologo -D X64
+intel_win_64 : CFLAGS    = -Od /nologo
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : CPP       = $(I_CC)
 intel_win_64 : exe       = get_time_win_64.exe

--- a/Build/hashfile/Makefile
+++ b/Build/hashfile/Makefile
@@ -47,7 +47,7 @@ no_target:
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = -Od -I $(SOURCE_DIR)/pthreads -D X64 /nologo $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -Od -I $(SOURCE_DIR)/pthreads /nologo $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = hashfile_win_64.exe
 

--- a/Build/makepo/Makefile
+++ b/Build/makepo/Makefile
@@ -40,7 +40,7 @@ no_target:
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = -O2 /nologo -I $(SOURCE_DIR)/pthreads -D X64 -D PTW32_STATIC_LIB  $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -O2 /nologo -I $(SOURCE_DIR)/pthreads -D PTW32_STATIC_LIB  $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : LFLAGS    =
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = makepo_win_64.exe

--- a/Build/mergepo/Makefile
+++ b/Build/mergepo/Makefile
@@ -42,7 +42,7 @@ no_target:
 
 # ------------- win 64 ----------------
 
-intel_win_64 : CFLAGS    = -O2 /nologo -D X64 -D PTW32_STATIC_LIB $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -O2 /nologo -D PTW32_STATIC_LIB $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : LFLAGS    =
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = mergepo_win_64.exe

--- a/Build/pnginfo/Makefile
+++ b/Build/pnginfo/Makefile
@@ -88,7 +88,7 @@ linux_osx_check : $(linux_osx_chk)
 
 # ------------- win_check ----------------
 
-win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB
+win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB
 win_check : INC_DIR += -I $(SOURCE_DIR)/pthreads
 win_check : $(win_chk)
 	$(CLANGWINSUMMARY) pnginfo.summary
@@ -96,7 +96,7 @@ win_check : $(win_chk)
 
 # ------------- intel winx 64 db ----------------
 
-intel_win_64_db : CFLAGS    = /Od /Wall /debug:full /W4 /ZI -I $(SOURCE_DIR)/pthreads -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64_db : CFLAGS    = /Od /Wall /debug:full /W4 /ZI -I $(SOURCE_DIR)/pthreads -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64_db : CC        = $(I_CC)
 intel_win_64_db : exe       = pnginfo_win_64_db.exe
 
@@ -105,7 +105,7 @@ intel_win_64_db : $(objwin)
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = /O2 /nologo -D X64 $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = /O2 /nologo $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = pnginfo_win_64.exe
 

--- a/Build/set_path/Makefile
+++ b/Build/set_path/Makefile
@@ -43,7 +43,7 @@ no_target:
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = -I $(SOURCE_DIR)/pthreads -D X64 -O2 /nologo $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -I $(SOURCE_DIR)/pthreads -O2 /nologo $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : CPP       = $(I_CC)
 intel_win_64 : exe       = set_path_win_64.exe

--- a/Build/sh2bat/Makefile
+++ b/Build/sh2bat/Makefile
@@ -43,7 +43,7 @@ no_target:
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = -I $(SOURCE_DIR)/pthreads -D X64 -O2 /nologo $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -I $(SOURCE_DIR)/pthreads -O2 /nologo $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : CPP       = $(I_CC)
 intel_win_64 : exe       = sh2bat_win_64.exe

--- a/Build/smokediff/Makefile
+++ b/Build/smokediff/Makefile
@@ -79,7 +79,7 @@ linux_osx_check : $(linux_osx_chk)
 
 # ------------- win_check ----------------
 
-win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB
+win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB
 win_check : INC_DIR += -I $(SOURCE_DIR)/pthreads
 win_check : $(win_chk)
 	$(CLANGWINSUMMARY) smokediff.summary
@@ -88,7 +88,7 @@ win_check : $(win_chk)
 
 intel_win_64_db : INC_DIR   += -I $(SOURCE_DIR)/pthreads
 intel_win_64_db : FFLAGS    = /Od /iface:stdref /fpp /nologo /debug:full /extend_source:132 /warn:unused /warn:nointerfaces /Qtrapuv /fp:strict /fp:except /traceback /check:all /stand:f18 /fpscomp:general
-intel_win_64_db : CFLAGS    = /Od /Wall /debug:full /W4 /ZI -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64_db : CFLAGS    = /Od /Wall /debug:full /W4 /ZI -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64_db : CC        = $(I_CC)
 intel_win_64_db : exe       = smokediff_win_64_db.exe
 
@@ -99,7 +99,7 @@ intel_win_64_db : $(objwin)
 
 intel_win_64 : INC_DIR   += -I $(SOURCE_DIR)/pthreads
 intel_win_64 : FFLAGS    = /O2 -fpp /nologo /iface:stdref /stand:f18 /fpscomp:general
-intel_win_64 : CFLAGS    = /O2 /nologo -D X64 $(GITINFO) $(SMV_TESTFLAG) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = /O2 /nologo $(GITINFO) $(SMV_TESTFLAG) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = smokediff_win_64.exe
 

--- a/Build/smokeview/Makefile
+++ b/Build/smokeview/Makefile
@@ -167,7 +167,7 @@ WIN32_LIBS = user32.lib gdi32.lib comdlg32.lib shell32.lib
 intel_win_64_san : DYNLIB_EXT = .dll
 intel_win_64_san : INC += $(WININC) -I $(SOURCE_DIR)/shared -I $(SOURCE_DIR)/smokeview
 intel_win_64_san : CFLAGS    = /Od /W4 /Wno-cast-function-type-mismatch /Wno-unused-function /Wno-unused-parameter
-intel_win_64_san : CFLAGS   += /debug:full /Zi  -D pp_INTEL -D _DEBUG -D _CONSOLE -D X64 -D GLEW_STATIC
+intel_win_64_san : CFLAGS   += /debug:full /Zi  -D pp_INTEL -D _DEBUG -D _CONSOLE -D GLEW_STATIC
 intel_win_64_san : CFLAGS   += -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64_san : CFLAGS   += $(SANITIZE_OPTIONS)
 intel_win_64_san : C_STANDARD    = -Qstd=gnu99
@@ -188,7 +188,7 @@ intel_win_64_san : $(objwin)
 
 intel_win_64_db : DYNLIB_EXT = .dll
 intel_win_64_db : INC += $(WININC) -I $(SOURCE_DIR)/shared -I $(SOURCE_DIR)/smokeview
-intel_win_64_db : CFLAGS    = /Od /W4 /Wno-cast-function-type-mismatch /Wno-unused-function /Wno-unused-parameter /debug:full /Zi  -D pp_INTEL -D _DEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64_db : CFLAGS    = /Od /W4 /Wno-cast-function-type-mismatch /Wno-unused-function /Wno-unused-parameter /debug:full /Zi  -D pp_INTEL -D _DEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
 ifeq ($(SANITIZE),1)
 intel_win_64_db : CFLAGS   += $(SANITIZE_OPTIONS)
 endif
@@ -213,7 +213,7 @@ intel_win_64_db : $(objwin)
 
 intel_win_64 : DYNLIB_EXT = .dll
 intel_win_64 : INC += $(WININC) -I $(SOURCE_DIR)/shared -I $(SOURCE_DIR)/smokeview
-intel_win_64 : CFLAGS    = -O1 -D pp_INTEL -D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -O1 -D pp_INTEL -D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO) $(INTEL_COMPINFO)
 ifeq ($(SANITIZE),1)
 intel_win_64 : CFLAGS   += $(SANITIZE_OPTIONS) -g
 endif
@@ -371,7 +371,7 @@ linux_osx_check : $(linux_osx_chk)
 
 # ------------- win_check ----------------
 
-win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB
+win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB
 win_check : INC += $(WININC)
 win_check : $(win_chk)
 	$(CLANGWINSUMMARY) smokeview.summary

--- a/Build/smokezip/Makefile
+++ b/Build/smokezip/Makefile
@@ -89,7 +89,7 @@ linux_osx_check : $(linux_osx_chk)
 
 # ------------- win_check ----------------
 
-win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB
+win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB
 win_check : INC_DIR += -I $(SOURCE_DIR)/pthreads
 win_check : $(win_chk)
 	$(CLANGWINSUMMARY) smokezip.summary
@@ -97,7 +97,7 @@ win_check : $(win_chk)
 # ------------- intel win 64 ----------------
 
 intel_win_64 : INC_DIR   += -I $(SOURCE_DIR)/pthreads
-intel_win_64 : CFLAGS    = -Od /nologo -D PTW32_STATIC_LIB -D X64  $(OPT) $(GITINFO) $(INTEL_COMPINFO) $(SMV_TESTFLAG)
+intel_win_64 : CFLAGS    = -Od /nologo -D PTW32_STATIC_LIB  $(OPT) $(GITINFO) $(INTEL_COMPINFO) $(SMV_TESTFLAG)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = smokezip_win_64.exe
 

--- a/Build/stars/Makefile
+++ b/Build/stars/Makefile
@@ -79,7 +79,7 @@ WIN32_LIBS = user32.lib gdi32.lib comdlg32.lib shell32.lib
 
 intel_win_64 : DYNLIB_EXT = .dll
 intel_win_64 : INC += $(WININC) -I $(SOURCE_DIR)/shared -I $(SOURCE_DIR)/stars
-intel_win_64 : CFLAGS    = -O1  -D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB
+intel_win_64 : CFLAGS    = -O1  -D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB
 intel_win_64 : C_STANDARD    = -Qstd=gnu99
 ifeq ($(GLUT),freeglut)
 intel_win_64 : CFLAGS   += -D FREEGLUT_STATIC

--- a/Build/timep/Makefile
+++ b/Build/timep/Makefile
@@ -48,7 +48,7 @@ no_target:
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = -Od -I $(SOURCE_DIR)/pthreads -D X64 /nologo $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -Od -I $(SOURCE_DIR)/pthreads /nologo $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = timep_win_64.exe
 

--- a/Build/wind2fds/Makefile
+++ b/Build/wind2fds/Makefile
@@ -80,14 +80,14 @@ linux_osx_check : $(linux_osx_chk)
 
 # ------------- win_check ----------------
 
-win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB
+win_check : CFLAGS    = -D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB
 win_check : INC_DIR += -I $(SOURCE_DIR)/pthreads
 win_check : $(win_chk)
 	$(CLANGWINSUMMARY) wind2fds.summary
 
 # ------------- intel win 64 ----------------
 
-intel_win_64 : CFLAGS    = -Od /nologo -I $(SOURCE_DIR)/pthreads -D X64 $(GITINFO) $(INTEL_COMPINFO)
+intel_win_64 : CFLAGS    = -Od /nologo -I $(SOURCE_DIR)/pthreads $(GITINFO) $(INTEL_COMPINFO)
 intel_win_64 : CC        = $(I_CC)
 intel_win_64 : exe       = wind2fds_win_64.exe
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 # Set flags for Windows
 if (WIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    add_compile_definitions(PTW32_BUILD PTW32_STATIC_LIB X64 _CONSOLE)
+    add_compile_definitions(PTW32_BUILD PTW32_STATIC_LIB _CONSOLE)
     if (UNICODE)
         # We only define pp_UNICODE_PATHS (which is specific to SMV) and not
         # _UNICODE as the vendored version of GLUT doesn't support Unicode

--- a/Source/scripts/check_code.bat
+++ b/Source/scripts/check_code.bat
@@ -8,6 +8,6 @@ set "CLANGOPTS=--analyze"
 if not "x%option%" == "x-t%" goto endif1
   set "CLANGOPTS=--analyze -Xanalyzer -analyzer-checker=core,deadcode -D pp_CLANG_TEST"
 :endif1
-set COPTS=-D NDEBUG -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB
+set COPTS=-D NDEBUG -D _CONSOLE -D GLEW_STATIC -D PTW32_STATIC_LIB
 set INC=-I ../glut_gl -I ../pthreads -I ../smokeview -I ../glui_v2_1_beta -I ../shared -I ../glew -I . -I ../gd-2.0.15 -I ../zlib128 %file%
 clang %CLANGOPTS% %INC% %COPTS% %file% 2> %base%.chk

--- a/Source/shared/file_util.c
+++ b/Source/shared/file_util.c
@@ -100,14 +100,10 @@ int STAT(const char *file, STRUCTSTAT *buffer) {
   int r = _wstat64(path, buffer);
   FREEMEMORY(path);
   return r;
-#elif defined(_WIN32)
-  return _stat64(file, buffer);
-#else
-#ifdef X64
+#elif defined(_WIN64)
   return _stat64(file, buffer);
 #else
   return stat(file, buffer);
-#endif
 #endif
 }
 

--- a/Source/shared/file_util.h
+++ b/Source/shared/file_util.h
@@ -72,7 +72,7 @@ typedef struct {
 // vvvvvvvvvvvvvvvvvvvvvvvv preprocessing directives
 // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 
-#ifdef X64
+#ifdef _WIN64
 #define FSEEK(a, b, c) _fseeki64(a, b, c)
 #define FTELL(a) _ftelli64(a)
 #else
@@ -106,17 +106,13 @@ typedef struct {
 
 #define BFILE bufferstreamdata
 
-#ifdef X64
-  #ifdef _WIN32
-    #define LINT __int64
-  #else
-    #define LINT long long int
-  #endif
+#ifdef _WIN64
+  #define LINT __int64
 #else
-  #define LINT long int
+  #define LINT long long int
 #endif
 
-#ifdef X64
+#ifdef _WIN64
   #define STRUCTSTAT struct __stat64
 #else
   #define STRUCTSTAT struct stat

--- a/Source/smokeview/IOslice.c
+++ b/Source/smokeview/IOslice.c
@@ -39,7 +39,7 @@
     )
 
 #define FOPEN_SLICE(a,b)         FOPEN(a,b)
-#ifdef X64
+#ifdef _WIN64
 #define FSEEK_SLICE(a,b,c)       _fseeki64(a,b,c)
 #define FTELL_SLICE(a)           _ftelli64(a)
 #else


### PR DESCRIPTION
`X64` is only used on Windows to identify 64-bit platforms, `_WIN64` does the same.

As there currently aren't any 32-bit versions being built it's not likely to be impactful, but theoretically this still supports 32-bit build.