### PR TITLE
Use NewColorbar more consistently

### DIFF
--- a/Source/shared/colorbars.c
+++ b/Source/shared/colorbars.c
@@ -613,7 +613,14 @@ colorbardata *NextColorbar(colorbar_collection *colorbars){
 }
 
 /* ------------------ NewColorbar ------------------------ */
-
+/**
+ * @brief Allocate a new (empty) colorbar and add it to the colorbar_collection.
+ *
+ * This function handles all of the allocation and array resizing necessary.
+ *
+ * @return A pointer to the new colorbar. This pointer remains valid until
+ * NewColorbar is called again.
+ */
 colorbardata *NewColorbar(colorbar_collection *colorbars){
   colorbardata *cb = NextColorbar(colorbars);
   memset(cb, 0, sizeof(colorbardata));
@@ -655,13 +662,12 @@ void ReadColorbarDir(colorbar_collection *colorbars, const char *dir_path,
   int n_files = GetFileListSize(dir_path, "*.csv", FILE_MODE);
   MakeFileList(dir_path, "*.csv", n_files, NO, &filelist, FILE_MODE);
   for(int i = 0; i < n_files; i++){
-    colorbardata *cbi = NextColorbar(colorbars);
-
     if(filelist[i].file == NULL || strlen(filelist[i].file) == 0) return;
     if(dir_path == NULL || strlen(dir_path) == 0) return;
     char *filepath = CombinePaths(dir_path, filelist[i].file);
+
+    colorbardata *cbi = NewColorbar(colorbars);
     ReadCSVColorbar(cbi, filepath, label, type);
-    colorbars->ncolorbars++;
     cbi->can_adjust = 1;
     FREEMEMORY(filepath);
   }
@@ -677,7 +683,7 @@ void ReadColorbarSubDir(colorbar_collection *colorbars, const char *subdir, int 
 
 /* ------------------ InitDefaultColorbars ------------------------ */
 
-void InitDefaultColorbars(colorbar_collection *colorbars, int nini,
+void InitDefaultColorbars(colorbar_collection *colorbars,
                                     int show_extreme_mindata,
                                     unsigned char rgb_below_min[3],
                                     int show_extreme_maxdata,

--- a/Source/shared/colorbars.h
+++ b/Source/shared/colorbars.h
@@ -111,7 +111,6 @@ EXTERNCPP int ReadCSVColorbar(colorbardata *colorbar, const char *filepath,
  *    - Reading and initializing from the use config directory.
  *
  * @param colorbars The colorbar collection to read into.
- * @param nini
  * @param show_extreme_mindata Should this colorbar color data below it's
  * bounds?
  * @param rgb_below_min What color should data below the minimum bound be
@@ -122,7 +121,7 @@ EXTERNCPP int ReadCSVColorbar(colorbardata *colorbar, const char *filepath,
  * colored.
  * @param colorbarcopyinfo
  */
-EXTERNCPP void InitDefaultColorbars(colorbar_collection *colorbars, int nini,
+EXTERNCPP void InitDefaultColorbars(colorbar_collection *colorbars,
                                     int show_extreme_mindata,
                                     unsigned char rgb_below_min[3],
                                     int show_extreme_maxdata,

--- a/Source/smokeview/colortimebar.c
+++ b/Source/smokeview/colortimebar.c
@@ -664,21 +664,15 @@ void UpdateColorbarDialogs(void){
 /* ------------------ AddColorbar ------------------------ */
 
 int AddColorbar(int icolorbar){
-  colorbardata *cb_to, *cb_from;
   char cb_label[255];
 
-  colorbars.ncolorbars++;
-  CheckMemory;
-  ResizeMemory((void **)&colorbars.colorbarinfo, colorbars.ncolorbars * sizeof(colorbardata));
+  colorbardata *cb_from = colorbars.colorbarinfo + icolorbar;
+  colorbardata *cb_to = NewColorbar(&colorbars);
   UpdateCurrentColorbar(colorbars.colorbarinfo + colorbartype);
 
-  cb_from = colorbars.colorbarinfo + icolorbar;
   CheckMemory;
 
-  // new colorbar
-
-  cb_to = colorbars.colorbarinfo + colorbars.ncolorbars - 1;
-
+  // Copy all of the data from the source colorbar
   memcpy(cb_to, cb_from, sizeof(colorbardata));
   strcpy(cb_to->menu_label, cb_from->menu_label);
   strcat(cb_to->menu_label, "_copy");

--- a/Source/smokeview/readsmv.c
+++ b/Source/smokeview/readsmv.c
@@ -6243,9 +6243,7 @@ int ReadIni2(const char *inifile, int localfile){
       */
 
       if(MatchINI(buffer, "GCOLORBAR") == 1){
-        colorbardata *cbi;
         int r1, g1, b1;
-        int n;
         int ncolorbarini;
 
         fgets(buffer, 255, stream);
@@ -6254,18 +6252,19 @@ int ReadIni2(const char *inifile, int localfile){
 
         ncolorbarini = MAX(ncolorbarini, 0);
         if(colorbars.ndefaultcolorbars==0){
-          InitDefaultColorbars(&colorbars, ncolorbarini, show_extreme_mindata,
+          InitDefaultColorbars(&colorbars,  show_extreme_mindata,
                              rgb_below_min, show_extreme_maxdata,
                              rgb_above_max, &colorbarcopyinfo);
           UpdateColorbarDialogs();
           UpdateCurrentColorbar(colorbars.colorbarinfo + colorbartype);
           update_colorbar_dialog = 0;
         }
-        colorbars.ncolorbars = colorbars.ndefaultcolorbars + ncolorbarini;
-        for(n = colorbars.ndefaultcolorbars; n<colorbars.ncolorbars; n++){
+        // Iterate through each of the colorbar entries in the GCOLOBAR section
+        // of the ini file (of which there are ncolorbarini).
+        for(int n = 0; n<ncolorbarini; n++){
           char *cb_buffptr;
-
-          cbi = colorbars.colorbarinfo + n;
+          // Add a new (empty) colorbar to the colobars list.
+          colorbardata *cbi = NewColorbar(&colorbars);
           fgets(buffer, 255, stream);
           TrimBack(buffer);
           cb_buffptr = TrimFront(buffer);
@@ -6296,8 +6295,10 @@ int ReadIni2(const char *inifile, int localfile){
           }
           RemapColorbar(cbi, show_extreme_mindata, rgb_below_min,
                   show_extreme_maxdata, rgb_above_max);
+          }
+          // A number of new colorbars may have been added, so update the GUI
+          // dialogs accordingly.
           UpdateColorbarDialogs();
-        }
 
         continue;
       }
@@ -7068,7 +7069,7 @@ int ReadIni(char *inifile){
     if(showall_textures==1)TextureShowMenu(MENU_TEXTURE_SHOWALL);
   }
   if(colorbars.ndefaultcolorbars==0){
-    InitDefaultColorbars(&colorbars, 0, show_extreme_mindata, rgb_below_min,
+    InitDefaultColorbars(&colorbars, show_extreme_mindata, rgb_below_min,
                          show_extreme_maxdata, rgb_above_max, &colorbarcopyinfo);
     UpdateColorbarDialogs();
     UpdateCurrentColorbar(colorbars.colorbarinfo + colorbartype);


### PR DESCRIPTION
I encountered a bug when you have exactly 10 user defined colorbars with 3 or more colorbars defined in the ini file.. The code which reads the .ini files wasn't allocating extra space in the same way as other instances in the code, and therefore could attempt to write to unallocated memory with a certain number of colorbars.

Other code generally uses the `NewColorbar` function, which deals with all the memory resize logic and initialization. The PR updates the two locations remaining locations which didn't use that function (thereby addressing the bug).

`NewColorbar` is now the only place in the code which increments `ncolorbars`.

This also adds a little more documentation where appropriate.