### PR TITLE
don't render animated GIF with no data loaded

### DIFF
--- a/Source/smokeview/menus.c
+++ b/Source/smokeview/menus.c
@@ -2106,7 +2106,7 @@ void RenderMenu(int value){
     render_filetype = GIF;
     render_mode = RENDER_GIF;
     resolution_multiplier=1;
-    {
+    if(RenderTime!=0||touring!=0){
       char *gif_filename;
       NEWMEMORY(gif_filename, strlen(global_scase.chidfilebase) + 4 + 1);
       strcpy(gif_filename, global_scase.chidfilebase);

--- a/Source/smokeview/renderimage.c
+++ b/Source/smokeview/renderimage.c
@@ -550,7 +550,6 @@ int GifEnd() {
 int GifAddFrame(int delay) {
   GLsizei width = screenWidth;
   GLsizei height = screenHeight;
-  gdImagePtr im;
   GLubyte *OpenGLimage;
   NewMemory((void **)&OpenGLimage, width * height * sizeof(GLubyte) * 3);
   im = gdImageCreate(width, height);

--- a/Source/smokeview/renderimage.c
+++ b/Source/smokeview/renderimage.c
@@ -525,6 +525,7 @@ int GifStart(const char *path) {
 
   gdImageColorAllocate(im, 255, 255, 255); /* allocate white as side effect */
   gdImageGifAnimBegin(im, out, 1, 0);
+  gdImageDestroy(im);
   return 0;
 }
 
@@ -536,8 +537,10 @@ int GifStart(const char *path) {
 int GifEnd() {
   gdImageGifAnimEnd(out);
   fclose(out);
-  im = NULL;
-  prev = NULL;
+  if(im != NULL) {
+    gdImageDestroy(im);
+    im = NULL;
+  }
   return 0;
 }
 


### PR DESCRIPTION
When using the GIF option without loaded data, smokeview renders a static gif (CHID_s0000.gif) but also starts an animated GIF.

This puts the animated GIFs under a branch so that they're only created when data is loaded.